### PR TITLE
[ADD] account_payment_cancel

### DIFF
--- a/account_payment_cancel/README.rst
+++ b/account_payment_cancel/README.rst
@@ -19,19 +19,6 @@ Configuration
 
 There is nothing to configure.
 
-Usage
-=====
-
-You are able to add a payment mode directly on a partner.
-This payment mode is automatically associated to the purchase order, then on related invoice.
-This default value could be change in a draft purchase or draft invoice.
-When you create an payment order, only invoices related to chosen payment mode are displayed.
-Invoices without any payment mode are displayed to.
-
-
-For further information, please visit:
-
- * https://www.odoo.com/forum/help-1
 
 Known issues / Roadmap
 ======================

--- a/account_payment_cancel/README.rst
+++ b/account_payment_cancel/README.rst
@@ -1,0 +1,68 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Account Payment Purchase
+========================
+
+This module allow cancel payment orders in done state if lines don't have account move reconciled.
+
+Installation
+============
+
+This module depends on :
+- account_payment
+
+This module is part of the OCA/bank-payment suite.
+
+Configuration
+=============
+
+There is nothing to configure.
+
+Usage
+=====
+
+You are able to add a payment mode directly on a partner.
+This payment mode is automatically associated to the purchase order, then on related invoice.
+This default value could be change in a draft purchase or draft invoice.
+When you create an payment order, only invoices related to chosen payment mode are displayed.
+Invoices without any payment mode are displayed to.
+
+
+For further information, please visit:
+
+ * https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+ * No known issues.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/bank-payment/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/bank-payment/issues/new?body=module:%20account_payment_purchase%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Roberto Lizana <robertolizana@trey.es>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_payment_cancel/README.rst
+++ b/account_payment_cancel/README.rst
@@ -4,7 +4,7 @@
 Account Payment Purchase
 ========================
 
-This module allow cancel payment orders in done state if lines don't have account move reconciled.
+This module allows cancel payment orders in done state if lines don't have account move reconciled.
 
 Installation
 ============

--- a/account_payment_cancel/__init__.py
+++ b/account_payment_cancel/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+# Copyright 2015 Roberto Lizana
+# For license notices, see __openerp__.py file in root directory
+###############################################################################
+from . import models

--- a/account_payment_cancel/__openerp__.py
+++ b/account_payment_cancel/__openerp__.py
@@ -23,9 +23,10 @@
     'category': 'Accounting & Finance',
     'summary': 'Allow cancel payment order',
     'version': '0.1',
-    'description': '''
-    ''',
-    'author': 'Trey Kilobytes de Soluciones (www.trey.es)',
+    'license': 'AGPL-3',
+    'author': 'Trey Kilobytes de Soluciones - Roberto Lizana (www.trey.es), '
+              'Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/bank-payment',
     'depends': [
         'account_payment',
     ],

--- a/account_payment_cancel/__openerp__.py
+++ b/account_payment_cancel/__openerp__.py
@@ -2,7 +2,7 @@
 ###############################################################################
 #
 #    Trey, Kilobytes de Soluciones
-#    Copyright (C) 2014-Today Trey, Kilobytes de Soluciones <www.trey.es>
+#    Copyright (C) 2015-Today Trey, Kilobytes de Soluciones <www.trey.es>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -24,7 +24,7 @@
     'summary': 'Allow cancel payment order',
     'version': '0.1',
     'license': 'AGPL-3',
-    'author': 'Trey Kilobytes de Soluciones - Roberto Lizana (www.trey.es), '
+    'author': 'Trey Kilobytes de Soluciones, '
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/bank-payment',
     'depends': [

--- a/account_payment_cancel/__openerp__.py
+++ b/account_payment_cancel/__openerp__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#    Trey, Kilobytes de Soluciones
+#    Copyright (C) 2014-Today Trey, Kilobytes de Soluciones <www.trey.es>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+{
+    'name': 'Payment Cancel',
+    'category': 'Accounting & Finance',
+    'summary': 'Allow cancel payment order',
+    'version': '0.1',
+    'description': '''
+    ''',
+    'author': 'Trey Kilobytes de Soluciones (www.trey.es)',
+    'depends': [
+        'account_payment',
+    ],
+    'data': [
+        'workflows/payment_workflow.xml',
+        'views/payment_view.xml'
+    ],
+    'installable': True,
+}

--- a/account_payment_cancel/i18n/account_payment_cancel.po
+++ b/account_payment_cancel/i18n/account_payment_cancel.po
@@ -1,0 +1,30 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_payment_cancel
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-12 07:09+0000\n"
+"PO-Revision-Date: 2015-07-12 07:09+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_cancel
+#: view:payment.order:account_payment_cancel.view_payment_order_cancel_form
+msgid "Cancel Payments"
+msgstr ""
+
+#. module: account_payment_cancel
+#: code:addons/account_payment_cancel/models/payment.py:21
+#, python-format
+msgid "You cannot cancel, the next lines has already been reconciled: \n"
+"%s\n"
+""
+msgstr ""
+

--- a/account_payment_cancel/i18n/es.po
+++ b/account_payment_cancel/i18n/es.po
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_payment_cancel
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-12 07:09+0000\n"
+"PO-Revision-Date: 2015-07-12 09:14+0100\n"
+"Last-Translator: Roberto Lizana <robertolizana@trey.es>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: account_payment_cancel
+#: view:payment.order:account_payment_cancel.view_payment_order_cancel_form
+msgid "Cancel Payments"
+msgstr "Cancelar Pagos"
+
+#. module: account_payment_cancel
+#: code:addons/account_payment_cancel/models/payment.py:21
+#, python-format
+msgid ""
+"You cannot cancel, the next lines has already been reconciled: \n"
+"%s\n"
+msgstr ""
+"No se puede cancelar, las siguientes líneas ya han sido conciliadas:\n"
+"%s\n"

--- a/account_payment_cancel/models/__init__.py
+++ b/account_payment_cancel/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+# Copyright 2015 Roberto Lizana
+# For license notices, see __openerp__.py file in root directory
+###############################################################################
+from . import payment

--- a/account_payment_cancel/models/payment.py
+++ b/account_payment_cancel/models/payment.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+###############################################################################
+# Copyright 2015 Roberto Lizana
+# For license notices, see __openerp__.py file in root directory
+###############################################################################
+from openerp import models, api, exceptions, _
+
+
+class PaymentOrder(models.Model):
+    _inherit = 'payment.order'
+
+    @api.one
+    def action_cancel(self):
+        lines = [
+            '%s - %s' % (l.communication, l.partner_id.display_name)
+            for l in self.line_ids
+            if l.move_line_id.reconcile_id
+            or l.move_line_id.reconcile_partial_id]
+        if lines:
+            raise exceptions.Warning(
+                _('You cannot cancel, the next lines has already been '
+                  'reconciled: \n%s\n') % '\n'.join(lines))

--- a/account_payment_cancel/views/payment_view.xml
+++ b/account_payment_cancel/views/payment_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <!-- [FORM] account.payment -->
+         <record id="view_payment_order_cancel_form" model="ir.ui.view">
+            <field name="name">account_payment_cancel_form</field>
+            <field name="model">payment.order</field>
+            <field name="inherit_id" ref="account_payment.view_payment_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//header/field[@name='state']" position="before">
+                    <button name="cancel" states="done" string="Cancel Payments"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/account_payment_cancel/workflows/payment_workflow.xml
+++ b/account_payment_cancel/workflows/payment_workflow.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!--Activity -->
+        <record id="account_payment.act_cancel" model="workflow.activity">
+            <field name="action">action_cancel()
+write({'state':'cancel'})</field>
+        </record>
+
+        <record id="account_payment.act_done" model="workflow.activity">
+            <field name="flow_stop" eval="False"/>
+        </record>
+
+        <!-- Transition -->
+        <record id="trans_draft_open" model="workflow.transition">
+            <field name="act_from" ref="account_payment.act_done"/>
+            <field name="act_to" ref="account_payment.act_cancel"/>
+            <field name="signal">cancel</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This module allow cancel payment orders in `done` state if lines don't have account move reconciled.
