### PR TITLE
[FIX] account_payment_*: Ensure work with dropshipping dual invoice

### DIFF
--- a/account_payment_purchase/models/stock_picking.py
+++ b/account_payment_purchase/models/stock_picking.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Account Payment Purchase module for OpenERP
@@ -28,11 +28,13 @@ class StockPicking(models.Model):
 
     @api.model
     def _create_invoice_from_picking(self, picking, vals):
-        if picking and picking.move_lines:
+        # This will assure that stock_dropshipping_dual_invoice will work
+        inv_type = self.env.context.get('inv_type', 'in_invoice')
+        if picking and picking.move_lines and inv_type == 'in_invoice':
             # Get purchase order from first move line
             if picking.move_lines[0].purchase_line_id:
                 purchase = picking.move_lines[0].purchase_line_id.order_id
                 vals['partner_bank_id'] = purchase.supplier_partner_bank_id.id
                 vals['payment_mode_id'] = purchase.payment_mode_id.id
-        return super(StockPicking, self)._create_invoice_from_picking(picking,
-                                                                      vals)
+        return super(StockPicking, self)._create_invoice_from_picking(
+            picking, vals)

--- a/account_payment_sale_stock/models/stock_picking.py
+++ b/account_payment_sale_stock/models/stock_picking.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -24,10 +24,12 @@ class StockPicking(models.Model):
 
     @api.model
     def _create_invoice_from_picking(self, picking, vals):
-        if picking and picking.sale_id:
+        # This will assure that stock_dropshipping_dual_invoice will work
+        inv_type = self.env.context.get('inv_type', 'out_invoice')
+        if picking and picking.sale_id and inv_type == 'out_invoice':
             sale_order = picking.sale_id
             if sale_order.payment_mode_id:
                 vals['partner_bank_id'] = sale_order.payment_mode_id.bank_id.id
                 vals['payment_mode_id'] = sale_order.payment_mode_id.id
-        return super(StockPicking, self)._create_invoice_from_picking(picking,
-                                                                      vals)
+        return super(StockPicking, self)._create_invoice_from_picking(
+            picking, vals)


### PR DESCRIPTION
When invoicing from dropshipping, the same picking serves for both invoicing sale and purchase orders. The OCA module _stock_dropshipping_dual_invoice_ makes that this happens, but as the picking is the same, it contains both the sale and the purchase reference, making that the resulting invoices don't have
the correct payment mode. This is harmless for the rest of operations, as the dictionary query is provided with the proper default value. On v9, dropshipping dual invoice has been merged into core, so this patch for sure will be welcome in that version (if the used method is the same).
