### PR TITLE
[FIX] Payment lines are editable from the mandate form view

### DIFF
--- a/account_banking_mandate/model/account_banking_mandate.py
+++ b/account_banking_mandate/model/account_banking_mandate.py
@@ -79,7 +79,8 @@ class mandate(orm.Model):
             "cancelled mandate is a mandate that has been cancelled by "
             "the customer."),
         'payment_line_ids': fields.one2many(
-            'payment.line', 'mandate_id', "Related Payment Lines"),
+            'payment.line', 'mandate_id', "Related Payment Lines",
+            readonly=True),
     }
 
     _defaults = {

--- a/account_banking_tests/tests/test_payment_roundtrip.py
+++ b/account_banking_tests/tests/test_payment_roundtrip.py
@@ -381,6 +381,8 @@ class TestPaymentRoundtrip(SingleTransactionCase):
 
     def test_payment_roundtrip(self):
         reg, cr, uid, = self.registry, self.cr, self.uid
+        # Tests fail if admin does not have the English language
+        reg('res.users').write(cr, uid, uid, {'lang': 'en_US'})
         self.setup_company(reg, cr, uid)
         self.setup_chart(reg, cr, uid)
         self.setup_payables(reg, cr, uid)

--- a/account_direct_debit/view/account_payment.xml
+++ b/account_direct_debit/view/account_payment.xml
@@ -30,7 +30,11 @@
             <field name="arch" type="xml">
                 <data>
                     <field name="reference" position="after">
-                        <field name="payment_order_type"/>
+                        <!--
+                            Add the order type as invisible because changing it in the form view
+                            is not supported. We still need to access its value in various attrs.
+                        -->
+                        <field name="payment_order_type" invisible="1" />
                     </field>
                     <xpath expr="//button[@string='Select Invoices to Pay']"
                            position="attributes">


### PR DESCRIPTION
[FIX] Changing the payment order type from the payment or debit order form leads to unexpected behaviour
[FIX] When running tests on an existing database, make sure the admin user has the English language during the test
