### PR TITLE
[FIX] Anticipate wrong encoding in camt files

### DIFF
--- a/account_banking_camt/camt.py
+++ b/account_banking_camt/camt.py
@@ -270,7 +270,11 @@ CAMT Format parser
         """
         Parse a CAMT053 XML file
         """
-        root = etree.fromstring(data)
+        try:
+            root = etree.fromstring(data)
+        except etree.XMLSyntaxError:
+            # ABNAmro is known to mix up encodings
+            root = etree.fromstring(data.decode('iso-8859-15').encode('utf-8'))
         self.ns = root.tag[:root.tag.index("}") + 1]
         self.check_version()
         self.assert_tag(root[0][0], 'GrpHdr')


### PR DESCRIPTION
ABNAmro can create iso-8859-15 encoded files, leading to the following exception:

 File "/home/openerp70/banking-addons/account_banking_camt/camt.py", line 286, in parse root = etree.fromstring(data) File "lxml.etree.pyx", line 2969, in lxml.etree.fromstring (src/lxml/lxml.etree.c:61978) File "parser.pxi", line 1594, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:91544) File "parser.pxi", line 1473, in lxml.etree._parseDoc (src/lxml/lxml.etree.c:90361) File "parser.pxi", line 988, in lxml.etree._BaseParser._parseDoc (src/lxml/lxml.etree.c:87024) File "parser.pxi", line 565, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:82877) File "parser.pxi", line 656, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:83862) File "parser.pxi", line 596, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:83186) XMLSyntaxError: Input is not proper UTF-8, indicate encoding ! Bytes: 0xA4 0x30 0x2C 0x31, line 1, column 1218
