### PR TITLE
[ADD] bump version, migrate total column

### DIFF
--- a/account_banking_payment_export/__openerp__.py
+++ b/account_banking_payment_export/__openerp__.py
@@ -24,7 +24,7 @@
 
 {
     'name': 'Account Banking - Payments Export Infrastructure',
-    'version': '0.1.165',
+    'version': '8.0.0.1.166',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_banking_payment_export/migrations/8.0.0.1.166/pre-migrate.py
+++ b/account_banking_payment_export/migrations/8.0.0.1.166/pre-migrate.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+def migrate(cr, version):
+    cr.execute('alter table payment_order add column total numeric')
+    cr.execute(
+        'update payment_order '
+        'set total=totals.total '
+        'from '
+        '(select order_id, sum(amount_currency) total '
+        'from payment_line group by order_id) totals '
+        'where payment_order.id=totals.order_id')


### PR DESCRIPTION
#216 will cause trouble when your workflow on payment orders contains functions defined in not yet loaded modules - `account_banking_payment_transfer` is a candidate for that. Then computing the field will fail because the workflow conditions can't be evaluated.

This migration writes the wrong value in multicurrency situations, but works fine otherwise
