### PR TITLE
Limit lenght of mandate reference, according to ISO 20022

### DIFF
--- a/account_banking_sepa_direct_debit/models/account_banking_mandate.py
+++ b/account_banking_sepa_direct_debit/models/account_banking_mandate.py
@@ -70,12 +70,14 @@ class AccountBankingMandate(models.Model):
              "active.", default=True)
     original_mandate_identification = fields.Char(
         string='Original Mandate Identification', track_visibility='onchange',
+        size=35,
         help="When the field 'Migrated to SEPA' is not active, this field "
              "will be used as the Original Mandate Identification in the "
              "Direct Debit file.")
     scheme = fields.Selection([('CORE', 'Basic (CORE)'),
                                ('B2B', 'Enterprise (B2B)')],
                               string='Scheme', required=True, default="CORE")
+    unique_mandate_reference = fields.Char(size=35)  # cf ISO 20022
 
     @api.one
     @api.constrains('type', 'recurrent_sequence_type')


### PR DESCRIPTION
This limitation of size=35 was configured in the past in my code in account_banking_sepa_direct_debit/account_banking_sdd.py, but it was dropped by mistake later on, cf:

http://bazaar.launchpad.net/~banking-addons-drivers/banking-addons/direct-debit-refactoring-fosdem/view/head:/account_banking_sepa_direct_debit/account_banking_sdd.py
