### PR TITLE
[8.0][account_banking_payment_transfer] Avoid to post the created move if entry_posted on the journal isn't true

### DIFF
--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -260,8 +260,10 @@ class PaymentOrder(models.Model):
                     total_amount, move, lines, labels)
                 aml_obj.create(trf_ml_vals)
 
-                # post account move
-                move.post()
+                # consider entry_posted on account_journal
+                if move.journal_id.entry_posted:
+                    # post account move
+                    move.post()
 
         # State field is written by act_sent_wait
         self.write({'date_sent': fields.Date.context_today(self)})


### PR DESCRIPTION
Avoid to post the created move if `entry_posted` on the journal isn't true
