### PR TITLE
[ADD] account banking sepa direct debit create mandates

### DIFF
--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/__init__.py
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import model

--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/__openerp__.py
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/__openerp__.py
@@ -36,9 +36,9 @@ mandates for the current payment order where necessary.
 Configuration
 -------------
 
-By default, this module creates one-off mandates, which seems to be the safe
-choice. If this module is to be used to slowly evolve towards using recurring
-mandates, set the config parameter
+By default, this module creates one-off mandates. If you rather want to create
+recurring mandates (i.e. because your available mandates are recurring ones),
+set the config parameter
 'account.banking.sepa.direct.debit.create.mandates' to 'recurrent'.
 
 Attention

--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/__openerp__.py
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/__openerp__.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Create mandates for payment orders",
+    "version": "1.0",
+    "author": "Therp BV",
+    "license": "AGPL-3",
+    "complexity": "normal",
+    "description": """
+Introduction
+------------
+
+When switching to SEPA payments, the mandates to be created can be a
+serious show stopper. Usually, they are available in one form or the other,
+but not in OpenERP. This plugin adds a button on payment orders to create
+mandates for the current payment order where necessary.
+
+Configuration
+-------------
+
+By default, this module creates one-off mandates, which seems to be the safe
+choice. If this module is to be used to slowly evolve towards using recurring
+mandates, set the config parameter
+'account.banking.sepa.direct.debit.create.mandates' to 'recurrent'.
+
+Attention
+---------
+
+Only use this if you actually have the mandates!
+    """,
+    "category": "Banking addons",
+    "depends": [
+        'account_banking_sepa_direct_debit',
+    ],
+    "data": [
+        "view/payment_order.xml",
+    ],
+    "js": [
+    ],
+    "css": [
+    ],
+    "qweb": [
+    ],
+    "test": [
+    ],
+    "auto_install": False,
+    "installable": True,
+    "application": False,
+    "external_dependencies": {
+        'python': [],
+    },
+}

--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/model/__init__.py
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/model/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import payment_order

--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/model/payment_order.py
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/model/payment_order.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from datetime import datetime
+from openerp.osv.orm import Model
+from openerp.osv import fields
+from openerp.tools.misc import DEFAULT_SERVER_DATE_FORMAT
+
+
+class PaymentOrder(Model):
+    _inherit = 'payment.order'
+
+    def _is_missing_mandates_get(self, cr, uid, ids, field_name, arg, context=None):
+        result = {}
+        for this in self.browse(cr, uid, ids, context=context):
+            if this.payment_order_type != 'debit':
+                result[this.id] = False
+                continue
+            result[this.id] = any(
+                [not l.sdd_mandate_id for l in this.line_ids])
+        return result
+
+    _columns = {
+        'is_missing_mandates': fields.function(
+            _is_missing_mandates_get, type='boolean',
+            string='Is missing mandates'),
+    }
+
+    def button_create_missing_sdd_mandates(self, cr, uid, ids, context=None):
+        sdd_mandate = self.pool['sdd.mandate']
+        sdd_type = self.pool['ir.config_parameter'].get_param(
+            cr, uid, 'account.banking.sepa.direct.debit.create.mandates',
+            'oneoff', context=context)
+        for this in self.browse(cr, uid, ids, context=context):
+            for line in this.line_ids:
+                if line.sdd_mandate_id:
+                    continue
+                mandate_id = sdd_mandate.create(
+                    cr, uid,
+                    {
+                        'type': sdd_type,
+                        'recurrent_sequence_type': 'first'
+                            if sdd_type == 'recurrent' else False,
+                        'sepa_migrated': True,
+                        'signature_date': datetime.today().strftime(
+                            DEFAULT_SERVER_DATE_FORMAT),
+                        'partner_bank_id': line.bank_id.id,
+                        'partner_id': line.partner_id.id,
+                    },
+                    context=context)
+                sdd_mandate.validate(cr, uid, [mandate_id], context=context)
+                line.write({'sdd_mandate_id': mandate_id})
+        return {}

--- a/account_banking_sepa_direct_debit_mandate_on_the_fly/view/payment_order.xml
+++ b/account_banking_sepa_direct_debit_mandate_on_the_fly/view/payment_order.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_payment_order_form" model="ir.ui.view">
+            <field name="model">payment.order</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="account_banking_sepa_direct_debit.sdd_view_payment_order_form" />
+            <field name="arch" type="xml">
+                <data>
+                    <button name="cancel" position="before">
+                        <field name="is_missing_mandates" invisible="True" />
+                        <button type="object" name="button_create_missing_sdd_mandates" string="Create missing mandates" confirm="Create missing direct debit mandates?" icon="gtk-indent" attrs="{'invisible': ['|', ('is_missing_mandates', '=', False), ('state', 'not in', ['draft', 'open'])]}" />
+                    </button>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Introduction

When switching to SEPA payments, the mandates to be created can be a
serious show stopper. Usually, they are available in one form or the other,
but not in OpenERP. This plugin adds a button on payment orders to create
mandates for the current payment order where necessary.
## Configuration

By default, this module creates one-off mandates. If you rather want to create
recurring mandates (i.e. because your available mandates are recurring ones),
set the config parameter
'account.banking.sepa.direct.debit.create.mandates' to 'recurrent'.
## Attention

Only use this if you actually have the mandates!
