### PR TITLE
[FIX][account_payment_blocking] In some cases, there isn't only one ine on receivable/payable account on journal entry genereted from invoice.

### DIFF
--- a/account_payment_blocking/model/account_invoice.py
+++ b/account_payment_blocking/model/account_invoice.py
@@ -41,7 +41,6 @@ class account_invoice(orm.Model):
         if invoice.move_id.id:
             move_line_ids = self._get_move_line(cr, uid, invoice.id,
                                                 context=context)
-            assert len(move_line_ids) == 1
             # work with account_constraints from OCA/AFT:
             context.update({'from_parent_object': True})
             self.pool.get('account.move.line')\
@@ -74,10 +73,10 @@ class account_invoice(orm.Model):
             if invoice.move_id.id:
                 move_line_ids = self._get_move_line(cr, uid, invoice.id,
                                                     context=context)
-                assert len(move_line_ids) == 1
-                move_line = self.pool.get('account.move.line')\
-                    .browse(cr, uid, move_line_ids, context=context)[0]
-                res[invoice.id] = move_line.blocked
+                move_lines = self.pool.get('account.move.line')\
+                    .browse(cr, uid, move_line_ids, context=context)
+                res[invoice.id] = move_lines and\
+                    all(line.blocked for line in move_lines) or False
             else:
                 res[invoice.id] = False
         return res

--- a/account_payment_blocking/tests/test_account_banking_payment_blocking.py
+++ b/account_payment_blocking/tests/test_account_banking_payment_blocking.py
@@ -24,13 +24,14 @@ import openerp.tests.common as common
 from openerp import workflow
 
 
-def create_simple_invoice(self, cr, uid, context=None):
+def create_simple_invoice(self, cr, uid, payment_term=False, context=None):
     partner_id = self.ref('base.res_partner_2')
     product_id = self.ref('product.product_product_4')
     return self.registry('account.invoice')\
         .create(cr, uid, {'partner_id': partner_id,
                           'account_id':
                           self.ref('account.a_recv'),
+                          'payment_term': payment_term,
                           'journal_id':
                           self.ref('account.expenses_journal'),
                           'invoice_line': [(0, 0, {'name': 'test',
@@ -77,4 +78,31 @@ class TestAccountBankingPaymentBlocking(common.TransactionCase):
                                      context=self.context)[0]
         move_line = move_line_obj.browse(self.cr, self.uid, move_line_ids)[0]
         self.assertEqual(invoice.blocked, move_line.blocked,
+                         'Blocked values are not equals')
+
+    def test_invoice_payment_term(self):
+        invoice_obj = self.registry('account.invoice')
+        move_line_obj = self.registry('account.move.line')
+        payment_term_advance = self.ref('account.account_payment_term_advance')
+        invoice_id = create_simple_invoice(self, self.cr, self.uid,
+                                           payment_term=payment_term_advance,
+                                           context=self.context)
+        invoice_obj.write(self.cr, self.uid, [invoice_id],
+                          {'draft_blocked': True})
+        workflow.trg_validate(self.uid, 'account.invoice', invoice_id,
+                              'invoice_open', self.cr)
+        invoice = invoice_obj.browse(self.cr, self.uid, [invoice_id],
+                                     context=self.context)[0]
+        move_line_ids = move_line_obj\
+            .search(self.cr, self.uid, [('account_id.type', 'in',
+                                         ['payable', 'receivable']),
+                                        ('invoice.id', '=', invoice.id)])
+        move_lines = move_line_obj.browse(self.cr, self.uid, move_line_ids)
+        self.assertTrue(
+            move_lines and all(line.blocked for line in move_lines) or False)
+        move_line_obj.write(self.cr, self.uid, move_line_ids,
+                            {'blocked': False})
+        invoice = invoice_obj.browse(self.cr, self.uid, [invoice_id],
+                                     context=self.context)[0]
+        self.assertEqual(invoice.blocked, False,
                          'Blocked values are not equals')


### PR DESCRIPTION
For exemple, if you use an advanced payment term with payment at different due date on an invoice. The journal entry genereted from this one that contains more than one line on payable/receivable account.
