### PR TITLE
8.0 Add read access on payment.mode to "Employee" group

### DIFF
--- a/account_payment_partner/__openerp__.py
+++ b/account_payment_partner/__openerp__.py
@@ -47,6 +47,7 @@ be filtered per Payment Mode.
     'data': [
         'views/res_partner_view.xml',
         'views/account_invoice_view.xml',
+        'security/ir.model.access.csv',
     ],
     'demo': ['demo/partner_demo.xml'],
     'installable': True,

--- a/account_payment_partner/security/ir.model.access.csv
+++ b/account_payment_partner/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_payment_mode_read,Read access on payment.mode to Employees,account_payment.model_payment_mode,base.group_user,1,0,0,0


### PR DESCRIPTION
With the module account_payment_partner, we add a M2O field to payment.mode on res.partner. But, the only ACL for payment.mode is in the module account_payment and it gives full access to payment.mode to the group "Account Payment". This PR adds read access on payment.mode to the "Employee" group.
