### PR TITLE
account_payment_blocking : migrate payment order create to new api

### DIFF
--- a/account_payment_blocking/model/payment_order_create.py
+++ b/account_payment_blocking/model/payment_order_create.py
@@ -20,15 +20,16 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp import api, models
 
 
-class payment_order_create(orm.TransientModel):
+class payment_order_create(models.TransientModel):
     _inherit = 'payment.order.create'
 
+    @api.multi
     def extend_payment_order_domain(
-            self, cr, uid, ids, payment_order, domain, context=None):
+            self, payment_order, domain):
         super(payment_order_create, self).extend_payment_order_domain(
-            cr, uid, ids, payment_order, domain, context=context)
+            payment_order, domain)
         domain += [('blocked', '!=', True)]
         return True

--- a/account_payment_blocking/model/payment_order_create.py
+++ b/account_payment_blocking/model/payment_order_create.py
@@ -29,7 +29,7 @@ class PaymentOrderCreate(models.TransientModel):
     @api.multi
     def extend_payment_order_domain(
             self, payment_order, domain):
-        super(payment_order_create, self).extend_payment_order_domain(
+        super(PaymentOrderCreate, self).extend_payment_order_domain(
             payment_order, domain)
         domain += [('blocked', '!=', True)]
         return True

--- a/account_payment_blocking/model/payment_order_create.py
+++ b/account_payment_blocking/model/payment_order_create.py
@@ -23,7 +23,7 @@
 from openerp import api, models
 
 
-class payment_order_create(models.TransientModel):
+class PaymentOrderCreate(models.TransientModel):
     _inherit = 'payment.order.create'
 
     @api.multi


### PR DESCRIPTION
When I try to import invoice in my payment order I get the following  error message :

```
Traceback (most recent call last):
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 537, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 574, in dispatch
    result = self._call_function(**self.params)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 310, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 307, in checked_call
    return self.endpoint(*a, **kw)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 803, in __call__
    return self.method(*args, **kw)
  File "/home/lga/project/openerp/parts/odoo/openerp/http.py", line 403, in response_wrap
    response = f(*args, **kw)
  File "/home/lga/project/openerp/parts/odoo/addons/web/controllers/main.py", line 948, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/lga/project/openerp/parts/odoo/addons/web/controllers/main.py", line 936, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 256, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 387, in old_api
    result = method(recs, *args, **kwargs)
  File "/home/lga/project/openerp/addons-bank-payment/account_cash_discount_payment/wizard/account_payment_create.py", line 88, in search_entries
    return super(PaymentOrderCreate, self.with_context(ctx))\
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 254, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/addons-bank-payment/account_banking_payment_export/wizard/payment_order_create.py", line 108, in search_entries
    self.extend_payment_order_domain(payment, domain)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 254, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/addons-bank-payment/account_payment_include_draft_move/wizard/payment_order_create.py", line 37, in extend_payment_order_domain
    .extend_payment_order_domain(payment_order, domain)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 254, in wrapper
    return new_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 580, in new_api
    result = method(self._model, cr, uid, self.ids, *args, **old_kwargs)
  File "/home/lga/project/openerp/addons-bank-payment/account_payment_blocking/model/payment_order_create.py", line 32, in extend_payment_order_domain
    cr, uid, ids, payment_order, domain, context=context)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 256, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 359, in old_api
    recs = self.browse(cr, uid, [], context)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 256, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/lga/project/openerp/parts/odoo/openerp/models.py", line 5266, in browse
    return self._browse(Environment(cr, uid, context or {}), ids)
  File "/home/lga/project/openerp/parts/odoo/openerp/api.py", line 747, in __new__
    self.cr, self.uid, self.context = self.args = (cr, uid, frozendict(context))
ValueError: dictionary update sequence element #0 has length 3; 2 is required
```
