### PR TITLE
[FIX] multicompany

### DIFF
--- a/account_import_line_multicurrency_extension/models/bank_statement.py
+++ b/account_import_line_multicurrency_extension/models/bank_statement.py
@@ -26,7 +26,8 @@ class AccountBankStatementLine(models.Model):
 
     currency_symbol = fields.Char(
         string='Journal Currency',
-        related='statement_id.currency.symbol', readonly=True)
+        related='statement_id.currency.symbol',
+        related_sudo=False, readonly=True)
 
 
 class AccountBankStatement(models.Model):


### PR DESCRIPTION
field related use sudo when they are called, so in multi-company,it will take the company currency of the user with id 1 that may differ
from the current user, so I replace the field related
by a field function that called the original _currency function to
keep the context
