### PR TITLE
[FIX] remove leftover code from refactoring

### DIFF
--- a/account_banking/account_banking.py
+++ b/account_banking/account_banking.py
@@ -272,68 +272,6 @@ class account_banking_imported_file(osv.osv):
     }
 account_banking_imported_file()
 
-class payment_mode_type(osv.osv):
-    _name= 'payment.mode.type'
-    _description= 'Payment Mode Type'
-    _columns= {
-        'name': fields.char(
-            'Name', size=64, required=True,
-            help='Payment Type'
-            ),
-        'code': fields.char(
-            'Code', size=64, required=True,
-            help='Specify the Code for Payment Type'
-            ),
-        # Setting suitable_bank_types to required pending
-        # https://bugs.launchpad.net/openobject-addons/+bug/786845
-        'suitable_bank_types': fields.many2many(
-            'res.partner.bank.type',
-            'bank_type_payment_type_rel',
-            'pay_type_id','bank_type_id',
-            'Suitable bank types', required=True),
-        'ir_model_id': fields.many2one(
-            'ir.model', 'Payment wizard',
-            help=('Select the Payment Wizard for payments of this type. '
-                  'Leave empty for manual processing'),
-            domain=[('osv_memory', '=', True)],
-            ),
-        'payment_order_type': fields.selection(
-            [('payment', 'Payment'),('debit', 'Direct debit')],
-            'Payment order type', required=True,
-            ),
-    }
-
-    _defaults = {
-        'payment_order_type': lambda *a: 'payment',
-        }
-
-payment_mode_type()
-
-class payment_mode(osv.osv):
-    ''' Restoring the payment type from version 5,
-    used to select the export wizard (if any) '''
-    _inherit = "payment.mode"
-
-    def suitable_bank_types(self, cr, uid, payment_mode_id=None, context=None):
-        """ Reinstates functional code for suitable bank type filtering.
-        Current code in account_payment is disfunctional.
-        """
-        res = []
-        payment_mode = self.browse(
-            cr, uid, payment_mode_id, context)
-        if (payment_mode and payment_mode.type and
-            payment_mode.type.suitable_bank_types):
-            res = [type.code for type in payment_mode.type.suitable_bank_types]
-        return res
-
-    _columns = {
-        'type': fields.many2one(
-            'payment.mode.type', 'Payment type',
-            help='Select the Payment Type for the Payment Mode.'
-            ),
-        }
-payment_mode()
-
 class account_bank_statement(osv.osv):
     '''
     Extensions from account_bank_statement:

--- a/account_banking/account_banking_view.xml
+++ b/account_banking/account_banking_view.xml
@@ -465,22 +465,6 @@
             </field>
         </record>
 
-	<!-- basic view for payment mode type -->
-        <record model="ir.ui.view" id="view_payment_mode_type_form">
-            <field name="name">view.payment.mode.type.form</field>
-            <field name="model">payment.mode.type</field>
-            <field name="type">form</field>
-            <field name="arch" type="xml">
-                <form>
-		    <field name="name" />
-		    <field name="code" />
-		    <field name="suitable_bank_types"/>
-		    <field name="payment_order_type"/>
-		    <field name="ir_model_id"/>
-                </form>
-            </field>
-        </record>
-
         <!-- fixes https://bugs.launchpad.net/openobject-addons/+bug/903156 for 6.0 
              Note that 6.1 does not suffer from the problem 
         -->

--- a/account_banking/data/account_banking_data.xml
+++ b/account_banking/data/account_banking_data.xml
@@ -20,12 +20,5 @@
         <record id="base_iban.bank_swift_field" model="res.partner.bank.type.field">
             <field eval="False" name="required"/>
         </record>
-        <!-- Add manual bank transfer as default payment option -->
-        <record model="payment.mode.type" id="account_banking.manual_bank_tranfer">
-            <field name="name">Manual Bank Transfer</field>
-            <field name="code">BANKMAN</field>
-            <field name="suitable_bank_types"
-                eval="[(6,0,[ref('base.bank_normal'),ref('base_iban.bank_iban'),])]" />
-        </record>
     </data>
 </openerp>

--- a/account_banking_payment_export/model/payment_mode_type.py
+++ b/account_banking_payment_export/model/payment_mode_type.py
@@ -67,5 +67,11 @@ class payment_mode_type(orm.Model):
         cr.execute("""UPDATE ir_model_data SET module='account_banking_payment_export'
                       WHERE module='account_banking' AND 
                             name='manual_bank_tranfer' AND 
-                            model='payment.mode.type'""")
+                            model='payment.mode.type' AND
+                            NOT EXISTS (
+                                SELECT id from ir_model_data WHERE
+                                    module='account_banking_payment_export' AND
+                                    name='manual_bank_tranfer' AND
+                                    model='payment.mode.type'
+                            )""")
         return r


### PR DESCRIPTION
that's a followup for the sepa backport, the _auto_init patch fixes a module update that goes wrong because the model also existed in account_banking and the xml id would be recreated during an --update=all
