### PR TITLE
[8.0][account_banking_payment_export] Add a custom view to select journal items that will added on payment order

### DIFF
--- a/account_banking_payment_export/models/account_move_line.py
+++ b/account_banking_payment_export/models/account_move_line.py
@@ -19,11 +19,30 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp.osv import orm, fields
 
 
 class AccountMoveLine(orm.Model):
     _inherit = 'account.move.line'
+
+    def _get_journal_entry_ref(self, cr, uid, ids, name, args, context=None):
+        res = {}
+        for record in self.browse(cr, uid, ids, context=context):
+            res[record.id] = record.move_id.name
+            if record.move_id.state == 'draft':
+                if record.invoice.id:
+                    res[record.id] = record.invoice.number
+                else:
+                    res[record.id] = '*' + str(record.move_id.id)
+            else:
+                res[record.id] = record.move_id.name
+        return res
+
+    _columns = {
+        'journal_entry_ref': fields.function(_get_journal_entry_ref,
+                                             string='Journal Entry Ref',
+                                             type="char")
+    }
 
     def get_balance(self, cr, uid, ids, context=None):
         """

--- a/account_banking_payment_export/models/account_move_line.py
+++ b/account_banking_payment_export/models/account_move_line.py
@@ -19,32 +19,27 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp import models, fields, api
 
 
-class AccountMoveLine(orm.Model):
+class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    def _get_journal_entry_ref(self, cr, uid, ids, name, args, context=None):
-        res = {}
-        for record in self.browse(cr, uid, ids, context=context):
-            res[record.id] = record.move_id.name
-            if record.move_id.state == 'draft':
-                if record.invoice.id:
-                    res[record.id] = record.invoice.number
-                else:
-                    res[record.id] = '*' + str(record.move_id.id)
+    @api.one
+    def _get_journal_entry_ref(self):
+        if self.move_id.state == 'draft':
+            if self.invoice.id:
+                self.journal_entry_ref = self.invoice.number
             else:
-                res[record.id] = record.move_id.name
-        return res
+                self.journal_entry_ref = '*' + str(self.move_id.id)
+        else:
+            self.journal_entry_ref = self.move_id.name
 
-    _columns = {
-        'journal_entry_ref': fields.function(_get_journal_entry_ref,
-                                             string='Journal Entry Ref',
-                                             type="char")
-    }
+    journal_entry_ref = fields.Char(compute=_get_journal_entry_ref,
+                                    string='Journal Entry Ref')
 
-    def get_balance(self, cr, uid, ids, context=None):
+    @api.multi
+    def get_balance(self):
         """
         Return the balance of any set of move lines.
 
@@ -52,9 +47,6 @@ class AccountMoveLine(orm.Model):
         returns the account balance that the move line applies to.
         """
         total = 0.0
-        if not ids:
-            return total
-        for line in self.read(
-                cr, uid, ids, ['debit', 'credit'], context=context):
-            total += (line['debit'] or 0.0) - (line['credit'] or 0.0)
+        for line in self:
+            total += (line.debit or 0.0) - (line.credit or 0.0)
         return total

--- a/account_banking_payment_export/wizard/payment_order_create.py
+++ b/account_banking_payment_export/wizard/payment_order_create.py
@@ -86,6 +86,22 @@ class PaymentOrderCreate(models.TransientModel):
         to_exclude = set([l.move_line_id.id for l in payment_lines])
         return [l.id for l in lines if l.id not in to_exclude]
 
+    @api.model
+    def display_credit(self):
+        ir_module = self.env['ir.module.module']
+        res = ir_module\
+            .search([('name', '=', 'account_banking_sepa_credit_transfer'),
+                     ('state', '=', 'installed')])
+        return len(res) > 0
+
+    @api.model
+    def display_debit(self):
+        ir_module = self.env['ir.module.module']
+        res = ir_module\
+            .search([('name', '=', 'account_banking_sepa_direct_debit'),
+                     ('state', '=', 'installed')])
+        return len(res) > 0
+
     @api.multi
     def search_entries(self):
         """This method taken from account_payment module.
@@ -109,6 +125,8 @@ class PaymentOrderCreate(models.TransientModel):
         context = self.env.context.copy()
         context['line_ids'] = self.filter_lines(lines)
         context['populate_results'] = self.populate_results
+        context['display_credit'] = self.display_credit()
+        context['display_debit'] = self.display_debit()
         model_datas = model_data_obj.search(
             [('model', '=', 'ir.ui.view'),
              ('name', '=', 'view_create_payment_order_lines')])

--- a/account_banking_payment_export/wizard/payment_order_create.py
+++ b/account_banking_payment_export/wizard/payment_order_create.py
@@ -86,22 +86,6 @@ class PaymentOrderCreate(models.TransientModel):
         to_exclude = set([l.move_line_id.id for l in payment_lines])
         return [l.id for l in lines if l.id not in to_exclude]
 
-    @api.model
-    def display_credit(self):
-        ir_module = self.env['ir.module.module']
-        res = ir_module\
-            .search([('name', '=', 'account_banking_sepa_credit_transfer'),
-                     ('state', '=', 'installed')])
-        return len(res) > 0
-
-    @api.model
-    def display_debit(self):
-        ir_module = self.env['ir.module.module']
-        res = ir_module\
-            .search([('name', '=', 'account_banking_sepa_direct_debit'),
-                     ('state', '=', 'installed')])
-        return len(res) > 0
-
     @api.multi
     def search_entries(self):
         """This method taken from account_payment module.
@@ -125,8 +109,12 @@ class PaymentOrderCreate(models.TransientModel):
         context = self.env.context.copy()
         context['line_ids'] = self.filter_lines(lines)
         context['populate_results'] = self.populate_results
-        context['display_credit'] = self.display_credit()
-        context['display_debit'] = self.display_debit()
+        if payment.payment_order_type == 'payment':
+            context['display_credit'] = True
+            context['display_debit'] = False
+        else:
+            context['display_credit'] = False
+            context['display_debit'] = True
         model_datas = model_data_obj.search(
             [('model', '=', 'ir.ui.view'),
              ('name', '=', 'view_create_payment_order_lines')])

--- a/account_banking_payment_export/wizard/payment_order_create_view.xml
+++ b/account_banking_payment_export/wizard/payment_order_create_view.xml
@@ -24,11 +24,35 @@
             <field name="inherit_id" ref="account_payment.view_create_payment_order_lines"/>
             <field name="arch" type="xml">
                 <field name="entries" position="attributes">
-                    <attribute name="context">{'journal_type': 'sale'}</attribute>
+                    <attribute name="context">{'display_credit': context.get('display_credit', False),'display_debit': context.get('display_debit', False),'journal_type': 'sale', 'tree_view_ref' : 'account_banking_payment_export.payment_order_populate_view_move_line_tree'}</attribute>
                     <attribute name="nolabel">1</attribute>
                 </field>
             </field>
         </record>
+
+        <record id="payment_order_populate_view_move_line_tree" model="ir.ui.view">
+            <field name="name">payment.order.populate.account.move.line.tree</field>
+            <field name="model">account.move.line</field>
+            <field name="arch" type="xml">
+                <tree string="Journal Items">
+                    <field name="journal_id" />
+                    <field name="date"/>
+                    <field name="name"/>
+                    <field name="ref"/>
+                    <field name="partner_id" />
+                    <field name="account_id" />
+                    <field name="journal_entry_ref" string="Journal Entry" />
+                    <field name="debit" sum="Total Debit" invisible="not context.get('display_debit', False)"/>
+                    <field name="credit" sum="Total Credit" invisible="not context.get('display_credit', False)"/>
+                    <field name="amount_residual" />
+                    <field name="date_maturity" invisible="context.get('journal_type', False) not in ['sale','sale_refund','purchase','purchase_refund']" />
+                    <field name="reconcile_ref"/>
+                    <field name="amount_currency" invisible="not context.get('currency',False)"/>
+                    <field name="currency_id" invisible="not context.get('currency',False)" />
+                </tree>
+            </field>
+        </record>
+        
 
     </data>
 </openerp>


### PR DESCRIPTION
- Add a custom journal items view based on an analysis of several production system
- Display credit and debit considering payment mode's type
- Create a new journal entry ref field which will contain the number of the related invoice if it exist and if the state of the releted move is draft. Otherwise, it will contain the name of the related journal entry.
