### PR TITLE
[8.0][FIX][account_banking_mandate] Allow to select bank account when creating a mandate

### DIFF
--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -32,8 +32,7 @@
                 <group name="main">
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="partner_bank_id"
-                        invisible="context.get('mandate_bank_partner_view')"
-                        domain="[('partner_id', '=', partner_id)]" />
+                        invisible="context.get('mandate_bank_partner_view')" />
                     <field name="partner_id"
                         invisible="context.get('mandate_bank_partner_view')"
                         readonly="True"/>


### PR DESCRIPTION
Remove domain `[('partner_id', '=', partner_id)]` in `partner_bank_id` field, in order to be able to select a bank account when creating. Then on_change selects partner_id related with that bank account.  
