### PR TITLE
[FIX] account_payment_mode_term new api compatibility

### DIFF
--- a/account_payment_mode_term/__openerp__.py
+++ b/account_payment_mode_term/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': 'Account Banking - Payments Term Filter',
-    'version': '8.0.0.1.1',
+    'version': '8.0.0.1.2',
     'license': 'AGPL-3',
     'author': "Banking addons community,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/banking',

--- a/account_payment_mode_term/models/payment_order_create.py
+++ b/account_payment_mode_term/models/payment_order_create.py
@@ -24,16 +24,16 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp import api, models
 
 
-class payment_order_create(orm.TransientModel):
+class payment_order_create(models.TransientModel):
     _inherit = 'payment.order.create'
 
-    def extend_payment_order_domain(
-            self, cr, uid, ids, payment_order, domain, context=None):
+    @api.multi
+    def extend_payment_order_domain(self, payment_order, domain):
         super(payment_order_create, self).extend_payment_order_domain(
-            cr, uid, ids, payment_order, domain, context=context)
+            payment_order, domain)
         # apply payment term filter
         if payment_order.mode.payment_term_ids:
             domain += [


### PR DESCRIPTION
Without this patch we have `TypeError: extend_payment_order_domain() takes exactly 3 arguments (2 given)` when adding an invoice to a payment order.
