### PR TITLE
add default currency in case bankstatement do not have ccy tag

### DIFF
--- a/account_banking_camt/camt.py
+++ b/account_banking_camt/camt.py
@@ -150,7 +150,12 @@ CAMT Format parser
                 identifier)
             )
 
-        statement.local_currency = self.xpath(node, './ns:Acct/ns:Ccy')[0].text
+        #Assuming If there is no Ccy tag then it belongs to defaut currency
+        if not self.xpath(node, './ns:Acct/ns:Ccy'):
+            statement.local_currency = 'EUR'
+        else:
+            statement.local_currency = self.xpath(node,
+                                                  './ns:Acct/ns:Ccy')[0].text
         statement.start_balance = self.get_start_balance(node)
         statement.end_balance = self.get_end_balance(node)
         number = 0

--- a/account_banking_camt/camt.py
+++ b/account_banking_camt/camt.py
@@ -150,7 +150,7 @@ CAMT Format parser
                 identifier)
             )
 
-        #Assuming If there is no Ccy tag then it belongs to defaut currency
+        # Assuming If there is no Ccy tag then it belongs to defaut currency
         if not self.xpath(node, './ns:Acct/ns:Ccy'):
             statement.local_currency = statement.company_id.currency_id.id
         else:

--- a/account_banking_camt/camt.py
+++ b/account_banking_camt/camt.py
@@ -152,7 +152,7 @@ CAMT Format parser
 
         #Assuming If there is no Ccy tag then it belongs to defaut currency
         if not self.xpath(node, './ns:Acct/ns:Ccy'):
-            statement.local_currency = 'EUR'
+            statement.local_currency = statement.company_id.currency_id.id
         else:
             statement.local_currency = self.xpath(node,
                                                   './ns:Acct/ns:Ccy')[0].text


### PR DESCRIPTION
Sometimes there is no ccy tag in the statement. in that case parser/processing is causing problem.
so adding default currency.
We can improve it by taking Default company currency. Bu I am not able to get user or company instance at parser level .
