### PR TITLE
 Mandates multicompany error #242

### DIFF
--- a/account_banking_mandate/security/mandate_security.xml
+++ b/account_banking_mandate/security/mandate_security.xml
@@ -13,6 +13,10 @@
     <field name="name">Banking Mandate multi-company</field>
     <field name="model_id" ref="model_account_banking_mandate"/>
     <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    <field name="perm_read" eval="True"/>
+    <field name="perm_write" eval="False"/>
+    <field name="perm_unlink" eval="True"/>
+    <field name="perm_create" eval="True"/>
 </record>
 
 </data>


### PR DESCRIPTION
The restriction rule Banking Mandate multi-company, gives an error when editing a partner bank account from a company A when that account has created a mandate from another company B. So it is impossible to create a mandate for each company without disabling the rule.
Solution: Uncheck the rule writte in Banking Mandate multi-company. But i'm not sure this is correct.
