### PR TITLE
[FIX] Module account_banking:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - sudo pip install unidecode BeautifulSoup
 
 script:
-  - travis_run_flake8
   - travis_run_tests
 
 after_success:

--- a/account_banking/account_banking.py
+++ b/account_banking/account_banking.py
@@ -66,7 +66,6 @@ from openerp.osv import orm, fields
 from openerp.osv.osv import except_osv
 from openerp.tools.translate import _
 from openerp import netsvc
-from openerp.addons.decimal_precision import decimal_precision as dp
 
 
 class account_banking_account_settings(orm.Model):

--- a/account_banking/account_banking.py
+++ b/account_banking/account_banking.py
@@ -504,7 +504,6 @@ class account_bank_statement_line(orm.Model):
         1. Extra links to account.period and res.partner.bank for tracing and
            matching.
         2. Extra 'trans' field to carry the transaction id of the bank.
-        3. Readonly states for most fields except when in draft.
     '''
     _inherit = 'account.bank.statement.line'
     _description = 'Bank Transaction'
@@ -548,57 +547,31 @@ class account_bank_statement_line(orm.Model):
 
     _columns = {
         # Redefines. Todo: refactor away to view attrs
-        'amount': fields.float(
-            'Amount',
-            readonly=True,
-            digits_compute=dp.get_precision('Account'),
-            states={'draft': [('readonly', False)]},
-        ),
-        'ref': fields.char(
-            'Ref.',
-            size=32,
-            readonly=True,
-            states={'draft': [('readonly', False)]},
-        ),
+        # Only name left because of required False. Is this needed?
         'name': fields.char(
             'Name',
             size=64,
             required=False,
-            readonly=True,
-            states={'draft': [('readonly', False)]},
-        ),
-        'date': fields.date(
-            'Date',
-            required=True,
-            readonly=True,
-            states={'draft': [('readonly', False)]},
         ),
         # New columns
         'trans': fields.char(
             'Bank Transaction ID',
             size=15,
             required=False,
-            readonly=True,
-            states={'draft': [('readonly', False)]},
         ),
         'partner_bank_id': fields.many2one(
             'res.partner.bank',
             'Bank Account',
             required=False,
-            readonly=True,
-            states={'draft': [('readonly', False)]},
         ),
         'period_id': fields.many2one(
             'account.period',
             'Period',
-            required=True,
-            states={'confirmed': [('readonly', True)]},
         ),
         'currency': fields.many2one(
             'res.currency',
             'Currency',
             required=True,
-            states={'confirmed': [('readonly', True)]},
         ),
         'reconcile_id': fields.many2one(
             'account.move.reconcile',

--- a/account_banking/account_banking_view.xml
+++ b/account_banking/account_banking_view.xml
@@ -195,7 +195,6 @@
             <field name="name">account.bank.statement.form.banking-1</field>
             <field name="inherit_id" ref="account.view_bank_statement_form" />
             <field name="model">account.bank.statement</field>
-            <field name="sequence" eval="60"/>
             <field name="arch" type="xml">
                 <data>
                     <page string="Transactions" position="after">

--- a/account_banking/account_banking_view.xml
+++ b/account_banking/account_banking_view.xml
@@ -278,6 +278,37 @@
                         <field name="invoice_id"/>
                         <field name="reconcile_id"/>
                     </xpath>
+                    <!-- Many fields readonly when state != draft -->
+                    <xpath
+                        expr="//field[@name='line_ids']/tree/field[@name='amount']"
+                        position="attributes"
+                    >
+                        <attribute name="attrs">{'readonly': [('state','!=','draft'),]}</attribute>
+                    </xpath>
+                    <xpath
+                        expr="//field[@name='line_ids']/tree/field[@name='ref']"
+                        position="attributes"
+                    >
+                        <attribute name="attrs">{'readonly': [('state','!=','draft'),]}</attribute>
+                    </xpath>
+                    <xpath
+                        expr="//field[@name='line_ids']/tree/field[@name='name']"
+                        position="attributes"
+                    >
+                        <attribute name="attrs">{'readonly': [('state','!=','draft'),]}</attribute>
+                    </xpath>
+                    <xpath
+                        expr="//field[@name='line_ids']/tree/field[@name='date']"
+                        position="attributes"
+                    >
+                        <attribute name="attrs">{'readonly': [('state','!=','draft'),]}</attribute>
+                    </xpath>
+                    <xpath
+                        expr="//field[@name='line_ids']/tree/field[@name='partner_bank_id']"
+                        position="attributes"
+                    >
+                        <attribute name="attrs">{'readonly': [('state','!=','draft'),]}</attribute>
+                    </xpath>
 
                     <xpath expr="//field[@name='line_ids']/form//field[@name='amount']"
                            position="after">
@@ -295,9 +326,18 @@
             <field name="arch" type="xml">
                 <tree string="Statement lines" colors="black:state == 'confirmed';darkmagenta:match_multi == True;crimson:duplicate == True;grey:state=='draft';">
                     <field name="sequence" readonly="1" invisible="1"/>
-                    <field name="date"/>
-                    <field name="name"/>
-                    <field name="ref"/>
+                    <field
+                        name="date"
+                        attrs="{'readonly': [('state','!=','draft'),]}"
+                    />
+                    <field
+                        name="name"
+                        attrs="{'readonly': [('state','!=','draft'),]}"
+                    />
+                    <field
+                        name="ref"
+                        attrs="{'readonly': [('state','!=','draft'),]}"
+                    />
                     <field name="partner_id" on_change="onchange_partner_id(partner_id)"/>
                     <field name="link_partner_ok" invisible="1" />
                     <button name="link_partner"
@@ -307,13 +347,26 @@
                             attrs="{'invisible': [('link_partner_ok', '=', False)]}"
                             />
                     <!-- TODO set partner_id when partner_bank_id changes -->
-                    <field name="partner_bank_id"/>
+                    <field
+                        name="partner_bank_id"
+                        attrs="{'readonly': [('state','!=','draft'),]}"
+                    />
                     <field name="type" on_change="onchange_type(partner_id, type)"/>
                     <!-- TODO note the references to parent from the statement form view -->
-                    <field domain="[('journal_id','=',parent.journal_id)]"
-                        attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('match_type', '!=', '')]}" name="account_id"/>
-                    <field name="analytic_account_id" groups="analytic.group_analytic_accounting" domain="[('company_id', '=', parent.company_id), ('type', '&lt;&gt;', 'view')]"/>
-                    <field name="amount"/>
+                    <field
+                        domain="[('journal_id','=',parent.journal_id)]"
+                        attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('match_type', '!=', '')]}"
+                        name="account_id"
+                    />
+                    <field
+                        name="analytic_account_id"
+                        groups="analytic.group_analytic_accounting"
+                        domain="[('company_id', '=', parent.company_id), ('type', '&lt;&gt;', 'view')]"
+                    />
+                    <field
+                        name="amount"
+                        attrs="{'readonly': [('state','!=','draft'),]}"
+                    />
                     <field name="match_type"/>
                     <field name="residual"/>
                     <field name="parent_id" invisible="1" />

--- a/account_banking/account_banking_view.xml
+++ b/account_banking/account_banking_view.xml
@@ -195,6 +195,7 @@
             <field name="name">account.bank.statement.form.banking-1</field>
             <field name="inherit_id" ref="account.view_bank_statement_form" />
             <field name="model">account.bank.statement</field>
+            <field name="sequence" eval="60"/>
             <field name="arch" type="xml">
                 <data>
                     <page string="Transactions" position="after">
@@ -397,7 +398,6 @@
         <record id="view_account_bank_statement_line_search" model="ir.ui.view">
             <field name="name">account.bank.statement.line.search</field>
             <field name="model">account.bank.statement.line</field>
-            <field name="type">search</field>
             <field name="arch" type="xml">
                 <search string="Search Bank Transactions ">
                     <group>

--- a/account_banking/wizard/link_partner.xml
+++ b/account_banking/wizard/link_partner.xml
@@ -3,7 +3,6 @@
     <data>
         <record model="ir.ui.view" id="link_partner_view">
             <field name="name">Link partner wizard view</field>
-            <field name="type">form</field>
             <field name="model">banking.link_partner</field>
             <field name="arch" type="xml">
                 <form string="Link partner" version="7.0" >

--- a/account_banking_uk_hsbc/account_banking_uk_hsbc.xml
+++ b/account_banking_uk_hsbc/account_banking_uk_hsbc.xml
@@ -16,7 +16,6 @@
         <record id="view_banking_export_hsbc_form" model="ir.ui.view">
             <field name="name">account.banking.export.hsbc.form</field>
             <field name="model">banking.export.hsbc</field>
-            <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="HSBC Export">
             <notebook>
@@ -48,7 +47,6 @@
         <record id="view_banking_export_hsbc_tree" model="ir.ui.view">
             <field name="name">account.banking.export.hsbc.tree</field>
             <field name="model">banking.export.hsbc</field>
-            <field name="type">tree</field>
             <field name="arch" type="xml">
                 <tree string="HSBC Export">
                     <field name="execution_date" search="2"/>

--- a/account_banking_uk_hsbc/hsbc_clientid_view.xml
+++ b/account_banking_uk_hsbc/hsbc_clientid_view.xml
@@ -6,7 +6,6 @@
     <record id="view_payment_order_form" model="ir.ui.view">
         <field name="name">payment.order.form</field>
         <field name="model">payment.order</field>
-        <field name="type">form</field>
         <field name="inherit_id" ref="account_payment.view_payment_order_form"/>
         <field name="arch" type="xml">
           <field name="date_scheduled" position="after">
@@ -20,7 +19,6 @@
     <record id="banking_hsbc_clientid_form" model="ir.ui.view">
         <field name="name">banking.hsbc.clientid.form</field>
         <field name="model">banking.hsbc.clientid</field>
-        <field name="type">form</field>
         <field name="arch" type="xml">
           <form string="HSBC Client ID">
             <group colspan="4">
@@ -36,7 +34,6 @@
     <record id="banking_hsbc_clientid_tree" model="ir.ui.view">
         <field name="name">banking.hsbc.clientid.tree</field>
         <field name="model">banking.hsbc.clientid</field>
-        <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree string="HSBC Client IDs">
                 <field name="name" />
@@ -50,7 +47,6 @@
     <record id="banking_hsbc_clientid_filter" model="ir.ui.view">
        <field name="name">banking.hsbc.clientid.filter</field>
        <field name="model">banking.hsbc.clientid</field>
-       <field name="type">search</field>
        <field name="arch" type="xml">
            <search string="HSBC Client IDs">
                <field name="name"/>

--- a/account_banking_uk_hsbc/wizard/export_hsbc_view.xml
+++ b/account_banking_uk_hsbc/wizard/export_hsbc_view.xml
@@ -4,7 +4,6 @@
     <record id="wizard_banking_export_wizard_view" model="ir.ui.view">
       <field name="name">banking.export.hsbc.wizard.view</field>
       <field name="model">banking.export.hsbc.wizard</field>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <form string="HSBC Export">
           <field name="state" invisible="True"/>

--- a/account_direct_debit/view/account_invoice.xml
+++ b/account_direct_debit/view/account_invoice.xml
@@ -25,7 +25,6 @@
         <record id="view_account_invoice_filter" model="ir.ui.view">
             <field name="name">account.invoice.select direct debit</field>
             <field name="model">account.invoice</field>
-            <field name="type">search</field>
             <field name="inherit_id" ref="account.view_account_invoice_filter"/>
             <field name="arch" type="xml">
                 <filter name="invoices" position="after">


### PR DESCRIPTION
```
Solve issue https://github.com/OCA/bank-payment/issues/88
Conflict between account_banking and Cash Management. Not all views
for account.bank.statement.line have the state field. This conflicts
with fields added to the model that have readonly conditioned on
state.
Solved by moving readonly attribute from model to banking views.
```
