### PR TITLE
This module will make the invoice paid when you finish the payment order workflow

### DIFF
--- a/account_payment_pay_invoice/__init__.py
+++ b/account_payment_pay_invoice/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import model
+from . import wizard

--- a/account_payment_pay_invoice/__openerp__.py
+++ b/account_payment_pay_invoice/__openerp__.py
@@ -1,0 +1,50 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Account Payment that pays invoices',
+    'version': '0.1',
+    "sequence": 14,
+    'complexity': "easy",
+    'category': 'Payment',
+    'description': """
+        Complete the payment workflow by simulating
+        a bank statement reconciliation.
+        We know that an invoice is going to be marked "paid" when the functional fields "reconciled" is going to be true.
+        And it is going to be True once all the account_move_line linked to the account_invoice are reconciled, aka once
+        all the account_move_line linked to the account_invoice are linked to account_move_reconcile through the
+        field reconcile_id
+    """,
+    'author': 'Visiondirect',
+    'website': 'visiondirect.co.uk',
+    'depends': ["account_payment"],
+    'data': [
+        "view/account_payment_view.xml",
+    ],
+    'test': [
+        'test/test_payment_method.yml',
+        'test/test_payment_method_multicurrency.yml',
+        'test/test_payment_method_partial.yml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'contributors': ['Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>'],
+}

--- a/account_payment_pay_invoice/model/__init__.py
+++ b/account_payment_pay_invoice/model/__init__.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account_payment

--- a/account_payment_pay_invoice/model/account_payment.py
+++ b/account_payment_pay_invoice/model/account_payment.py
@@ -1,0 +1,154 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from datetime import date
+from openerp.osv import osv
+from openerp.tools.translate import _
+
+
+class payment_order(osv.osv):
+    _inherit = 'payment.order'
+
+    def get_payment_ref(self, cr, uid, ids):
+        return "Payment " + date.today().strftime("%d/%m/%y")
+
+    _defaults = {
+        'reference': get_payment_ref,
+    }
+
+    def create_bs(self, cr, uid, bank_journal):
+        bs = self.pool.get('account.bank.statement')
+        bank_stmt_id = bs.create(cr, uid, {
+            'journal_id': bank_journal,
+        })
+        return bank_stmt_id
+
+    def create_bsline(
+            self, cr, uid,
+            obj, invoice_record, bank_stmt_id, amount=0.0,
+            amount_currency=0.0, currency_id=None
+    ):
+        bsl = self.pool.get('account.bank.statement.line')
+        number = invoice_record.number or ""
+        supplier_invoice_number = invoice_record.supplier_invoice_number or ""
+        bank_stmt_line_id = bsl.create(cr,
+                                       uid,
+                                       {'ref': obj.reference,
+                                        'name': number + " " + supplier_invoice_number,
+                                        'statement_id': bank_stmt_id,
+                                        'partner_id': invoice_record.partner_id.id,
+                                        'amount': -amount,
+                                        'amount_currency': -amount_currency,
+                                        'currency_id': currency_id,
+                                        })
+        return bank_stmt_line_id
+
+    def reconcile(
+            self, cr, uid,
+            invoice_record, bank_stmt_line_id, amount,
+            amount_currency, currency_id
+    ):
+        # reconcile the payment with the invoice
+        data_obj = self.pool.get('ir.model.data')
+        bsl = self.pool.get('account.bank.statement.line')
+        line_id = False
+        for line in invoice_record.move_id.line_id:
+            if line.account_id.user_type.id == data_obj.get_object_reference(
+                    cr, uid, 'account', 'data_account_type_payable'
+            )[1]:
+                line_id = line
+                break
+        if not line_id:
+            raise osv.except_osv(
+                _('Warning!'),
+                _("The journal entry '%s' for the invoice '%s' does "
+                  "not have a line with an account receivable." % (
+                      invoice_record.move_id.name, invoice_record.number
+                  ))
+            )
+        amount_in_widget = currency_id and amount_currency or amount
+        bsl.process_reconciliation(cr,
+                                   uid,
+                                   bank_stmt_line_id,
+                                   [{'counterpart_move_line_id': line_id.id,
+                                     'credit': amount_in_widget < 0 and -amount_in_widget or 0.0,
+                                     'debit': amount_in_widget > 0 and amount_in_widget or 0.0,
+                                     'name': line_id.name,
+                                     }])
+        return bank_stmt_line_id
+
+    def set_done(self, cr, uid, ids, *args):
+        if isinstance(ids, (int, long)):
+            ids = [ids]
+        res = super(payment_order, self).set_done(cr, uid, ids, *args)
+        bs = self.pool.get('account.bank.statement')
+        for obj in self.browse(cr, uid, ids):
+            bank_journal = obj.mode.journal.id
+            total_amount = 0.0
+            # create the bank statement
+            bank_stmt_id = self.create_bs(cr, uid, bank_journal)
+            line_ids = obj.line_ids
+            for line in line_ids:
+                currency_id = None
+                invoice = line.move_line_id.invoice
+                if not invoice:
+                    raise osv.except_osv(
+                        _('Warning!'), _(
+                            "The line {0} is not associated to any invoice.".format(
+                                line.id)))
+                if invoice.state == 'paid':
+                    payments = ' '.join(
+                        [l.move_id.name for l in invoice.payment_ids]
+                    )
+                    raise osv.except_osv(
+                        _('Warning!'),
+                        _("The invoice {0} has already been paid: {1}".format(
+                            invoice.number, payments
+                        ))
+                    )
+                amount_currency = line.amount_currency
+                amount = line.amount
+                if line.currency.id != line.company_currency.id:
+                    currency_id = line.currency.id
+                # bank statement line
+                bank_stmt_line_id = self.create_bsline(
+                    cr,
+                    uid,
+                    obj,
+                    invoice,
+                    bank_stmt_id,
+                    amount,
+                    amount_currency,
+                    currency_id)
+                self.reconcile(
+                    cr,
+                    uid,
+                    invoice,
+                    bank_stmt_line_id,
+                    amount,
+                    amount_currency,
+                    currency_id)
+                total_amount += amount
+            bs.write(
+                cr, uid, bank_stmt_id, {
+                    'balance_end_real': -total_amount})
+            bs.button_confirm_bank(cr, uid, [bank_stmt_id])
+        return res

--- a/account_payment_pay_invoice/test/test_payment_method.yml
+++ b/account_payment_pay_invoice/test/test_payment_method.yml
@@ -1,0 +1,103 @@
+-
+  I create a supplier invoice
+-
+  !record {model: account.invoice, id: account_invoice_supplier0, view: account.invoice_supplier_form}:
+    check_total: 450.0
+    partner_id: base.res_partner_4
+    reference_type: none
+    type: in_invoice
+    account_id: account.a_pay
+    company_id: base.main_company
+    currency_id: base.EUR
+    invoice_line:
+      - account_id: account.a_expense
+        name: 'Some contact lenses'
+        price_unit: 450.0
+        quantity: 1.0
+      - account_id: account.a_expense
+        name: 'Some other contact lenses'
+        price_unit: 555.55
+        quantity: 1.0
+    journal_id: account.expenses_journal
+-
+  Make sure that the type is in_invoice
+-
+  !python {model: account.invoice}: |
+    self.write(cr, uid, ref("account_invoice_supplier0"), {'type': 'in_invoice'})
+-
+  I change the state of invoice to open by clicking Validate button
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: account_invoice_supplier0}
+-
+  I check that the invoice state is now "Open"
+-
+  !assert {model: account.invoice, id: account_invoice_supplier0}:
+    - state == 'open'
+    - type == 'in_invoice'
+-
+  I create a payment order on which I will select the invoice I created
+-
+  !record {model: payment.order, id: payment_order_0}:
+    mode: account_payment.payment_mode_1
+    date_prefered: 'due'
+-
+  !record {model: payment.order.create, id: payment_order_create_0}:
+    duedate: !eval time.strftime('%Y-%m-%d')
+-
+  I search for the invoice entries to make the payment.
+-
+  !python {model: payment.order.create}: |
+    self.search_entries(cr, uid, [ref("payment_order_create_0")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_0")],
+      "active_id": ref("payment_order_0"), })
+-
+  I create payment lines entries.
+-
+  !python {model: payment.order.create}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account_invoice_supplier0"))
+    entries = []
+    for move_line in invoice.move_id.line_id:
+        if move_line.credit and not move_line.debit:
+            entries.append((6, 0, [move_line.id]))
+    self.write(cr, uid, [ref("payment_order_create_0")], {'entries': entries})
+    self.create_payment(cr, uid, [ref("payment_order_create_0")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_0")],
+      "active_id": ref("payment_order_0")})
+    pay_obj = self.pool.get('payment.order')
+    pay = pay_obj.browse(cr, uid, ref('payment_order_0'))
+    for line in pay.line_ids:
+        assert line.amount != 0.0
+-
+  I confirm the payment order.
+-
+  !workflow {model: payment.order, action: open, ref: payment_order_0}
+-
+  I check that payment order is now "Confirmed".
+-
+  !assert {model: payment.order, id: payment_order_0, severity: error, string: Payment Order should be 'Confirmed'.}:
+    - state == 'open'
+-
+  After making all payments, I finish the payment order.
+-
+  !python {model: payment.order}: |
+    self.set_done(cr, uid, [ref("payment_order_0")])
+-
+  I check that payment order is now "Done".
+-
+  !assert {model: payment.order, id: payment_order_0, severity: error, string: Payment Order should be in 'Done' state}:
+    - state == 'done'
+-
+  I check that the invoice has payments associated
+-
+  !assert {model: account.invoice, id: account_invoice_supplier0, severity: error, string: payment_ids should be populated}:
+    - payment_ids
+-
+  I check the content of the payment
+-
+  !python {model: account.invoice}: |
+    inv = self.browse(cr, uid, ref("account_invoice_supplier0"))
+    assert round(inv.payment_ids[0].debit, 2) == 1005.55
+    assert inv.payment_ids[0].credit == 0
+    assert inv.payment_ids[0].reconcile_id.id != False
+    assert inv.payment_ids[0].reconcile_ref != False
+    assert inv.state == 'paid'

--- a/account_payment_pay_invoice/test/test_payment_method_multicurrency.yml
+++ b/account_payment_pay_invoice/test/test_payment_method_multicurrency.yml
@@ -1,0 +1,104 @@
+-
+  I create currency GBP against EUR at 0.778277
+-
+  !record {model: res.currency.rate, id: jan_gbp}:
+    currency_id: base.GBP
+    name: !eval "'%s-01-01' %(datetime.now().year)"
+    rate: 0.778277
+-
+  I create a supplier invoice
+-
+  !record {model: account.invoice, id: account_invoice_supplier1, view: account.invoice_supplier_form}:
+    check_total: 450.0
+    partner_id: base.res_partner_12
+    reference_type: none
+    type: in_invoice
+    account_id: account.a_pay
+    company_id: base.main_company
+    currency_id: base.GBP
+    invoice_line:
+      - account_id: account.a_expense
+        name: 'Some contact lenses'
+        price_unit: 450.0
+        quantity: 1.0
+    journal_id: account.expenses_journal
+-
+  Make sure that the type is in_invoice
+-
+  !python {model: account.invoice}: |
+    self.write(cr, uid, ref("account_invoice_supplier1"), {'type': 'in_invoice'})
+-
+  I change the state of invoice to open by clicking Validate button
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: account_invoice_supplier1}
+-
+  I check that the invoice state is now "Open"
+-
+  !assert {model: account.invoice, id: account_invoice_supplier1}:
+    - state == 'open'
+    - type == 'in_invoice'
+-
+  I create a payment order on which I will select the invoice I created
+-
+  !record {model: payment.order, id: payment_order_1}:
+    mode: account_payment.payment_mode_1
+    date_prefered: 'due'
+-
+  !record {model: payment.order.create, id: payment_order_create_1}:
+    duedate: !eval time.strftime('%Y-%m-%d')
+-
+  I search for the invoice entries to make the payment.
+-
+  !python {model: payment.order.create}: |
+    self.search_entries(cr, uid, [ref("payment_order_create_1")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_1")],
+      "active_id": ref("payment_order_1"), })
+-
+  I create payment lines entries.
+-
+  !python {model: payment.order.create}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account_invoice_supplier1"))
+    move_line = invoice.move_id.line_id[0]
+    self.write(cr, uid, [ref("payment_order_create_1")], {'entries': [(6,0,[move_line.id])]})
+    self.create_payment(cr, uid, [ref("payment_order_create_1")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_1")],
+      "active_id": ref("payment_order_1")})
+    pay_obj = self.pool.get('payment.order')
+    pay = pay_obj.browse(cr, uid, ref('payment_order_1'))
+    assert pay.line_ids
+    for line in pay.line_ids:
+        assert line.amount != 0.0
+-
+  I confirm the payment order.
+-
+  !workflow {model: payment.order, action: open, ref: payment_order_1}
+-
+  I check that payment order is now "Confirmed".
+-
+  !assert {model: payment.order, id: payment_order_1, severity: error, string: Payment Order should be 'Confirmed'.}:
+    - state == 'open'
+-
+  After making all payments, I finish the payment order.
+-
+  !python {model: payment.order}: |
+    self.set_done(cr, uid, [ref("payment_order_1")])
+-
+  I check that payment order is now "Done".
+-
+  !assert {model: payment.order, id: payment_order_1, severity: error, string: Payment Order should be in 'Done' state}:
+    - state == 'done'
+-
+  I check that the invoice has payments associated
+-
+  !assert {model: account.invoice, id: account_invoice_supplier1, severity: error, string: payment_ids should be populated}:
+    - payment_ids
+-
+  I check the content of the payment
+-
+  !python {model: account.invoice}: |
+    inv = self.browse(cr, uid, ref("account_invoice_supplier1"))
+    assert inv.payment_ids[0].debit == round(450 / 0.778277, 2)
+    assert inv.payment_ids[0].credit == 0
+    assert inv.payment_ids[0].reconcile_id.id != False
+    assert inv.payment_ids[0].reconcile_ref != False
+    assert inv.state == 'paid'

--- a/account_payment_pay_invoice/test/test_payment_method_partial.yml
+++ b/account_payment_pay_invoice/test/test_payment_method_partial.yml
@@ -1,0 +1,154 @@
+-
+  I create a supplier invoice
+-
+  !record {model: account.invoice, id: account_invoice_supplier2, view: account.invoice_supplier_form}:
+    check_total: 450.0
+    partner_id: base.res_partner_12
+    reference_type: none
+    type: in_invoice
+    account_id: account.a_pay
+    company_id: base.main_company
+    currency_id: base.EUR
+    invoice_line:
+      - account_id: account.a_expense
+        name: 'Some contact lenses'
+        price_unit: 450.0
+        quantity: 1.0
+    journal_id: account.expenses_journal
+-
+  Make sure that the type is in_invoice
+-
+  !python {model: account.invoice}: |
+    self.write(cr, uid, ref("account_invoice_supplier2"), {'type': 'in_invoice'})
+-
+  I change the state of invoice to open by clicking Validate button
+-
+  !workflow {model: account.invoice, action: invoice_open, ref: account_invoice_supplier2}
+-
+  I check that the invoice state is now "Open"
+-
+  !assert {model: account.invoice, id: account_invoice_supplier2}:
+    - state == 'open'
+    - type == 'in_invoice'
+-
+  I create a payment order on which I will select the invoice I created
+-
+  !record {model: payment.order, id: payment_order_2}:
+    mode: account_payment.payment_mode_1
+    date_prefered: 'due'
+-
+  !record {model: payment.order.create, id: payment_order_create_2}:
+    duedate: !eval time.strftime('%Y-%m-%d')
+-
+  I search for the invoice entries to make the payment.
+-
+  !python {model: payment.order.create}: |
+    self.search_entries(cr, uid, [ref("payment_order_create_2")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_2")],
+      "active_id": ref("payment_order_2"), })
+-
+  I create payment lines entries.
+-
+  !python {model: payment.order.create}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account_invoice_supplier2"))
+    move_line = invoice.move_id.line_id[0]
+    self.write(cr, uid, [ref("payment_order_create_2")], {'entries': [(6,0,[move_line.id])]})
+    self.create_payment(cr, uid, [ref("payment_order_create_2")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_2")],
+      "active_id": ref("payment_order_2")})
+    pay_obj = self.pool.get('payment.order')
+    pay = pay_obj.browse(cr, uid, ref('payment_order_2'))
+    assert pay.line_ids
+    for line in pay.line_ids:
+        assert line.amount != 0.0
+-
+  I change the amount paid to test the partial payment
+-
+  !python {model: payment.order}: |
+    line_ids = self.browse(cr, uid, ref('payment_order_2')).line_ids
+    self.pool.get('payment.line').write(cr, uid, line_ids[0].id, {'amount_currency':50})
+-
+  I confirm the payment order.
+-
+  !workflow {model: payment.order, action: open, ref: payment_order_2}
+-
+  I check that payment order is now "Confirmed".
+-
+  !assert {model: payment.order, id: payment_order_2, severity: error, string: Payment Order should be 'Confirmed'.}:
+    - state == 'open'
+-
+  After making this partial payment, I finish the payment order.
+-
+  !python {model: payment.order}: |
+    self.set_done(cr, uid, [ref("payment_order_2")])
+-
+  I check that payment order is now "Done".
+-
+  !assert {model: payment.order, id: payment_order_2, severity: error, string: Payment Order should be in 'Done' state}:
+    - state == 'done'
+-
+  I check that the invoice has payments associated
+-
+  !assert {model: account.invoice, id: account_invoice_supplier2, severity: error, string: payment_ids should be populated}:
+    - payment_ids
+-
+  I check the content of the payment
+-
+  !python {model: account.invoice}: |
+    inv = self.browse(cr, uid, ref("account_invoice_supplier2"))
+    assert inv.payment_ids[0].debit == 50
+    assert inv.payment_ids[0].credit == 0
+    assert inv.payment_ids[0].reconcile_partial_id.id != False
+    assert inv.state == 'open'
+-
+  I create a payment order on which I will select the invoice I created
+-
+  !record {model: payment.order, id: payment_order_3}:
+    mode: account_payment.payment_mode_1
+    date_prefered: 'due'
+-
+  !record {model: payment.order.create, id: payment_order_create_3}:
+    duedate: !eval time.strftime('%Y-%m-%d')
+-
+  I search for the invoice entries to make the payment.
+-
+  !python {model: payment.order.create}: |
+    self.search_entries(cr, uid, [ref("payment_order_create_3")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_3")],
+      "active_id": ref("payment_order_3"), })
+-
+  I create payment lines entries.
+-
+  !python {model: payment.order.create}: |
+    invoice = self.pool.get('account.invoice').browse(cr, uid, ref("account_invoice_supplier2"))
+    move_line = invoice.move_id.line_id[0]
+    self.write(cr, uid, [ref("payment_order_create_3")], {'entries': [(6,0,[move_line.id])]})
+    self.create_payment(cr, uid, [ref("payment_order_create_3")], {
+      "active_model": "payment.order", "active_ids": [ref("payment_order_3")],
+      "active_id": ref("payment_order_3")})
+    pay_obj = self.pool.get('payment.order')
+    pay = pay_obj.browse(cr, uid, ref('payment_order_3'))
+    assert pay.line_ids
+    for line in pay.line_ids:
+        assert line.amount != 0.0
+-
+  I check the remaining amount to pay, it should be 400 (450 - 50)
+-
+  !python {model: payment.order}: |
+    assert self.browse(cr, uid, ref('payment_order_3')).line_ids[0].amount_currency == 400.0
+-
+  I confirm the payment order.
+-
+  !workflow {model: payment.order, action: open, ref: payment_order_3}
+-
+  After making all payments, I finish the payment order.
+-
+  !python {model: payment.order}: |
+    self.set_done(cr, uid, [ref("payment_order_3")])
+-
+  I check the content of the payment
+-
+  !python {model: account.invoice}: |
+    inv = self.browse(cr, uid, ref("account_invoice_supplier2"))
+    assert inv.state == 'paid'
+

--- a/account_payment_pay_invoice/view/account_payment_view.xml
+++ b/account_payment_pay_invoice/view/account_payment_view.xml
@@ -7,10 +7,6 @@
             <field name="inherit_id" ref="account_payment.view_payment_order_form" />
             <field name="arch" type="xml">
                 <data>
-                    <xpath expr="//form[@string='Payment Order']/header/button[@name='set_done']" position="replace">
-                        <button name="set_done" states="open" string="Make Payments" type="object" class="oe_highlight"
-                                confirm="Did you send the BACS file to the bank (accessible from the top button 'More')?"/>
-                    </xpath>
                     <xpath expr="//tree[@string='Payment Line']/field[@name='amount']" position="replace">
                         <field name="amount" sum="Total in Company Currency" invisible="0"/>
                     </xpath>

--- a/account_payment_pay_invoice/view/account_payment_view.xml
+++ b/account_payment_pay_invoice/view/account_payment_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_payment_order_form" model="ir.ui.view">
+            <field name="name">payment.order.form.getlenses</field>
+            <field name="model">payment.order</field>
+            <field name="inherit_id" ref="account_payment.view_payment_order_form" />
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//form[@string='Payment Order']/header/button[@name='set_done']" position="replace">
+                        <button name="set_done" states="open" string="Make Payments" type="object" class="oe_highlight"
+                                confirm="Did you send the BACS file to the bank (accessible from the top button 'More')?"/>
+                    </xpath>
+                    <xpath expr="//tree[@string='Payment Line']/field[@name='amount']" position="replace">
+                        <field name="amount" sum="Total in Company Currency" invisible="0"/>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/account_payment_pay_invoice/wizard/__init__.py
+++ b/account_payment_pay_invoice/wizard/__init__.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import account_payment_order

--- a/account_payment_pay_invoice/wizard/account_payment_order.py
+++ b/account_payment_pay_invoice/wizard/account_payment_order.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Account Payment that pays invoices module for OpenERP
+#    Copyright (C) 2015 VisionDirect (http://www.visiondirect.co.uk)
+#    @author Matthieu Choplin <matthieu.choplin@visiondirect.co.uk>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import osv
+
+
+class payment_order_create(osv.osv_memory):
+    _inherit = 'payment.order.create'
+
+    def filter_lines_ids(self, cr, uid, line_ids):
+        """
+        :param cr: cursor of the database
+        :param uid: user id
+        :param line_ids: account_move_line records
+        :return: updated list of line_ids that we want to pay
+        """
+        line_obj = self.pool.get('account.move.line')
+        updated_line_ids = []
+        payment_line = self.pool.get('payment.line')
+        # we do not want to select the account_move_line that
+        # have already been selected in non canceled payment orders.
+        payment_line_ids = payment_line.search(cr, uid, [])
+        move_line_ids = [
+            line.move_line_id.id
+            for line in payment_line.browse(cr, uid, payment_line_ids)
+            if line.order_id.state != 'cancel'
+            and line.move_line_id.invoice.state == 'paid'
+        ]
+        for line in line_obj.browse(cr, uid, line_ids):
+            if line.id in move_line_ids:
+                continue
+            if not line.statement_id:
+                updated_line_ids.append(line.id)
+        return updated_line_ids
+
+    def search_entries(self, cr, uid, ids, context=None):
+        res = super(
+            payment_order_create, self).search_entries(
+            cr, uid, ids, context
+            )
+        line_ids = res['context']['line_ids']
+        res['context']['line_ids'] = self.filter_lines_ids(cr, uid, line_ids)
+        return res


### PR DESCRIPTION
I had a look at the module https://github.com/OCA/account-payment/tree/8.0/__unported__/account_payment_extension that has not been ported to 7 but this module is working differently.
account_payment_extension was creating a journal entry and doing the reconciliation directly there.
This module is creating the bank statement reconciliation and use the method of Odoo core.

Most of the feature happen in the method process_reconciliation and button_confirm_bank (that I call from the Odoo account_payment module).
