### PR TITLE
[ADD] German pain.001.003.03 format

### DIFF
--- a/account_banking_sepa_credit_transfer/README.rst
+++ b/account_banking_sepa_credit_transfer/README.rst
@@ -17,6 +17,10 @@ European Payments Council (http://http://www.europeanpaymentscouncil.eu) use
 PAIN version 001.001.03, so it's probably the version of PAIN that you should
 try first.
 
+It also includes pain.001.003.03 which is used in Germany instead of 001.001.03.
+You can read more about this here (only in german language):
+http://www.ebics.de/startseite/
+
 Installation
 ============
 

--- a/account_banking_sepa_credit_transfer/data/pain.001.003.03.xsd
+++ b/account_banking_sepa_credit_transfer/data/pain.001.003.03.xsd
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Version gemäß DFÜ-Abkommen Anlage 3, Version 2.7, gültig ab November 2013 mit Umsetzung von IBAN Only gemäß EPC SCT 7.0, zudem Erweiterung Service Level auf Externe Codeliste-->
+<!-- Mit XMLSpy v2008 am 29.11.2012 von der SIZ GmbH bearbeitet -->
+<xs:schema xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03" elementFormDefault="qualified">
+	<xs:element name="Document" type="Document"/>
+	<xs:complexType name="AccountIdentificationSEPA">
+		<xs:sequence>
+			<xs:element name="IBAN" type="IBAN2007Identifier"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyAndAmount_SimpleTypeSEPA">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0.01"/>
+			<xs:maxInclusive value="999999999.99"/>
+			<xs:fractionDigits value="2"/>
+			<xs:totalDigits value="11"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{3,3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ActiveOrHistoricCurrencyAndAmountSEPA">
+		<xs:simpleContent>
+			<xs:extension base="ActiveOrHistoricCurrencyAndAmount_SimpleTypeSEPA">
+				<xs:attribute name="Ccy" type="ActiveOrHistoricCurrencyCodeEUR" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCodeEUR">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EUR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AmountTypeSEPA">
+		<xs:sequence>
+			<xs:element name="InstdAmt" type="ActiveOrHistoricCurrencyAndAmountSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="AnyBICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BatchBookingIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentificationSEPA3">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentificationSEPA3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccountSEPA1">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentificationSEPA"/>
+			<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccountSEPA2">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentificationSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurposeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ChargeBearerTypeSEPACode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SLEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CreditTransferTransactionInformationSCT">
+		<xs:sequence>
+			<xs:element name="PmtId" type="PaymentIdentificationSEPA"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformationSCT2" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If used, it is recommended to be used at ‘Payment Information’ level and not at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Amt" type="AmountTypeSEPA"/>
+			<xs:element name="ChrgBr" type="ChargeBearerTypeSEPACode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>It is recommended that this element be specified at ‘Payment Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UltmtDbtr" type="PartyIdentificationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This data element may be present either at ‘Payment Information’ or at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="Cdtr" type="PartyIdentificationSEPA2"/>
+			<xs:element name="CdtrAcct" type="CashAccountSEPA2"/>
+			<xs:element name="UltmtCdtr" type="PartyIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="Purp" type="PurposeSEPA" minOccurs="0"/>
+			<xs:element name="RmtInf" type="RemittanceInformationSEPA1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceInformationSEPA1">
+		<xs:sequence>
+			<xs:element name="Tp" type="CreditorReferenceTypeSEPA"/>
+			<xs:element name="Ref" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>If a Creditor Reference contains a check digit, the receiving bank is not required to validate this.
+If the receiving bank validates the check digit and if this validation fails, the bank may continue its processing and send the transaction to the next party in the chain.
+RF Creditor Reference may be used (ISO 11649).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceTypeSEPA">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="CreditorReferenceTypeCodeSEPA"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceTypeCodeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="DocumentType3CodeSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV03">
+		<xs:sequence>
+			<xs:element name="GrpHdr" type="GroupHeaderSCT"/>
+			<xs:element name="PmtInf" type="PaymentInstructionInformationSCT" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DateAndPlaceOfBirth">
+		<xs:sequence>
+			<xs:element name="BirthDt" type="ISODate"/>
+			<xs:element name="PrvcOfBirth" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CityOfBirth" type="Max35Text"/>
+			<xs:element name="CtryOfBirth" type="CountryCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DecimalNumber">
+		<xs:restriction base="xs:decimal">
+			<xs:fractionDigits value="17"/>
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Document">
+		<xs:sequence>
+			<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV03"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DocumentType3CodeSEPA">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SCOR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCategoryPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalOrganisationIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPersonIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalServiceLevel1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FinancialInstitutionIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="BIC" type="BICIdentifier"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentificationSEPA3">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="BIC" type="BICIdentifier"/>
+				<xs:element name="Othr" type="OthrIdentification"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OthrIdentification">
+		<xs:sequence>
+			<xs:element name="Id" type="OthrIdentificationCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="OthrIdentificationCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NOTPROVIDED"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="GenericOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="OrganisationIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeaderSCT">
+		<xs:sequence>
+			<xs:element name="MsgId" type="RestrictedIdentificationSEPA1"/>
+			<xs:element name="CreDtTm" type="ISODateTime"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="InitgPty" type="PartyIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="IBAN2007Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ISODate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="ISODateTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="Max140Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="140"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max15NumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max70Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="70"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="OrganisationIdentificationSEPAChoice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="BICOrBEI" type="AnyBICIdentifier"/>
+				<xs:element name="Othr" type="GenericOrganisationIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalOrganisationIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartySEPAChoice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="OrgId" type="OrganisationIdentificationSEPAChoice">
+					<xs:annotation>
+						<xs:documentation>Either ‘BIC or BEI’ or one
+occurrence of ‘Other’ is allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="PrvtId" type="PersonIdentificationSEPA1Choice">
+					<xs:annotation>
+						<xs:documentation>Either ‘Date and Place of Birth’ or one occurrence of ‘Other’ is allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>‘Name’ is limited to 70 characters
+in length.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Id" type="PartySEPAChoice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentificationSEPA2">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text">
+				<xs:annotation>
+					<xs:documentation>‘Name’ is limited to 70 characters
+in length.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PstlAdr" type="PostalAddressSEPA" minOccurs="0"/>
+			<xs:element name="Id" type="PartySEPAChoice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentificationSEPA">
+		<xs:sequence>
+			<xs:element name="InstrId" type="RestrictedIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="EndToEndId" type="RestrictedIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstructionInformationSCT">
+		<xs:sequence>
+			<xs:element name="PmtInfId" type="RestrictedIdentificationSEPA1"/>
+			<xs:element name="PmtMtd" type="PaymentMethodSCTCode">
+				<xs:annotation>
+					<xs:documentation>Only ‘TRF’ is allowed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If present and contains ‘true’, batch booking is requested. If present and contains ‘false’, booking per transaction is requested. If element is not present, pre-agreed customer-to-bank conditions apply.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformationSCT1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If used, it is recommended to be used only at ‘Payment Information’ level and not at Credit Transfer Transaction Information’ level.
+When Instruction Priority is to be used, ‘Payment Type Information’ must be present at ‘Payment Information’ level. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ReqdExctnDt" type="ISODate"/>
+			<xs:element name="Dbtr" type="PartyIdentificationSEPA2"/>
+			<xs:element name="DbtrAcct" type="CashAccountSEPA1"/>
+			<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentificationSEPA3"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentificationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This data element may be present either at ‘Payment Information’ or at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChrgBr" type="ChargeBearerTypeSEPACode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>It is recommended that this element be specified at ‘Payment Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtTrfTxInf" type="CreditTransferTransactionInformationSCT" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="PaymentMethodSCTCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TRF"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PaymentTypeInformationSCT1">
+		<xs:sequence>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If present, pre-agreed customer-to-bank conditions apply.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SvcLvl" type="ServiceLevelSEPA"/>
+			<xs:element name="CtgyPurp" type="CategoryPurposeSEPA" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Depending on the agreement between the Originator and the Originator Bank, ‘Category Purpose’ may be forwarded to the Beneficiary Bank.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformationSCT2">
+		<xs:sequence>
+			<xs:element name="SvcLvl" type="ServiceLevelSEPA"/>
+			<xs:element name="CtgyPurp" type="CategoryPurposeSEPA" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Depending on the agreement between the Originator and the Originator Bank, ‘Category Purpose’ may be forwarded to the Beneficiary Bank.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSEPA1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth"/>
+				<xs:element name="Othr" type="GenericPersonIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalPersonIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PostalAddressSEPA">
+		<xs:sequence>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Priority2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HIGH"/>
+			<xs:enumeration value="NORM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PurposeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalPurpose1Code">
+				<xs:annotation>
+					<xs:documentation>Only codes from the ISO 20022 ExternalPurposeCode list are allowed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformationSEPA1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Ustrd" type="Max140Text"/>
+				<xs:element name="Strd" type="StructuredRemittanceInformationSEPA1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceLevelSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalServiceLevel1Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformationSEPA1">
+		<xs:sequence>
+			<xs:element name="CdtrRefInf" type="CreditorReferenceInformationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When present, the receiving bank is not obliged to validate the the reference information. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RestrictedIdentificationSEPA1">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="([A-Za-z0-9]|[\+|\?|/|\-|:|\(|\)|\.|,|'| ]){1,35}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/account_banking_sepa_credit_transfer/data/payment_type_sepa_sct.xml
+++ b/account_banking_sepa_credit_transfer/data/payment_type_sepa_sct.xml
@@ -40,6 +40,14 @@
     <field name="ir_model_id" ref="model_banking_export_sepa_wizard"/>
 </record>
 
+<record id="export_sepa_sct_001_003_03" model="payment.mode.type">
+    <field name="name">SEPA Credit Transfer pain 001.003.03 (only for Germany)</field>
+    <field name="code">pain.001.003.03</field>
+    <field name="payment_order_type">payment</field>
+    <field name="suitable_bank_types"
+       eval="[(6,0,[ref('base_iban.bank_iban')])]" />
+    <field name="ir_model_id" ref="model_banking_export_sepa_wizard"/>
+</record>
 
 </data>
 </openerp>

--- a/account_banking_sepa_credit_transfer/data/payment_type_sepa_sct.xml
+++ b/account_banking_sepa_credit_transfer/data/payment_type_sepa_sct.xml
@@ -41,7 +41,7 @@
 </record>
 
 <record id="export_sepa_sct_001_003_03" model="payment.mode.type">
-    <field name="name">SEPA Credit Transfer pain 001.003.03 (only for Germany)</field>
+    <field name="name">SEPA Credit Transfer pain 001.003.03 (used in Germany)</field>
     <field name="code">pain.001.003.03</field>
     <field name="payment_order_type">payment</field>
     <field name="suitable_bank_types"

--- a/account_banking_sepa_credit_transfer/wizard/export_sepa.py
+++ b/account_banking_sepa_credit_transfer/wizard/export_sepa.py
@@ -104,12 +104,20 @@ class BankingExportSepaWizard(models.TransientModel):
             bic_xml_tag = 'BICFI'
             name_maxsize = 140
             root_xml_tag = 'CstmrCdtTrfInitn'
+        # added pain.001.003.03 for German Banks
+        # it is not in the offical ISO 20022 documentations, but nearly all
+        # german banks are working with this instead 001.001.03
+        elif pain_flavor == 'pain.001.003.03':
+            bic_xml_tag = 'BIC'
+            name_maxsize = 70
+            root_xml_tag = 'CstmrCdtTrfInitn'
         else:
             raise Warning(
                 _("Payment Type Code '%s' is not supported. The only "
                   "Payment Type Codes supported for SEPA Credit Transfers "
                   "are 'pain.001.001.02', 'pain.001.001.03', "
-                  "'pain.001.001.04' and 'pain.001.001.05'.") %
+                  "'pain.001.001.04', 'pain.001.001.05'"
+                  " and 'pain.001.003.03'.") %
                 pain_flavor)
         gen_args = {
             'bic_xml_tag': bic_xml_tag,
@@ -128,8 +136,12 @@ class BankingExportSepaWizard(models.TransientModel):
         }
         xml_root = etree.Element('Document', nsmap=pain_ns)
         pain_root = etree.SubElement(xml_root, root_xml_tag)
-        pain_03_to_05 = \
-            ['pain.001.001.03', 'pain.001.001.04', 'pain.001.001.05']
+        pain_03_to_05 = [
+            'pain.001.001.03',
+            'pain.001.001.04',
+            'pain.001.001.05',
+            'pain.001.003.03'
+        ]
         # A. Group header
         group_header_1_0, nb_of_transactions_1_6, control_sum_1_7 = \
             self.generate_group_header_block(pain_root, gen_args)


### PR DESCRIPTION
However, in Germany we don't use pain.001.001.03 for SEPA-credit-files.
Our banks decided to use an other standard (pain.001.003.03) which is not described in the ISO 20022. But the needed XML-File is exactly the same as for pain.001.001.03.

To use this module in Germany I added this format.
More informations about the german standards here (only in german):
http://www.ebics.de/
http://www.die-deutsche-kreditwirtschaft.de/uploads/media/SRZ-Richtlinien_2015.pdf

If there are questions, please don't hesitate to ask.
Thanks, Mathias
