### PR TITLE
[ADD] inhibit deleting a move line if it belongs to a confirmed bank statement

### DIFF
--- a/account_banking/account_banking.py
+++ b/account_banking/account_banking.py
@@ -653,3 +653,15 @@ class account_move_line(orm.Model):
                 cr, uid, ids, ['debit', 'credit'], context=context):
             total += (line['debit'] or 0.0) - (line['credit'] or 0.0)
         return total
+
+    def unlink(self, cr, uid, ids, context=None):
+        if any(
+            this.statement_id.state == 'confirm'
+            for this in self.browse(cr, uid, ids, context=context)
+        ):
+            raise except_osv(
+                _('Error'),
+                _('Cannot delete lines belonging to confirmed bank statements')
+            )
+        return super(account_move_line, self).unlink(
+            cr, uid, ids, context=context)


### PR DESCRIPTION
I propose this here rather than for the account module in general because this hurts a lot more with a statement import workflow.
