### PR TITLE
[IMP] account_banking_payment_transfer: Use payment line date as the maturity date for the new move

### DIFF
--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -154,10 +154,12 @@ class PaymentOrder(models.Model):
             partner_id = payment_lines[0].partner_id.id
             name = _('%s line %s') % (
                 labels[self.payment_order_type], payment_lines[0].name)
+            date_maturity = payment_lines[0].date
         else:
             partner_id = False
             name = '%s %s' % (
                 labels[self.payment_order_type], self.reference)
+            date_maturity = False
         vals = {
             'name': name,
             'move_id': move.id,
@@ -167,7 +169,8 @@ class PaymentOrder(models.Model):
                        amount or 0.0),
             'debit': (self.payment_order_type == 'debit' and
                       amount or 0.0),
-            }
+            'date_maturity': date_maturity,
+        }
         return vals
 
     @api.model

--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -154,12 +154,11 @@ class PaymentOrder(models.Model):
             partner_id = payment_lines[0].partner_id.id
             name = _('%s line %s') % (
                 labels[self.payment_order_type], payment_lines[0].name)
-            date_maturity = payment_lines[0].date
         else:
             partner_id = False
             name = '%s %s' % (
                 labels[self.payment_order_type], self.reference)
-            date_maturity = False
+        date_maturity = payment_lines[0].date
         vals = {
             'name': name,
             'move_id': move.id,


### PR DESCRIPTION
In a chain of payment orders with transfer accounts, new maturity date should be the previous "payment" date.
