### PR TITLE
Add multi-company rule on account.banking.mandate

### DIFF
--- a/account_banking_mandate/__openerp__.py
+++ b/account_banking_mandate/__openerp__.py
@@ -38,6 +38,7 @@
         'views/account_payment_view.xml',
         'views/res_partner_bank_view.xml',
         'data/mandate_reference_sequence.xml',
+        'security/mandate_security.xml',
         'security/ir.model.access.csv',
     ],
     'demo': [],

--- a/account_banking_mandate/security/mandate_security.xml
+++ b/account_banking_mandate/security/mandate_security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 Akretion (http://www.akretion.com/)
+    @author: Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+
+<openerp>
+<data noupdate="1">
+
+<record id="account_banking_mandate_rule" model="ir.rule">
+    <field name="name">Banking Mandate multi-company</field>
+    <field name="model_id" ref="model_account_banking_mandate"/>
+    <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
That's very important for multi-company deployments ! I had some debit denied with a SEPA direct debit because of this missing rule :-(
