### PR TITLE
[IMP] sepa credit tfr: get BIC from bank account if bank is not specified on bank account

### DIFF
--- a/account_banking_pain_base/models/res_partner_bank.py
+++ b/account_banking_pain_base/models/res_partner_bank.py
@@ -1,9 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    PAIN Base module for OpenERP
-#    Copyright (C) 2013 Akretion (http://www.akretion.com)
-#    @author: Alexis de Lattre <alexis.delattre@akretion.com>
+#    Copyright (c) ACSONE SA/NV (<http://acsone.eu>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -20,8 +18,18 @@
 #
 ##############################################################################
 
-from . import payment_line
-from . import payment_mode
-from . import res_company
-from . import banking_export_pain
-from . import res_partner_bank
+from openerp import models, fields
+
+
+class ResPartnerBank(models.Model):
+    _inherit = 'res.partner.bank'
+
+    bank = fields.Many2one(help="If this field is set and the related bank "
+                                "has a 'Bank Identifier Code', then this BIC "
+                                "will be used to generate the credit "
+                                "transfers and direct debits files.")
+    bank_bic = fields.Char(help="In the generation of credit transfer and "
+                                "direct debit files, this BIC will be used "
+                                "only when the 'Bank' field is empty, or "
+                                "has a value but the field 'Bank Identifier "
+                                "Code' is not set on the related bank.")

--- a/account_banking_sepa_credit_transfer/wizard/export_sepa.py
+++ b/account_banking_sepa_credit_transfer/wizard/export_sepa.py
@@ -195,7 +195,8 @@ class BankingExportSepaWizard(orm.TransientModel):
                 'sepa_export.payment_order_ids[0].mode.bank_id.partner_id.'
                 'name',
                 'sepa_export.payment_order_ids[0].mode.bank_id.acc_number',
-                'sepa_export.payment_order_ids[0].mode.bank_id.bank.bic',
+                'sepa_export.payment_order_ids[0].mode.bank_id.bank.bic or '
+                'sepa_export.payment_order_ids[0].mode.bank_id.bank_bic',
                 {'sepa_export': sepa_export},
                 gen_args, context=context)
             charge_bearer_2_24 = etree.SubElement(payment_info_2_0, 'ChrgBr')
@@ -236,7 +237,8 @@ class BankingExportSepaWizard(orm.TransientModel):
                 self.generate_party_block(
                     cr, uid, credit_transfer_transaction_info_2_27, 'Cdtr',
                     'C', 'line.partner_id.name', 'line.bank_id.acc_number',
-                    'line.bank_id.bank.bic', {'line': line}, gen_args,
+                    'line.bank_id.bank.bic or '
+                    'line.bank_id.bank_bic', {'line': line}, gen_args,
                     context=context)
                 self.generate_remittance_info_block(
                     cr, uid, credit_transfer_transaction_info_2_27,

--- a/account_banking_sepa_direct_debit/wizard/export_sdd.py
+++ b/account_banking_sepa_direct_debit/wizard/export_sdd.py
@@ -249,7 +249,8 @@ class BankingExportSddWizard(orm.TransientModel):
                 'sepa_export.payment_order_ids[0].mode.bank_id.partner_id.'
                 'name',
                 'sepa_export.payment_order_ids[0].mode.bank_id.acc_number',
-                'sepa_export.payment_order_ids[0].mode.bank_id.bank.bic',
+                'sepa_export.payment_order_ids[0].mode.bank_id.bank.bic or '
+                'sepa_export.payment_order_ids[0].mode.bank_id.bank_bic',
                 {'sepa_export': sepa_export},
                 gen_args, context=context)
             charge_bearer_2_24 = etree.SubElement(payment_info_2_0, 'ChrgBr')
@@ -316,7 +317,10 @@ class BankingExportSddWizard(orm.TransientModel):
                         amendment_info_details_2_51 = etree.SubElement(
                             mandate_related_info_2_47, 'AmdmntInfDtls')
                     if previous_bank:
-                        if previous_bank.bank.bic == line.bank_id.bank.bic:
+                        if (previous_bank.bank.bic or
+                            previous_bank.bank_bic) == \
+                            (line.bank_id.bank.bic or
+                             line.bank_id.bank_bic):
                             ori_debtor_account_2_57 = etree.SubElement(
                                 amendment_info_details_2_51, 'OrgnlDbtrAcct')
                             ori_debtor_account_id = etree.SubElement(
@@ -340,7 +344,8 @@ class BankingExportSddWizard(orm.TransientModel):
                                 ori_debtor_agent_institution, bic_xml_tag)
                             ori_debtor_agent_bic.text = self._prepare_field(
                                 cr, uid, 'Original Debtor Agent',
-                                'previous_bank.bank.bic',
+                                'previous_bank.bank.bic or '
+                                'previous_bank.bank_bic',
                                 {'previous_bank': previous_bank},
                                 gen_args=gen_args,
                                 context=context)
@@ -375,7 +380,8 @@ class BankingExportSddWizard(orm.TransientModel):
                     cr, uid, dd_transaction_info_2_28, 'Dbtr', 'C',
                     'line.partner_id.name',
                     'line.bank_id.acc_number',
-                    'line.bank_id.bank.bic',
+                    'line.bank_id.bank.bic or '
+                    'line.bank_id.bank_bic',
                     {'line': line}, gen_args, context=context)
 
                 self.generate_remittance_info_block(


### PR DESCRIPTION
Since the bank is optional on bank accounts and the BIC can be set
on the bank account if there is no bank, we allow the system to
get the BIC from the bank account in case it is not on the bank
or the bank account has no associated bank.

We give priority to the BIC indicated on the bank.
