### PR TITLE
[FIX] Change computation of bank-name for IBAN.

### DIFF
--- a/account_banking/__openerp__.py
+++ b/account_banking/__openerp__.py
@@ -23,7 +23,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
 {
     'name': 'Account Banking',
     'version': '0.5',
@@ -37,6 +36,7 @@
     'data': [
         'security/ir.model.access.csv',
         'data/account_banking_data.xml',
+        'data/iban_simple_name.xml',
         'wizard/bank_import_view.xml',
         'account_banking_view.xml',
         'wizard/banking_transaction_wizard.xml',

--- a/account_banking/data/iban_simple_name.xml
+++ b/account_banking/data/iban_simple_name.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- Simplify template for IBAN bank name. Bank itself is part of IBAN
+            and BIC is no longer required.
+            Function write trick to handle noupdate. -->
+        <function model="res.partner.bank.type" name="write">
+            <value eval="[ref('base_iban.bank_iban')]" />
+            <value eval="{'format_layout': 'IBAN %(acc_number)s'}" />
+        </function>
+
+    </data>
+</openerp>
+


### PR DESCRIPTION
BIC is no longer required. And the string 'BANK' in the name of a bank account seems rather superfluous. This merge updates the formatting of IBAN bank name to make it shorter and simpler.
