### PR TITLE
[8.0] Improvements for account_banking_payment_transfer

### DIFF
--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -215,11 +215,11 @@ class PaymentOrder(models.Model):
         # on the payment line and call reconciliation on it
         line.write({'transit_move_line_id': partner_move_line.id})
 
+    @api.model
     def _reconcile_payment_lines(self, payment_lines):
-        pl_obj = self.env['payment.line']
         for line in payment_lines:
             if line.move_line_id:
-                pl_obj.debit_reconcile(line.id)
+                line.debit_reconcile()
             else:
                 self.action_sent_no_move_line_hook(line)
 

--- a/account_banking_payment_transfer/model/payment_line.py
+++ b/account_banking_payment_transfer/model/payment_line.py
@@ -154,10 +154,6 @@ class PaymentLine(orm.Model):
                 transit_move_line.name
             )
 
-        def is_zero(total):
-            return self.pool.get('res.currency').is_zero(
-                cr, uid, transit_move_line.company_id.currency_id, total)
-
         line_ids = [transit_move_line.id, torec_move_line.id]
         move_line_obj.reconcile_partial(cr, uid, line_ids, type='manual',
                                         context=context)

--- a/account_banking_payment_transfer/model/payment_line.py
+++ b/account_banking_payment_transfer/model/payment_line.py
@@ -155,7 +155,7 @@ class PaymentLine(orm.Model):
             )
 
         line_ids = [transit_move_line.id, torec_move_line.id]
-        move_line_obj.reconcile_partial(cr, uid, line_ids, type='manual',
+        move_line_obj.reconcile_partial(cr, uid, line_ids, type='auto',
                                         context=context)
 
         # If a bank transaction of a storno was first confirmed

--- a/account_banking_payment_transfer/model/payment_line.py
+++ b/account_banking_payment_transfer/model/payment_line.py
@@ -158,10 +158,6 @@ class PaymentLine(orm.Model):
         move_line_obj.reconcile_partial(cr, uid, line_ids, type='manual',
                                         context=context)
 
-        for line_id in line_ids:
-            workflow.trg_trigger(
-                uid, 'account.move.line', line_id, cr)
-
         # If a bank transaction of a storno was first confirmed
         # and now canceled (the invoice is now in state 'debit_denied'
         if torec_move_line.invoice:

--- a/account_banking_payment_transfer/model/payment_line.py
+++ b/account_banking_payment_transfer/model/payment_line.py
@@ -24,7 +24,7 @@
 ##############################################################################
 
 from openerp.osv import orm, fields
-from openerp import workflow
+from openerp import workflow, api
 from openerp.tools.translate import _
 
 
@@ -116,6 +116,7 @@ class PaymentLine(orm.Model):
 
         return False
 
+    @api.cr_uid_id_context
     def debit_reconcile(self, cr, uid, payment_line_id, context=None):
         """
         Reconcile a debit order's payment line with the the move line


### PR DESCRIPTION
- Create a function for partners move line creation
- Remove the use of `self` in `@api.model` decoreted method
- Use standard reconcile method
