### PR TITLE
[FIX] account_payment_partner: Fix for finding account move lines without invoice (manual entries in receivables/payables)

### DIFF
--- a/account_payment_partner/wizard/payment_order_create.py
+++ b/account_payment_partner/wizard/payment_order_create.py
@@ -30,8 +30,29 @@ class PaymentOrderCreate(models.TransientModel):
     def extend_payment_order_domain(self, payment_order, domain):
         res = super(PaymentOrderCreate, self).extend_payment_order_domain(
             payment_order, domain)
-        domain += ['|', '|',
-                   ('invoice', '=', False),
+        # Monkey patch for fixing problem with the core search function
+        # when args has ('invoice', '=', False), referred in the issue #4857
+        # (https://github.com/odoo/odoo/issues/4857)
+        #
+        # Original domain:
+        # domain += ['|', '|',
+        #            ('invoice', '=', False),
+        #            ('invoice.payment_mode_id', '=', False),
+        #            ('invoice.payment_mode_id', '=', payment_order.mode.id)]
+        self.env.cr.execute(
+            "SELECT l.id "
+            "FROM account_move_line l "
+            "LEFT OUTER JOIN account_invoice i "
+            "ON l.move_id = i.move_id "
+            "INNER JOIN account_account a "
+            "ON a.id = l.account_id "
+            "WHERE i.id IS NULL"
+            "  AND l.reconcile_id IS NULL"
+            "  AND a.type in ('receivable', 'payable')")
+        ids = [x[0] for x in self.env.cr.fetchall()]
+        domain += ['|',
+                   ('id', 'in', ids),
+                   '|',
                    ('invoice.payment_mode_id', '=', False),
                    ('invoice.payment_mode_id', '=', payment_order.mode.id)]
         return res


### PR DESCRIPTION
This is a monkey patch for overriding the problem with the `('invoice', '=', False)` search, that doesn't work well on core. This should be handled as a patch on core, but I think this would be quicker for now, although I will do the corresponding issue.

@alexis-via, this is what you commented me that you didn't get on a past PR. Please review.
