### PR TITLE
[IMP] set default value for payment.mode.type

### DIFF
--- a/account_banking_payment_export/models/payment_mode.py
+++ b/account_banking_payment_export/models/payment_mode.py
@@ -43,9 +43,14 @@ class PaymentMode(models.Model):
             res = [t.code for t in payment_mode.type.suitable_bank_types]
         return res
 
+    def _default_type(self):
+        return self.env.ref('account_banking_payment_export.'
+                            'manual_bank_tranfer')
+
     type = fields.Many2one(
         'payment.mode.type', string='Export type', required=True,
-        help='Select the Export Payment Type for the Payment Mode.')
+        help='Select the Export Payment Type for the Payment Mode.',
+        default=_default_type)
     payment_order_type = fields.Selection(
         related='type.payment_order_type', readonly=True, string="Order Type",
         selection=[('payment', 'Payment'), ('debit', 'Debit')],

--- a/account_banking_payment_export/models/payment_mode.py
+++ b/account_banking_payment_export/models/payment_mode.py
@@ -23,7 +23,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class PaymentMode(models.Model):
@@ -43,9 +43,12 @@ class PaymentMode(models.Model):
             res = [t.code for t in payment_mode.type.suitable_bank_types]
         return res
 
+    @api.model
     def _default_type(self):
-        return self.env.ref('account_banking_payment_export.'
-                            'manual_bank_tranfer')
+        return self.env.ref(
+            'account_banking_payment_export.'
+            'manual_bank_tranfer', raise_if_not_found=False)\
+            or self.env['payment.mode.type']
 
     type = fields.Many2one(
         'payment.mode.type', string='Export type', required=True,


### PR DESCRIPTION
Since the type field is required and payment modes may exist when
account_banking_payment_export is installed, a default value
is necessary to let Odoo set the required database constraint.

We use the Manual Bank Transfer as default.
