### PR TITLE
[FIX] use set_done instead of plain workflow

### DIFF
--- a/account_banking_fr_lcr/wizard/export_lcr.py
+++ b/account_banking_fr_lcr/wizard/export_lcr.py
@@ -355,7 +355,6 @@ class banking_export_lcr_wizard(orm.TransientModel):
         self.pool['banking.export.lcr'].write(
             cr, uid, lcr_export.file_id.id, {'state': 'sent'},
             context=context)
-        wf_service = netsvc.LocalService('workflow')
-        for order in lcr_export.payment_order_ids:
-            wf_service.trg_validate(uid, 'payment.order', order.id, 'done', cr)
+        self.pool['payment.order'].set_done(
+            cr, uid, [r.id for r in lcr_export.payment_order_ids])
         return {'type': 'ir.actions.act_window_close'}

--- a/account_banking_payment_export/migrations/7.0.0.1.166/post-migrate.py
+++ b/account_banking_payment_export/migrations/7.0.0.1.166/post-migrate.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    """ for done statements, set date_done if not set from date_scheduled """
+    cr.execute(
+        'update payment_order '
+        'set date_done=coalesce(date_scheduled, write_date) '
+        "where state='done' and date_done is null"
+    )

--- a/account_banking_payment_export/model/account_payment.py
+++ b/account_banking_payment_export/model/account_payment.py
@@ -85,9 +85,5 @@ class payment_order(orm.Model):
                           'type')
                     )
             # process manual payments
-            wf_service = netsvc.LocalService('workflow')
-            for order_id in ids:
-                wf_service.trg_validate(
-                    uid, 'payment.order', order_id, 'done', cr
-                )
+            self.set_done(cr, uid, ids)
         return result

--- a/account_banking_sepa_credit_transfer/wizard/export_sepa.py
+++ b/account_banking_sepa_credit_transfer/wizard/export_sepa.py
@@ -307,7 +307,6 @@ class banking_export_sepa_wizard(orm.TransientModel):
         self.pool.get('banking.export.sepa').write(
             cr, uid, sepa_export.file_id.id, {'state': 'sent'},
             context=context)
-        wf_service = netsvc.LocalService('workflow')
-        for order in sepa_export.payment_order_ids:
-            wf_service.trg_validate(uid, 'payment.order', order.id, 'done', cr)
+        self.pool['payment.order'].set_done(
+            cr, uid, [r.id for r in sepa_export.payment_order_ids])
         return {'type': 'ir.actions.act_window_close'}

--- a/account_banking_sepa_direct_debit/wizard/export_sdd.py
+++ b/account_banking_sepa_direct_debit/wizard/export_sdd.py
@@ -423,9 +423,8 @@ class banking_export_sdd_wizard(orm.TransientModel):
         self.pool.get('banking.export.sdd').write(
             cr, uid, sepa_export.file_id.id, {'state': 'sent'},
             context=context)
-        wf_service = netsvc.LocalService('workflow')
         for order in sepa_export.payment_order_ids:
-            wf_service.trg_validate(uid, 'payment.order', order.id, 'done', cr)
+            self.pool['payment.order'].set_done(cr, uid, [order.id])
             mandate_ids = [line.mandate_id.id for line in order.line_ids]
             self.pool['account.banking.mandate'].write(
                 cr, uid, mandate_ids,


### PR DESCRIPTION
without this, `date_done` stays empty forever. In the migration, I try to restore this from `date_scheduled` or the last write date.
