### PR TITLE
protect import of external dependencies

### DIFF
--- a/__unported__/account_banking_fr_lcr/account_banking_lcr.py
+++ b/__unported__/account_banking_fr_lcr/account_banking_lcr.py
@@ -22,7 +22,11 @@
 
 from openerp.osv import orm, fields
 from openerp.addons.decimal_precision import decimal_precision as dp
-from unidecode import unidecode
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = None
 
 
 class banking_export_lcr(orm.Model):

--- a/__unported__/account_banking_fr_lcr/wizard/export_lcr.py
+++ b/__unported__/account_banking_fr_lcr/wizard/export_lcr.py
@@ -25,8 +25,12 @@ from openerp.tools.translate import _
 from openerp import netsvc
 from datetime import datetime
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
-from unidecode import unidecode
 import base64
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = None
 
 LCR_DATE_FORMAT = '%d%m%y'
 

--- a/account_banking_pain_base/models/banking_export_pain.py
+++ b/account_banking_pain_base/models/banking_export_pain.py
@@ -24,11 +24,16 @@ from openerp.osv import orm
 from openerp.tools.translate import _
 from openerp.tools.safe_eval import safe_eval
 from datetime import datetime
-from unidecode import unidecode
 from lxml import etree
 from openerp import tools
 import logging
 import base64
+
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = None
 
 logger = logging.getLogger(__name__)
 

--- a/account_banking_sepa_credit_transfer/models/account_banking_sepa.py
+++ b/account_banking_sepa_credit_transfer/models/account_banking_sepa.py
@@ -22,7 +22,11 @@
 
 from openerp import models, fields, api
 from openerp.addons.decimal_precision import decimal_precision as dp
-from unidecode import unidecode
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = None
 
 
 class BankingExportSepa(models.Model):

--- a/account_banking_sepa_direct_debit/models/banking_export_sdd.py
+++ b/account_banking_sepa_direct_debit/models/banking_export_sdd.py
@@ -22,7 +22,11 @@
 
 from openerp import models, fields, api
 from openerp.addons.decimal_precision import decimal_precision as dp
-from unidecode import unidecode
+
+try:
+    from unidecode import unidecode
+except ImportError:
+    unidecode = None
 
 
 class BankingExportSdd(models.Model):


### PR DESCRIPTION
closes #148

Odoo won't install an addon if the external dependencies are not met.
However, the python modules of the addons are imported at startup, and the
lack of an external dependency for an external addon will cause a crash,
therefore the import needs to be in a try..except block.
