### PR TITLE
[FIX] account_banking_payment_export: Use residual amount in direct debits

### DIFF
--- a/account_banking_payment_export/wizard/payment_order_create.py
+++ b/account_banking_payment_export/wizard/payment_order_create.py
@@ -171,12 +171,7 @@ class PaymentOrderCreate(models.TransientModel):
                 # customer invoice number (in the case of debit order)
                 communication = line.invoice.number.replace('/', '')
                 state = 'structured'
-        # support debit orders when enabled
-        if (payment.payment_order_type == 'debit' and
-                'amount_to_receive' in line):
-            amount_currency = line.amount_to_receive
-        else:
-            amount_currency = line.amount_residual_currency
+        amount_currency = line.amount_residual_currency
         line2bank = line.line2bank(payment.mode.id)
         # -- end account banking
         res = {'move_line_id': line.id,


### PR DESCRIPTION
When making direct debit orders, the amount taken for the order is the total of the move line, not the residual one, leading to possible invoices over-debited. This is due to the rely on _amount_to_receive_ field, which doesn't take into account the residual value, but the full one (https://github.com/OCA/bank-payment/blob/8.0/account_direct_debit/models/account_move_line.py#L39). 

This patch solves this in a fast way by using the same amount_residual_currency for both lines. Later, I plan to fix the `amount_to_receive` compute method so that we can rely on it, but this is a bigger patch that maybe will be done for v9.
