### PR TITLE
[FIX] Backport 8.0 improvements in ING mt940 parsing.

### DIFF
--- a/account_banking_nl_ing_mt940/__openerp__.py
+++ b/account_banking_nl_ing_mt940/__openerp__.py
@@ -11,11 +11,12 @@
 This addon imports the structured MT940 format as offered by the Dutch ING
 bank.
     """,
-    "category": "Account Banking",
-    "depends": [
+    'category': 'Account Banking',
+    'depends': [
         'account_banking_mt940',
     ],
-    "auto_install": False,
-    "installable": True,
-    "application": False,
+    'images': [],  # Satisfy travis
+    'auto_install': False,
+    'installable': True,
+    'application': False,
 }

--- a/account_banking_nl_ing_mt940/account_banking_nl_ing_mt940.py
+++ b/account_banking_nl_ing_mt940/account_banking_nl_ing_mt940.py
@@ -22,8 +22,10 @@ class IngMT940Parser(MT940, parser):
     code = 'INT_MT940_STRUC'
 
     tag_61_regex = re.compile(
-        r'^(?P<date>\d{6})(?P<sign>[CD])(?P<amount>\d+,\d{2})N(?P<type>.{3})'
-        r'(?P<reference>\w{1,16})')
+        r'^(?P<date>\d{6})(?P<line_date>\d{0,4})'
+        r'(?P<sign>[CD])(?P<amount>\d+,\d{2})N(?P<type>.{3})'
+        r'(?P<reference>\w{1,50})'
+    )
 
     def create_transaction(self, cr):
         return transaction()
@@ -41,7 +43,10 @@ class IngMT940Parser(MT940, parser):
 
     def handle_tag_61(self, cr, data):
         super(IngMT940Parser, self).handle_tag_61(cr, data)
-        parsed_data = self.tag_61_regex.match(data).groupdict()
+        re_61 = self.tag_61_regex.match(data)
+        if not re_61:
+            raise ValueError("Cannot parse %s" % data)
+        parsed_data = re_61.groupdict()
         self.current_transaction.transferred_amount = \
             (-1 if parsed_data['sign'] == 'D' else 1) * str2float(
                 parsed_data['amount'])


### PR DESCRIPTION
Date format of record 61 in ing mt940 structured changed.

Solution was already present in 8.0.
