### PR TITLE
[FIX] account_banking_payment_transfer: Use selection_add for state overwrite

### DIFF
--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -61,13 +61,9 @@ class PaymentOrder(models.Model):
         'rejected': [('readonly', True)],
         'done': [('readonly', True)],
         })
-    state = fields.Selection([
-        ('draft', 'Draft'),
-        ('open', 'Confirmed'),
-        ('cancel', 'Cancelled'),
+    state = fields.Selection(selection_add=[
         ('sent', 'Sent'),
         ('rejected', 'Rejected'),
-        ('done', 'Done'),
         ], string='State')
     line_ids = fields.One2many(states={
         'open': [('readonly', True)],


### PR DESCRIPTION
Use `selection_add` for state overwrite in `payment.order`
