### PR TITLE
7.0 uk hsbc import improvements

### DIFF
--- a/account_banking_uk_hsbc/hsbc_mt940.py
+++ b/account_banking_uk_hsbc/hsbc_mt940.py
@@ -53,6 +53,7 @@ class transaction(models.mem_bank_transaction):
     type_map = {
         'NTRF': bt.ORDER,
         'NMSC': bt.ORDER,
+        'NACH': bt.ORDER,
         'NPAY': bt.PAYMENT_BATCH,
         'NCHK': bt.CHECK,
     }

--- a/account_banking_uk_hsbc/hsbc_mt940.py
+++ b/account_banking_uk_hsbc/hsbc_mt940.py
@@ -153,7 +153,7 @@ class statement(models.mem_bank_statement):
                 record[k]
                 for k in (
                     'infoline{0}'.format(i)
-                    for i in range(2, 5)
+                    for i in range(1, 5)
                 )
                 if k in record
             ))

--- a/account_banking_uk_hsbc/hsbc_mt940.py
+++ b/account_banking_uk_hsbc/hsbc_mt940.py
@@ -46,7 +46,6 @@ class transaction(models.mem_bank_transaction):
         'value_date': 'valuedate',
         'local_currency': 'currency',
         'transfer_type': 'bookingcode',
-        'reference': 'custrefno',
         'message': 'furtherinfo'
     }
 
@@ -68,6 +67,10 @@ class transaction(models.mem_bank_transaction):
                 setattr(self, key, record[value])
 
         self.transferred_amount = record2float(record, 'amount')
+
+        ref = record.get('custrefno')
+        if ref and ref != 'NONREF':
+            self.reference = ref
 
         # Set the transfer type based on the bookingcode
         if record.get('bookingcode', 'ignore') in self.type_map:

--- a/account_banking_uk_hsbc/mt940_parser.py
+++ b/account_banking_uk_hsbc/mt940_parser.py
@@ -36,7 +36,10 @@ class HSBCParser(object):
 
     def __init__(self):
         recparse = dict()
-        patterns = {'ebcdic': r"\w/\?:\(\).,'+{} -"}
+        # Allowed characters. The list was originally taken from HSBC's
+        # spec, but the ampersand character was found out in the wild in
+        # the customer account name
+        patterns = {'ebcdic': r"\w/\?:\(\).,'+{} &-"}
 
         # MT940 header
         recparse["20"] = r":(?P<recordid>20):(?P<transref>.{1,16})"


### PR DESCRIPTION
This branch contains 3 small changes I made to improve HSBC MT940 import:
- Add first information line in transaction description. This often contains useful information such as the remote partner name, so is very helpful in deciding how to match transactions
- Do not import NONREF reference - it is a placeholder for nothing, and makes the statement easier to read if it is imported as blank instead.
- Explicitly recognise ACH as payment order type. This does not change functionality, because the default payment type is payment order, but makes the code more explicit.
