### PR TITLE
initialize nb_of_transactions_2_4 and control_sum_2_5 with Default value

### DIFF
--- a/account_banking_pain_base/banking_export_pain.py
+++ b/account_banking_pain_base/banking_export_pain.py
@@ -210,6 +210,8 @@ class banking_export_pain(orm.AbstractModel):
             gen_args=gen_args, context=context)
         payment_method_2_2 = etree.SubElement(payment_info_2_0, 'PmtMtd')
         payment_method_2_2.text = gen_args['payment_method']
+        nb_of_transactions_2_4 = False
+        control_sum_2_5 = False
         if gen_args.get('pain_flavor') != 'pain.001.001.02':
             batch_booking_2_3 = etree.SubElement(payment_info_2_0, 'BtchBookg')
             batch_booking_2_3.text = \


### PR DESCRIPTION
When we export File and if pain_flavor == pain.001.001.02
we are getting the error for nb_of_transactions_2_4 is not define

as it is not initialized before if condition.
from file account_banking_pain_base/banking_export_pain.py

Migratefrom Launchpad to github
https://code.launchpad.net/~ruchir.shukla/banking-addons/banking-addons-fix-1334526/+merge/224554
