### PR TITLE
[account_invoice_bank_usability] New addon to cover usability concepts

### DIFF
--- a/account_invoice_bank_usability/__init__.py
+++ b/account_invoice_bank_usability/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_bank_usability/__openerp__.py
+++ b/account_invoice_bank_usability/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Pexego (<http://www.pexego.es>).
+#
+#    All other contributions are (C) by their respective contributors
+#
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Invoice bank usability',
+    'version': '0.1',
+    'license': 'AGPL-3',
+    'author': 'Banking addons community',
+    'website': 'https://github.com/OCA/banking',
+    'category': 'Banking addons',
+    'depends': ['account'],
+    'data': ['views/account_invoice_view.xml'],
+    'description': '''Allow to select customer bank accounts on customer
+    invoices.''',
+    'auto_install': False,
+    'installable': True,
+}

--- a/account_invoice_bank_usability/models/__init__.py
+++ b/account_invoice_bank_usability/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/account_invoice_bank_usability/models/account_invoice.py
+++ b/account_invoice_bank_usability/models/account_invoice.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Pexego (<http://www.pexego.es>).
+#
+#    All other contributions are (C) by their respective contributors
+#
+#    All Rights Reserved
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from lxml import etree
+
+
+class account_invoice(models.Model):
+
+    _inherit = "account.invoice"
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type=False, toolbar=False,
+                        submenu=False):
+        context = self._context
+
+        res = super(account_invoice, self).fields_view_get(view_id=view_id,
+                                                           view_type=view_type,
+                                                           toolbar=toolbar,
+                                                           submenu=submenu)
+
+        doc = etree.XML(res['arch'])
+
+        if context.get('type'):
+            for node in doc.xpath("//field[@name='partner_bank_id']"):
+                if context['type'] in ('in_refund', 'out_refund'):
+                    node.set('domain', """['|','|',('partner_id.ref_companies',
+'in', [company_id]),('partner_id', '=', partner_id),('partner_id.child_ids',
+'child_of', [partner_id])]""")
+
+        res['arch'] = etree.tostring(doc)
+        return res

--- a/account_invoice_bank_usability/views/account_invoice_view.xml
+++ b/account_invoice_bank_usability/views/account_invoice_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="invoice_supplier_form_imp_bank_domain" model="ir.ui.view">
+            <field name="name">account.invoice.supplier.form.imp.bank.domain</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <field name="partner_bank_id" position="attributes">
+                    <attribute name="domain">['|','|',('partner_id.ref_companies','in', [company_id]),('partner_id', '=', partner_id),('partner_id.child_ids', 'child_of', [partner_id])]</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record id="invoice_form_imp_bank_domain" model="ir.ui.view">
+            <field name="name">account.invoice.form.imp.bank.domain</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <field name="partner_bank_id" position="attributes">
+                    <attribute name="domain">['|','|',('partner_id.ref_companies','in', [company_id]),('partner_id', '=', partner_id),('partner_id.child_ids', 'child_of', [partner_id])]</attribute>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hi,

We found an usability issue on customer invoices, because, we are not able to select customer bank accounts. I didn't know if is only common at Spain but, we should be able to create customer invoices as direct debit.

In addition, this addon contemplates the possibility of customer/supplier bank account was defined in partner parents.

Regards
