### PR TITLE
[IMP] support MT940 without footer record at end of file

### DIFF
--- a/account_banking_mt940/mt940.py
+++ b/account_banking_mt940/mt940.py
@@ -101,6 +101,12 @@ class MT940(object):
                 record_line = line
         except StopIteration:
             pass
+        if self.current_statement:
+            if record_line:
+                self.handle_record(cr, record_line)
+                record_line = ''
+            self.statements.append(self.current_statement)
+            self.current_statement = None
         return self.statements
 
     def append_continuation_line(self, cr, line, continuation_line):


### PR DESCRIPTION
Luxemburg multiline MT940 bank statements contain one statement and have no footer record.
https://www.multiline.lu/fileadmin/media/downloads/MT940_V2_fr.pdf
This commit adapts the base parser to handle that situation.
