### PR TITLE
[IMP] account_banking_payment_export: Add option for not grouping lines

### DIFF
--- a/account_banking_payment_export/__openerp__.py
+++ b/account_banking_payment_export/__openerp__.py
@@ -2,12 +2,12 @@
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<http://therp.nl>)
 # © 2013-2014 ACSONE SA (<http://acsone.eu>).
-# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2014-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Banking - Payments Export Infrastructure',
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.3.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_banking_payment_export/i18n/es.po
+++ b/account_banking_payment_export/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-18 08:37+0000\n"
-"PO-Revision-Date: 2016-02-18 08:37+0000\n"
+"POT-Creation-Date: 2016-02-25 17:56+0000\n"
+"PO-Revision-Date: 2016-02-25 17:56+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,6 +29,7 @@ msgid "Active"
 msgstr "Activo"
 
 #. module: account_banking_payment_export
+#: field:bank.payment.line,amount_currency:0
 #: view:payment.order:account_banking_payment_export.view_payment_order_form
 msgid "Amount"
 msgstr "Importe"
@@ -123,7 +124,7 @@ msgid "Entry Information"
 msgstr "Información del asiento"
 
 #. module: account_banking_payment_export
-#: code:addons/account_banking_payment_export/wizard/payment_order_create.py:149
+#: code:addons/account_banking_payment_export/wizard/payment_order_create.py:152
 #, python-format
 msgid "Entry Lines"
 msgstr "Líneas de pago"
@@ -145,11 +146,33 @@ msgid "General Information"
 msgstr "Información General"
 
 #. module: account_banking_payment_export
+#: field:payment.mode,group_lines:0
+msgid "Group lines in payment orders"
+msgstr "Agrupar líneas en las órdenes de pago"
+
+#. module: account_banking_payment_export
 #: field:bank.payment.line,id:0
 #: field:payment.manual,id:0
 #: field:payment.mode.type,id:0
 msgid "ID"
 msgstr "ID"
+
+#. module: account_banking_payment_export
+#: help:payment.mode,group_lines:0
+msgid "If this mark is checked, the payment order lines will be grouped when validating the payment order before exporting the bank file. The grouping will be done only if the following fields matches:\n"
+"* Partner\n"
+"* Currency\n"
+"* Destination Bank Account\n"
+"* Communication Type (structured, free)\n"
+"* Payment Date\n"
+"(other modules can set additional fields to restrict the grouping.)"
+msgstr "Si esta casilla está marcada, las líneas de las órdenes de pago serán agrupadas cuando se valide la orden de pago antes de la exportación al archivo bancario. La agrupación se realizará sólo si los siguientes campos casan:\n"
+"* Empresa\n"
+"* Moneda\n"
+"* Cuenta bancaria destino\n"
+"* Tipo de comunicacion (estructurada, libre)\n"
+"* Fecha de pago\n"
+"(otros módulo pueden establecer campos adicionales para restringir la agrupación.)"
 
 #. module: account_banking_payment_export
 #: view:payment.order:account_banking_payment_export.view_payment_order_form
@@ -196,6 +219,11 @@ msgstr "Última actualización por"
 #: field:payment.mode.type,write_date:0
 msgid "Last Updated on"
 msgstr "Última actualización en"
+
+#. module: account_banking_payment_export
+#: view:payment.mode:account_banking_payment_export.view_payment_mode_form_inherit
+msgid "Line grouping"
+msgstr "Agrupación de líneas"
 
 #. module: account_banking_payment_export
 #: field:payment.mode,default_invoice:0
@@ -297,7 +325,7 @@ msgid "Payment Order Export"
 msgstr "Exportación de la orden de pago"
 
 #. module: account_banking_payment_export
-#: code:addons/account_banking_payment_export/wizard/payment_order_create.py:243
+#: code:addons/account_banking_payment_export/wizard/payment_order_create.py:246
 #, python-format
 msgid "Payment Orders"
 msgstr "Órdenes de pago"
@@ -342,7 +370,7 @@ msgstr "Líneas de pago relacionadas"
 #. module: account_banking_payment_export
 #: view:payment.mode:account_banking_payment_export.view_payment_mode_form_inherit
 msgid "Select Move Lines to Pay - Default Values"
-msgstr "Seleccione los apuntes a pagar - Valores por defecto"
+msgstr "Selección de los apuntes - Valores por defecto"
 
 #. module: account_banking_payment_export
 #: help:payment.mode,type:0
@@ -387,7 +415,7 @@ msgid "Suitable bank types"
 msgstr "Tipos de cuentas bancarias adecuadas"
 
 #. module: account_banking_payment_export
-#: code:addons/account_banking_payment_export/models/account_payment.py:146
+#: code:addons/account_banking_payment_export/models/account_payment.py:151
 #, python-format
 msgid "The amount for Partner '%s' is negative or null (%.2f) !"
 msgstr "El importe para el empresa '%s' es negativo o nulo (%.2f) !"

--- a/account_banking_payment_export/models/account_payment.py
+++ b/account_banking_payment_export/models/account_payment.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<http://therp.nl>)
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api, exceptions, workflow, _
@@ -129,7 +130,12 @@ class PaymentOrder(models.Model):
                     requested_date = today
                 # Write requested_date on 'date' field of payment line
                 payline.date = requested_date
-                hashcode = payline.payment_line_hashcode()
+                # Group options
+                if order.mode.group_lines:
+                    hashcode = payline.payment_line_hashcode()
+                else:
+                    # Use line ID as hascode, which actually means no grouping
+                    hashcode = payline.id
                 if hashcode in group_paylines:
                     group_paylines[hashcode]['paylines'] += payline
                     group_paylines[hashcode]['total'] +=\
@@ -138,7 +144,7 @@ class PaymentOrder(models.Model):
                     group_paylines[hashcode] = {
                         'paylines': payline,
                         'total': payline.amount_currency,
-                        }
+                    }
             # Create bank payment lines
             for paydict in group_paylines.values():
                 # Block if a bank payment line is <= 0

--- a/account_banking_payment_export/models/payment_mode.py
+++ b/account_banking_payment_export/models/payment_mode.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<http://therp.nl>)
-# © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2014-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api, SUPERUSER_ID
@@ -91,6 +91,19 @@ class PaymentMode(models.Model):
         ], default='due', string="Type of Date Filter")
     default_populate_results = fields.Boolean(
         string='Populate Results Directly')
+    group_lines = fields.Boolean(
+        string="Group lines in payment orders", default=True,
+        help="If this mark is checked, the payment order lines will be "
+             "grouped when validating the payment order before exporting the "
+             "bank file. The grouping will be done only if the following "
+             "fields matches:\n"
+             "* Partner\n"
+             "* Currency\n"
+             "* Destination Bank Account\n"
+             "* Communication Type (structured, free)\n"
+             "* Payment Date\n"
+             "(other modules can set additional fields to restrict the "
+             "grouping.)")
 
     @api.onchange('type')
     def type_on_change(self):

--- a/account_banking_payment_export/views/payment_mode.xml
+++ b/account_banking_payment_export/views/payment_mode.xml
@@ -23,6 +23,9 @@
                         <field name="default_invoice"/>
                         <field name="default_date_type"/>
                     </group>
+                    <group name="group_grouping" string="Line grouping">
+                        <field name="group_lines"/>
+                    </group>
                     <group string="Note" col="4">
                         <field name="note" nolabel="1"/>
                     </group>


### PR DESCRIPTION
There can be multiple reasons for not grouping payment lines:
- The customer needs each payment line individually for matching references.
- For avoiding the risk of returning a big amount.
- For not overpassing amout limits.
- ...

So with this PR, you have the possibility of selecting at payment mode level if you want to group or not
