### PR TITLE
[FIX] account_banking_payment_export: Correct communication type for customer invoices in payment lines

### DIFF
--- a/account_banking_payment_export/__openerp__.py
+++ b/account_banking_payment_export/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Account Banking - Payments Export Infrastructure',
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.3.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_banking_payment_export/models/account_invoice.py
+++ b/account_banking_payment_export/models/account_invoice.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import api, models, _
+from lxml import etree
 
 
 class AccountInvoice(models.Model):
@@ -14,3 +15,34 @@ class AccountInvoice(models.Model):
         rt = super(AccountInvoice, self)._get_reference_type()
         rt.append(('structured', _('Structured Reference')))
         return rt
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type=False, toolbar=False,
+                        submenu=False):
+        """This adds the field 'reference_type' only if the view doesn't
+        contain this field (this is for customer invoice and with
+        l10n_be_invoice_bba not installed).
+        """
+        res = super(AccountInvoice, self).fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar,
+            submenu=submenu)
+        if view_type != 'form':
+            return res
+        field_name = 'reference_type'
+        doc = etree.XML(res['arch'])
+        if not doc.xpath("//field[@name='%s']" % field_name):
+            nodes = doc.xpath("//field[@name='origin']")
+            if nodes:
+                field = self.fields_get([field_name])[field_name]
+                field_xml = etree.Element(
+                    'field', {'name': field_name,
+                              'widget': 'selection',
+                              'states': str(field['states']),
+                              'selection': str(field['selection']),
+                              'required': '1' if field['required'] else '0',
+                              'string': field['string'],
+                              'nolabel': '0'})
+                nodes[0].addnext(field_xml)
+                res['arch'] = etree.tostring(doc)
+                res['fields'][field_name] = field
+        return res


### PR DESCRIPTION
In current version of _account_banking_payment_export_, all customer invoices are imported in payment orders with communication type = structured, and the invoice number is used for the communication, but this kind of communication follows ISO, which requires to have an specific format, and invoice number may not have the required format, so this default value is very dangerous.

In this PR, what I do is to show the selection to decide if you want to use the structured communication at invoice level, and take this into consideration importing customer invoice lines into the payment order.

I have also bumped the version number.
