### PR TITLE
Remove deprecated view types

### DIFF
--- a/account_banking/account_banking_view.xml
+++ b/account_banking/account_banking_view.xml
@@ -345,7 +345,6 @@
         <record id="view_account_bank_statement_line_search" model="ir.ui.view">
             <field name="name">account.bank.statement.line.search</field>
             <field name="model">account.bank.statement.line</field>
-            <field name="type">search</field>
             <field name="arch" type="xml">
                 <search string="Search Bank Transactions ">
                     <group>

--- a/account_banking/wizard/link_partner.xml
+++ b/account_banking/wizard/link_partner.xml
@@ -3,7 +3,6 @@
     <data>
         <record model="ir.ui.view" id="link_partner_view">
             <field name="name">Link partner wizard view</field>
-            <field name="type">form</field>
             <field name="model">banking.link_partner</field>
             <field name="arch" type="xml">
                 <form string="Link partner" version="7.0" >

--- a/account_banking_uk_hsbc/account_banking_uk_hsbc.xml
+++ b/account_banking_uk_hsbc/account_banking_uk_hsbc.xml
@@ -16,7 +16,6 @@
         <record id="view_banking_export_hsbc_form" model="ir.ui.view">
             <field name="name">account.banking.export.hsbc.form</field>
             <field name="model">banking.export.hsbc</field>
-            <field name="type">form</field>
             <field name="arch" type="xml">
                 <form string="HSBC Export">
             <notebook>
@@ -48,7 +47,6 @@
         <record id="view_banking_export_hsbc_tree" model="ir.ui.view">
             <field name="name">account.banking.export.hsbc.tree</field>
             <field name="model">banking.export.hsbc</field>
-            <field name="type">tree</field>
             <field name="arch" type="xml">
                 <tree string="HSBC Export">
                     <field name="execution_date" search="2"/>

--- a/account_banking_uk_hsbc/hsbc_clientid_view.xml
+++ b/account_banking_uk_hsbc/hsbc_clientid_view.xml
@@ -6,7 +6,6 @@
     <record id="view_payment_order_form" model="ir.ui.view">
         <field name="name">payment.order.form</field>
         <field name="model">payment.order</field>
-        <field name="type">form</field>
         <field name="inherit_id" ref="account_payment.view_payment_order_form"/>
         <field name="arch" type="xml">
           <field name="date_scheduled" position="after">
@@ -20,7 +19,6 @@
     <record id="banking_hsbc_clientid_form" model="ir.ui.view">
         <field name="name">banking.hsbc.clientid.form</field>
         <field name="model">banking.hsbc.clientid</field>
-        <field name="type">form</field>
         <field name="arch" type="xml">
           <form string="HSBC Client ID">
             <group colspan="4">
@@ -36,7 +34,6 @@
     <record id="banking_hsbc_clientid_tree" model="ir.ui.view">
         <field name="name">banking.hsbc.clientid.tree</field>
         <field name="model">banking.hsbc.clientid</field>
-        <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree string="HSBC Client IDs">
                 <field name="name" />
@@ -50,7 +47,6 @@
     <record id="banking_hsbc_clientid_filter" model="ir.ui.view">
        <field name="name">banking.hsbc.clientid.filter</field>
        <field name="model">banking.hsbc.clientid</field>
-       <field name="type">search</field>
        <field name="arch" type="xml">
            <search string="HSBC Client IDs">
                <field name="name"/>

--- a/account_banking_uk_hsbc/wizard/export_hsbc_view.xml
+++ b/account_banking_uk_hsbc/wizard/export_hsbc_view.xml
@@ -4,7 +4,6 @@
     <record id="wizard_banking_export_wizard_view" model="ir.ui.view">
       <field name="name">banking.export.hsbc.wizard.view</field>
       <field name="model">banking.export.hsbc.wizard</field>
-      <field name="type">form</field>
       <field name="arch" type="xml">
         <form string="HSBC Export">
           <field name="state" invisible="True"/>

--- a/account_direct_debit/view/account_invoice.xml
+++ b/account_direct_debit/view/account_invoice.xml
@@ -25,7 +25,6 @@
         <record id="view_account_invoice_filter" model="ir.ui.view">
             <field name="name">account.invoice.select direct debit</field>
             <field name="model">account.invoice</field>
-            <field name="type">search</field>
             <field name="inherit_id" ref="account.view_account_invoice_filter"/>
             <field name="arch" type="xml">
                 <filter name="invoices" position="after">


### PR DESCRIPTION
Some views still have the deprecated field `type`.
