### PR TITLE
[FIX] account_banking_pain_base: Set a general rule for the initiating party identifier

### DIFF
--- a/account_banking_pain_base/models/res_company.py
+++ b/account_banking_pain_base/models/res_company.py
@@ -44,13 +44,11 @@ class ResCompany(orm.Model):
         assert isinstance(company_id, int), 'Only one company ID'
         company = self.browse(cr, uid, company_id, context=context)
         company_vat = company.vat
-        party_identifier = False
-        if company_vat:
+        party_identifier = company.sepa_creditor_identifier
+        if not party_identifier and company_vat:
             country_code = company_vat[0:2].upper()
             if country_code == 'BE':
                 party_identifier = company_vat[2:].replace(' ', '')
-            elif country_code == 'ES':
-                party_identifier = company.sepa_creditor_identifier
         return party_identifier
 
     def _initiating_party_issuer_default(self, cr, uid, context=None):


### PR DESCRIPTION
Currently, there is no general rule for each country of the SEPA area for getting the initiating party identification (only two for Belgium and Spain), so the rest of the countries cannot generate for example correct SEPA direct debit files. Also, with current rules, you need to set company vat identification for making any match, which is unneeded.

I propose to set company SEPA creditor identifier as the default value, and then each country can set another value (as Belgium does) if it's needed.
