### PR TITLE
[8.0][IMP] Adapt the filter selecting invoices to pay

### DIFF
--- a/account_banking_payment_export/wizard/payment_order_create.py
+++ b/account_banking_payment_export/wizard/payment_order_create.py
@@ -69,12 +69,9 @@ class PaymentOrderCreate(models.TransientModel):
             in the payment order.
 
         This implementation filters out move lines that are already
-        included in draft or open payment orders. This prevents the
+        included in non-cancelled payment orders. This prevents the
         user to include the same line in two different open payment
-        orders. When the payment order is sent, it is assumed that
-        the move will be reconciled soon (or immediately with
-        account_banking_payment_transfer), so it will not be
-        proposed anymore for payment.
+        orders.
 
         See also https://github.com/OCA/bank-payment/issues/93.
 

--- a/account_banking_payment_export/wizard/payment_order_create.py
+++ b/account_banking_payment_export/wizard/payment_order_create.py
@@ -83,7 +83,7 @@ class PaymentOrderCreate(models.TransientModel):
         """
         self.ensure_one()
         payment_lines = self.env['payment.line'].\
-            search([('order_id.state', 'in', ('draft', 'open')),
+            search([('order_id.state', '!=', 'cancel'),
                     ('move_line_id', 'in', lines.ids)])
         to_exclude = set([l.move_line_id.id for l in payment_lines])
         return [l.id for l in lines if l.id not in to_exclude]


### PR DESCRIPTION
**Filter as well invoices that are present in a confirmed payment_order** : in our use case, we don't immediately reconcile invoices after having them collected in a payment_order. I think it is not wrong to avoid the ability to collect them in another order before they are reconciled.
