### PR TITLE
[FIX] tests.common.DB was removed from 8.0 stable

### DIFF
--- a/account_payment_blocking/tests/test_account_banking_payment_blocking.py
+++ b/account_payment_blocking/tests/test_account_banking_payment_blocking.py
@@ -23,9 +23,6 @@
 import openerp.tests.common as common
 from openerp import workflow
 
-DB = common.DB
-ADMIN_USER_ID = common.ADMIN_USER_ID
-
 
 def create_simple_invoice(self, cr, uid, context=None):
     partner_id = self.ref('base.res_partner_2')


### PR DESCRIPTION
See https://github.com/odoo/odoo/commit/2df9060d97a201c2f54c6d79af13ffca45f91cef
