### PR TITLE
8.0 FIX selection of mandate when invoice is linked to a contact

### DIFF
--- a/account_banking_mandate/views/account_invoice_view.xml
+++ b/account_banking_mandate/views/account_invoice_view.xml
@@ -13,7 +13,8 @@
     <field name="inherit_id" ref="account.invoice_form"/>
     <field name="arch" type="xml">
         <field name="partner_bank_id" position="after">
-            <field name="mandate_id" domain="[('partner_id', '=', partner_id), ('state', '=', 'valid')]" attrs="{'invisible': [('type', '=', 'out_refund')]}"/>
+            <field name="commercial_partner_id" invisible="1"/>
+            <field name="mandate_id" domain="[('partner_id', '=', commercial_partner_id), ('state', '=', 'valid')]" attrs="{'invisible': [('type', '=', 'out_refund')]}"/>
         </field>
     </field>
 </record>


### PR DESCRIPTION
The mandate is linked to a bank account, which itself is linked to a "parent" partner.

But, if partner_id on invoice is a contact (parent_id != False), you cannot select the mandate of the parent contact. This PR fixes this.
