### PR TITLE
8.0 FIX bug #111: crash when generating SEPA credit transfer file

### DIFF
--- a/account_banking_pain_base/models/res_company.py
+++ b/account_banking_pain_base/models/res_company.py
@@ -44,8 +44,8 @@ class ResCompany(orm.Model):
         assert isinstance(company_id, int), 'Only one company ID'
         company = self.browse(cr, uid, company_id, context=context)
         company_vat = company.vat
-        party_identifier = company.sepa_creditor_identifier
-        if not party_identifier and company_vat:
+        party_identifier = False
+        if company_vat:
             country_code = company_vat[0:2].upper()
             if country_code == 'BE':
                 party_identifier = company_vat[2:].replace(' ', '')


### PR DESCRIPTION
Please refer to the bug report #111 for the explainations. In fact, the commit just goes back to the code of v7.0, which worked well.
