### PR TITLE
7.0 fix uk hsbc mt940 import

### DIFF
--- a/account_banking_uk_hsbc/mt940_parser.py
+++ b/account_banking_uk_hsbc/mt940_parser.py
@@ -50,18 +50,18 @@ class HSBCParser(object):
                            r"(?P<startingbalance>[\d,]{1,15})")
 
         # Transaction
-        recparse["61"] = r"""\
-:(?P<recordid>61):\
-(?P<valuedate>\d{6})(?P<bookingdate>\d{4})?\
-(?P<creditmarker>R?[CD])\
-(?P<currency>[A-Z])?\
-(?P<amount>[\d,]{1,15})\
-(?P<bookingcode>[A-Z][A-Z0-9]{3})\
-(?P<custrefno>[%(ebcdic)s]{1,16})\
-(?://)\
-(?P<bankref>[%(ebcdic)s]{1,16})?\
-(?:\n(?P<furtherinfo>[%(ebcdic)s]))?\
-""" % (patterns)
+        recparse["61"] = (r"""
+:(?P<recordid>61):
+(?P<valuedate>\d{6})(?P<bookingdate>\d{4})?
+(?P<creditmarker>R?[CD])
+(?P<currency>[A-Z])?
+(?P<amount>[\d,]{1,15})
+(?P<bookingcode>[A-Z][A-Z0-9]{3})
+(?P<custrefno>[%(ebcdic)s]{1,16})
+(?://)
+(?P<bankref>[%(ebcdic)s]{1,16})?
+(?:\n(?P<furtherinfo>[%(ebcdic)s]))?
+""" % (patterns)).replace('\n','')
 
         # Further info
         recparse["86"] = (r":(?P<recordid>86):"
@@ -156,7 +156,7 @@ class HSBCParser(object):
 
 def parse_file(filename):
     with open(filename, "r") as hsbcfile:
-        HSBCParser().parse(hsbcfile.readlines())
+        HSBCParser().parse(None, hsbcfile.readlines())
 
 
 def main():

--- a/account_banking_uk_hsbc/mt940_parser.py
+++ b/account_banking_uk_hsbc/mt940_parser.py
@@ -61,7 +61,7 @@ class HSBCParser(object):
 (?://)
 (?P<bankref>[%(ebcdic)s]{1,16})?
 (?:\n(?P<furtherinfo>[%(ebcdic)s]))?
-""" % (patterns)).replace('\n','')
+""" % (patterns)).replace('\n', '')
 
         # Further info
         recparse["86"] = (r":(?P<recordid>86):"


### PR DESCRIPTION
Fixed a problem with a recent change to the regexp string causing it
to no longer match against statement lines due to backslash.

Also fixed testing code when running from the command line

This pull request replaces https://github.com/OCA/bank-payment/pull/92, which was missing PEP8 compliance.

@sbidoul previously commented:

> Interesting bug. The fix looks good to me.
> Can you add a space after the comma for pep8 compliance?

PEP8 fix in 5de112de8dc0e547af283a73e25d48554255dd2a
