### PR TITLE
[IMP] pain: do not use InstrPrty for Direct Debit

### DIFF
--- a/account_banking_pain_base/models/banking_export_pain.py
+++ b/account_banking_pain_base/models/banking_export_pain.py
@@ -229,7 +229,7 @@ class BankingExportPain(orm.AbstractModel):
             control_sum_2_5 = etree.SubElement(payment_info_2_0, 'CtrlSum')
         payment_type_info_2_6 = etree.SubElement(
             payment_info_2_0, 'PmtTpInf')
-        if priority:
+        if priority and gen_args['payment_method'] != 'DD':
             instruction_priority_2_7 = etree.SubElement(
                 payment_type_info_2_6, 'InstrPrty')
             instruction_priority_2_7.text = priority


### PR DESCRIPTION
In Luxembourg, InstrPrty is not allowed for Direct Debit [1]. The pain.008 files that we generate are therefore rejected. 

The argument is that this element only makes sense for credit transfer. For what I could gather, this element is ignored in other countries.

Therefore I propose to remove it in the case of direct debit.

Any other suggestion on how to handle this are welcome.

[1] http://www.abbl.lu/download/14692/standard-xml-sdd-initiation-v1.pdf
