### PR TITLE
[ADD] account_payment_transfer_reconcile_batch

### DIFF
--- a/account_payment_transfer_reconcile_batch/README.rst
+++ b/account_payment_transfer_reconcile_batch/README.rst
@@ -1,0 +1,88 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License AGPL-3
+
+=================================================================
+Batch reconciliation for transfer lines created in payment orders
+=================================================================
+
+This module allows to process with the connector technology the heavy task of
+reconciliation of the receivable/payable journal entries of a payment order
+against the created entries in transfer accounts.
+
+This approach provides many advantages, similar to the ones we get
+using that connector for e-commerce:
+
+- Asynchronous: the operation is done in background, and users can
+  continue to work.
+- Dedicated workers: the queued jobs are performed by specific workers
+  (processes). This is good for a long task, since the main workers are
+  busy handling HTTP requests and can be killed if operations take
+  too long, for example.
+- Multiple transactions: this is an operation that doesn't need to be
+  atomic, and if a line out of 100,000 fails, it is possible to catch
+  it, see the error message, and fix the situation. Meanwhile, all
+  other jobs can proceed.
+
+Inspired on *account_move_batch_validate* module from Camptocamp and ACSONE.
+
+Installation
+============
+
+This module requires the connector module, hosted on
+`OCA/connector <https://github.com/OCA/connector>`_
+
+Configuration
+=============
+
+This will only work for payment modes that have a transfer account set.
+
+Usage
+=====
+
+When exporting the payment order, click on *Validate* to generate the transfer
+move. One connector job will be created for each payment line for a deferred
+conciliation of this line.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/173/8.0
+
+Known issues / Roadmap
+======================
+
+* Add tests.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/bank-payment/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/
+bank-payment/issues/new?body=module:%20
+account_payment_transfer_reconcile_batch%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_payment_transfer_reconcile_batch/README.rst
+++ b/account_payment_transfer_reconcile_batch/README.rst
@@ -29,7 +29,7 @@ Inspired on *account_move_batch_validate* module from Camptocamp and ACSONE.
 Installation
 ============
 
-This module requires the connector module, hosted on
+This module requires the *connector* module, hosted on
 `OCA/connector <https://github.com/OCA/connector>`_
 
 Configuration
@@ -48,21 +48,13 @@ conciliation of this line.
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/173/8.0
 
-Known issues / Roadmap
-======================
-
-* Add tests.
-
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/bank-payment/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/
-bank-payment/issues/new?body=module:%20
-account_payment_transfer_reconcile_batch%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/bank-payment/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
@@ -70,12 +62,12 @@ Credits
 Contributors
 ------------
 
-* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
    :target: http://odoo-community.org
 
@@ -85,4 +77,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_payment_transfer_reconcile_batch/__init__.py
+++ b/account_payment_transfer_reconcile_batch/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/account_payment_transfer_reconcile_batch/__init__.py
+++ b/account_payment_transfer_reconcile_batch/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# © 2015-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models

--- a/account_payment_transfer_reconcile_batch/__init__.py
+++ b/account_payment_transfer_reconcile_batch/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models
+from . import wizard

--- a/account_payment_transfer_reconcile_batch/__init__.py
+++ b/account_payment_transfer_reconcile_batch/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models

--- a/account_payment_transfer_reconcile_batch/__openerp__.py
+++ b/account_payment_transfer_reconcile_batch/__openerp__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
     'name': "Batch Reconciliation for transfer moves",
     'version': '8.0.1.0.0',
-    'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+    'author': "Tecnativa, "
               "Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'category': 'Accounting & Finance',
@@ -13,7 +13,7 @@
         'account_banking_payment_transfer',
         'connector',
     ],
-    'website': 'http://www.serviciosbaeza.com',
+    'website': 'https://www.tecnativa.com',
     'data': [
     ],
     'installable': True,

--- a/account_payment_transfer_reconcile_batch/__openerp__.py
+++ b/account_payment_transfer_reconcile_batch/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    'name': "Batch Reconciliation for transfer moves",
+    'version': '8.0.1.0.0',
+    'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
+    'category': 'Accounting & Finance',
+    'depends': [
+        'account_banking_payment_transfer',
+        'connector',
+    ],
+    'website': 'http://www.serviciosbaeza.com',
+    'data': [
+    ],
+    'installable': True,
+}

--- a/account_payment_transfer_reconcile_batch/__openerp__.py
+++ b/account_payment_transfer_reconcile_batch/__openerp__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {

--- a/account_payment_transfer_reconcile_batch/models/__init__.py
+++ b/account_payment_transfer_reconcile_batch/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import payment_order

--- a/account_payment_transfer_reconcile_batch/models/__init__.py
+++ b/account_payment_transfer_reconcile_batch/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import payment_order

--- a/account_payment_transfer_reconcile_batch/models/payment_order.py
+++ b/account_payment_transfer_reconcile_batch/models/payment_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import logging
@@ -25,7 +25,9 @@ class PaymentOrder(models.Model):
 
     @api.multi
     def _reconcile_payment_lines(self, bank_payment_lines):
-        if config['test_enable'] or self.env.context.get('no_connector'):
+        test_condition = (config['test_enable'] and
+                          not self.env.context.get('test_connector'))
+        if test_condition or self.env.context.get('no_connector'):
             return super(PaymentOrder, self)._reconcile_payment_lines(
                 bank_payment_lines)
         session = ConnectorSession.from_env(self.env)

--- a/account_payment_transfer_reconcile_batch/models/payment_order.py
+++ b/account_payment_transfer_reconcile_batch/models/payment_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 import logging

--- a/account_payment_transfer_reconcile_batch/models/payment_order.py
+++ b/account_payment_transfer_reconcile_batch/models/payment_order.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import logging
+from openerp import models, api, _
+from openerp.tools import config
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openerp.addons.connector.queue.job import job
+    from openerp.addons.connector.session import ConnectorSession
+except ImportError:
+    _logger.debug('Can not `import connector`.')
+    import functools
+
+    def empty_decorator_factory(*argv, **kwargs):
+        return functools.partial
+    job = empty_decorator_factory
+
+
+class PaymentOrder(models.Model):
+    _inherit = 'payment.order'
+
+    @api.multi
+    def _reconcile_payment_lines(self, payment_lines):
+        if config['test_enable']:
+            return super(PaymentOrder, self)._reconcile_payment_lines(
+                payment_lines)
+        session = ConnectorSession(
+            self.env.cr, self.env.uid, context=self.env.context)
+        for line in payment_lines:
+            if line.move_line_id:
+                reconcile_one_move.delay(
+                    session, 'payment.line', line.id)
+            else:
+                self.action_sent_no_move_line_hook(line)
+
+
+@job(default_channel='root.account_payment_transfer_reconcile_batch')
+def reconcile_one_move(session, model_name, payment_line_id):
+    payment_line_pool = session.pool[model_name]
+    if payment_line_pool.exists(session.cr, session.uid, payment_line_id):
+        payment_line_pool.debit_reconcile(
+            session.cr, session.uid, [payment_line_id])
+    else:
+        return _(u'Nothing to do because the record has been deleted')

--- a/account_payment_transfer_reconcile_batch/tests/__init__.py
+++ b/account_payment_transfer_reconcile_batch/tests/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from . import payment_order_create
+from . import test_account_payment_transfer_reconcile_batch

--- a/account_payment_transfer_reconcile_batch/tests/test_account_payment_transfer_reconcile_batch.py
+++ b/account_payment_transfer_reconcile_batch/tests/test_account_payment_transfer_reconcile_batch.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp.tests import common
+
+
+class TestAccountPaymentTransferReconcileBatch(common.TransactionCase):
+    def setUp(self):
+        super(TestAccountPaymentTransferReconcileBatch, self).setUp()
+        self.journal = self.env['account.journal'].create({
+            'name': 'Test journal',
+            'type': 'general',
+            'code': 'TEST',
+        })
+        self.bank_account = self.env['res.partner.bank'].create({
+            'state': 'bank',
+            'acc_number': 'TEST',
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test partner',
+            'supplier': True,
+        })
+        self.mode = self.env['payment.mode'].create({
+            'name': 'Test payment mode',
+            'journal': self.journal.id,
+            'bank_id': self.bank_account.id,
+            'transfer_journal_id': self.journal.id,
+            'transfer_account_id': self.partner.property_account_payable.id,
+            'type': self.env.ref(
+                'account_banking_payment_export.manual_bank_tranfer').id,
+        })
+        self.product = self.env['product.product'].create({
+            'name': 'Test product',
+        })
+        self.invoice = self.env['account.invoice'].create({
+            'type': 'in_invoice',
+            'partner_id': self.partner.id,
+            'account_id': self.partner.property_account_payable.id,
+            'invoice_line': [
+                (0, 0, {
+                    'product_id': self.product.id,
+                    'name': self.product.name,
+                    'price_unit': 20,
+                }),
+            ]
+        })
+        self.invoice.signal_workflow('invoice_open')
+        self.payment_order = self.env['payment.order'].create({
+            'mode': self.mode.id,
+        })
+        line = self.invoice.move_id.line_id.filtered(
+            lambda x: x.account_id == self.invoice.account_id)
+        wizard = self.env['payment.order.create'].with_context(
+            active_model='payment.order', active_id=self.payment_order.id
+        ).create({})
+        line_vals = wizard._prepare_payment_line(self.payment_order, line)
+        self.payment_line = self.env['payment.line'].create(line_vals)
+
+    def test_enqueue(self):
+        self.payment_order.signal_workflow('open')
+        self.payment_order.action_open()
+        self.payment_order.with_context(test_connector=True).action_sent()
+        func = "openerp.addons.account_payment_transfer_reconcile_batch." \
+               "models.payment_order.reconcile_one_move('bank.payment.line', "
+        job = self.env['queue.job'].sudo().search(
+            [('func_string', 'like', "%s%%" % func)])
+        self.assertTrue(job)

--- a/account_payment_transfer_reconcile_batch/wizard/__init__.py
+++ b/account_payment_transfer_reconcile_batch/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import payment_order_create

--- a/account_payment_transfer_reconcile_batch/wizard/payment_order_create.py
+++ b/account_payment_transfer_reconcile_batch/wizard/payment_order_create.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models
+
+
+class PaymentOrderCreate(models.TransientModel):
+    _inherit = 'payment.order.create'
+
+    @api.multi
+    def filter_lines(self, lines):
+        """Filter move lines before proposing them for inclusion in the payment
+        order (inherited). This one removes the move lines that aren't still
+        being processed in the connector queue.
+
+        :param lines: recordset of move lines
+        :returns: list of move line ids
+        """
+        filtered_line_ids = super(PaymentOrderCreate, self).filter_lines(lines)
+        func = "openerp.addons.account_payment_transfer_reconcile_batch." \
+               "models.payment_order.reconcile_one_move('bank.payment.line', "
+        jobs = self.env['queue.job'].sudo().search(
+            [('func_string', 'like', "%s%%" % func), ('state', '!=', 'done')])
+        if not jobs:
+            return filtered_line_ids
+        pline_ids = jobs.mapped(lambda x: int(x.func_string[len(func):-1]))
+        # With this, we remove non existing records
+        plines = self.env['bank.payment.line'].search(
+            [('id', 'in', pline_ids)])
+        to_exclude = plines.mapped('payment_line_ids.move_line_id')
+        return [line_id for line_id in filtered_line_ids if
+                line_id not in to_exclude.ids]

--- a/account_payment_transfer_reconcile_batch/wizard/payment_order_create.py
+++ b/account_payment_transfer_reconcile_batch/wizard/payment_order_create.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import api, models

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+connector


### PR DESCRIPTION
# 
# Batch reconciliation for transfer lines created in payment orders

This module allows to process with the connector technology the heavy task of
reconciliation of the receivable/payable journal entries of a payment order
against the created entries in transfer accounts.

This approach provides many advantages, similar to the ones we get
using that connector for e-commerce:
- Asynchronous: the operation is done in background, and users can
  continue to work.
- Dedicated workers: the queued jobs are performed by specific workers
  (processes). This is good for a long task, since the main workers are
  busy handling HTTP requests and can be killed if operations take
  too long, for example.
- Multiple transactions: this is an operation that doesn't need to be
  atomic, and if a line out of 100,000 fails, it is possible to catch
  it, see the error message, and fix the situation. Meanwhile, all
  other jobs can proceed.

Inspired on _account_move_batch_validate_ module from Camptocamp and ACSONE.
# Installation

This module requires the connector module, hosted on
`OCA/connector <https://github.com/OCA/connector>`_
# Configuration

This will only work for payment modes that have a transfer account set.
# Usage

When exporting the payment order, click on _Validate_ to generate the transfer
move. One connector job will be created for each payment line for a deferred
conciliation of this line.
