### PR TITLE
[FIX] Voucher still assigns bank statement period instead of statement line period

### DIFF
--- a/account_banking/__init__.py
+++ b/account_banking/__init__.py
@@ -2,6 +2,7 @@
 ##############################################################################
 #
 #    Copyright (C) 2009 EduSense BV (<http://www.edusense.nl>).
+#              (C) 2011 - 2014 Banking addons community
 #    All Rights Reserved
 #
 #    WARNING: This program as such is intended to be used by professional
@@ -34,3 +35,4 @@ from . import wizard
 from . import res_partner
 from . import res_bank
 from . import res_partner_bank
+from . import bank_statement_monkeypatch

--- a/account_banking/bank_statement_monkeypatch.py
+++ b/account_banking/bank_statement_monkeypatch.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, an open source suite of business applications
+#    Copyright (C) 2004-2014 Odoo S.A.
+#    Modifications Copyright (C) 2014 Banking addons community
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+# Monkeypatch based on non-compliant core code, therefore
+# flake8: noqa
+from openerp import netsvc
+from openerp.osv import orm
+from openerp.addons.account_voucher.account_voucher import account_bank_statement
+
+
+def create_move_from_st_line(self, cr, uid, st_line_id, company_currency_id, next_number, context=None):
+    """
+    Modified version of the method in account_voucher/account_voucher.py,
+    which assigns the bank statement period to the voucher.
+
+    As monkeypatching affects all databases of the instance, take care not
+    to mess up on databases which do not have the period_id on the statement
+    line.
+    """
+    if True: # align the indentation level with the original method
+        voucher_obj = self.pool.get('account.voucher')
+        wf_service = netsvc.LocalService("workflow")
+        move_line_obj = self.pool.get('account.move.line')
+        bank_st_line_obj = self.pool.get('account.bank.statement.line')
+        st_line = bank_st_line_obj.browse(cr, uid, st_line_id, context=context)
+        # <change>
+        period_id = st_line.statement_id.period_id.id
+        if 'period_id' in st_line._columns and st_line.period_id:
+            period_id = st_line.period_id.id
+        # </change>
+        if st_line.voucher_id:
+            voucher_obj.write(cr, uid, [st_line.voucher_id.id],
+                            {'number': next_number,
+                            'date': st_line.date,
+                             # <change>
+                             # 'period_id': statement_id.period_id.id},
+                            'period_id': period_id},
+                             # </change>
+                            context=context)
+            if st_line.voucher_id.state == 'cancel':
+                voucher_obj.action_cancel_draft(cr, uid, [st_line.voucher_id.id], context=context)
+            wf_service.trg_validate(uid, 'account.voucher', st_line.voucher_id.id, 'proforma_voucher', cr)
+
+            v = voucher_obj.browse(cr, uid, st_line.voucher_id.id, context=context)
+            bank_st_line_obj.write(cr, uid, [st_line_id], {
+                'move_ids': [(4, v.move_id.id, False)]
+            })
+
+            return move_line_obj.write(cr, uid, [x.id for x in v.move_ids], {'statement_id': st_line.statement_id.id}, context=context)
+        return super(account_bank_statement, self).create_move_from_st_line(cr, uid, st_line.id, company_currency_id, next_number, context=context)
+
+
+class BankStatementMonkeypatch(orm.AbstractModel):
+    _name = 'account.bank.statement.monkeypatch'
+    _description = 'Bank statement monkeypatch'
+
+    def _register_hook(self, cr):
+        account_bank_statement.create_move_from_st_line = create_move_from_st_line
+        return super(BankStatementMonkeypatch, self)._register_hook(cr)


### PR DESCRIPTION
In 6.1, we could not call super on create_move_from_st_line and had to incorporate a large body of core code in account_banking. In 7.0 it looked like we did because of refactorings driven by the good people of C2C but as it turns out, account_voucher's override of this method still insists in writing the statement period to the voucher that account_banking creates for each reconciled bank statement line, instead of the period based on the statement line's date itself.

I see no other way than monkeypatching this out of account_voucher but I am taking care not to mess up other databases on the same instance. Setting this file to noqa to preserve original style for easy detection of any upstream changes.
