### PR TITLE
[RFR] Stateful amendment info

### DIFF
--- a/account_banking_sepa_direct_debit/README.rst
+++ b/account_banking_sepa_direct_debit/README.rst
@@ -19,6 +19,13 @@ Payments Council (http://http://www.europeanpaymentscouncil.eu) use PAIN
 version 008.001.02. So if you don't know which version your bank supports, you
 should try version 008.001.02 first.
 
+Amendments
+----------
+Changes to previously used mandates are passed on to the bank using so-called
+amendments in the SDD files. Currently supported is the re-use of the same
+amendment for a different bank account. This is configured automatically on the
+mandate when it is associated with a different bank account.
+
 Installation
 ============
 
@@ -72,6 +79,7 @@ Contributors
 * Sandy Carter
 * Antonio Espinosa <antonioea@antiun.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
+* Stefan Rijnhart <stefan@opener.amsterdam>
 
 
 Maintainer

--- a/account_banking_sepa_direct_debit/__openerp__.py
+++ b/account_banking_sepa_direct_debit/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking SEPA Direct Debit',
     'summary': 'Create SEPA files for Direct Debit',
-    'version': '8.0.0.5.0',
+    'version': '8.0.1.5.0',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/account_banking_sepa_direct_debit/migrations/8.0.1.5.0/post-migration.py
+++ b/account_banking_sepa_direct_debit/migrations/8.0.1.5.0/post-migration.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+# © 2016 Opener B.V. - Stefan Rijnhart
+import logging
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """ Create amendment triggers on mandates that have a different bank
+    account than their last payment line """
+    logger = logging.getLogger(__name__)
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        cr.execute(
+            """
+            WITH latest_line AS (
+                SELECT abm.partner_bank_id, (
+                    SELECT pl.id AS plid FROM payment_line pl
+                        JOIN payment_order po ON pl.order_id = po.id
+                    WHERE pl.mandate_id = abm.id
+                        AND po.date_sent IS NOT NULL
+                        OR po.date_done IS NOT NULL
+                    ORDER BY COALESCE(po.date_sent, po.date_done) DESC
+                    LIMIT 1)
+                 FROM account_banking_mandate abm
+                 WHERE state = 'valid' AND type = 'recurrent')
+            SELECT mandate_id, pl.bank_id AS line_bank FROM latest_line
+                JOIN payment_line pl ON pl.id = plid
+            WHERE partner_bank_id != pl.bank_id;
+            """)
+        for row in cr.fetchall():
+            mandate = env['account.banking.mandate'].browse(row[0])
+            old_bank = env['res.partner.bank'].browse(row[1])
+            mandate.write(env['account.banking.mandate'].get_amendment_vals(
+                old_bank, mandate.partner_bank_id))
+            logger.info(
+                'Setting amendment trigger for mandate %s (previously for '
+                'account %s)', mandate.unique_mandate_reference,
+                old_bank.acc_number)

--- a/account_banking_sepa_direct_debit/models/__init__.py
+++ b/account_banking_sepa_direct_debit/models/__init__.py
@@ -4,3 +4,4 @@ from . import res_company
 from . import account_banking_mandate
 from . import bank_payment_line
 from . import payment_mode
+from . import payment_order

--- a/account_banking_sepa_direct_debit/models/payment_order.py
+++ b/account_banking_sepa_direct_debit/models/payment_order.py
@@ -15,6 +15,15 @@ class PaymentOrder(models.Model):
 
     @api.multi
     def action_sent(self):
+        """ Lazy compatibility with account_banking_payment_transfer """
         res = super(PaymentOrder, self).action_sent()
         self.mapped('line_ids').mapped('mandate_id').amendment_sent()
+        return res
+
+    @api.multi
+    def action_done(self):
+        res = super(PaymentOrder, self).action_done()
+        if not hasattr(self, 'action_sent'):
+            # no account_banking_payment_transfer
+            self.mapped('line_ids').mapped('mandate_id').amendment_sent()
         return res

--- a/account_banking_sepa_direct_debit/models/payment_order.py
+++ b/account_banking_sepa_direct_debit/models/payment_order.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+# © 2016 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, models
+
+
+class PaymentOrder(models.Model):
+    _inherit = 'payment.order'
+
+    @api.multi
+    def action_rejected(self):
+        res = super(PaymentOrder, self).action_rejected()
+        self.mapped('line_ids').mapped('mandate_id').amendment_reset()
+        return res
+
+    @api.multi
+    def action_sent(self):
+        res = super(PaymentOrder, self).action_sent()
+        self.mapped('line_ids').mapped('mandate_id').amendment_sent()
+        return res

--- a/account_banking_sepa_direct_debit/views/account_banking_mandate_view.xml
+++ b/account_banking_sepa_direct_debit/views/account_banking_mandate_view.xml
@@ -29,6 +29,15 @@
             <field name="sepa_migrated" groups="account_banking_sepa_direct_debit.group_original_mandate_required"/>
             <field name="original_mandate_identification" attrs="{'invisible': [('sepa_migrated', '=', True)], 'required': [('sepa_migrated', '=', False)]}" groups="account_banking_sepa_direct_debit.group_original_mandate_required"/>
         </field>
+        <group name="payment_lines" position="before">
+            <group name="amendment" string="Amendment">
+                <field name="amendment_state"/>
+                <field name="amendment_type"
+                       attrs="{'required': [('amendment_state', '!=', False)]}"/>
+                <field name="original_debtor_account"/>
+                <field name="original_debtor_agent"/>
+            </group>
+        </group>
     </field>
 </record>
 

--- a/account_banking_sepa_direct_debit/wizard/export_sdd.py
+++ b/account_banking_sepa_direct_debit/wizard/export_sdd.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ##############################################################################
 #
 #    SEPA Direct Debit module for Odoo
@@ -22,7 +22,7 @@
 
 
 from openerp import models, fields, api, _
-from openerp.exceptions import Warning
+from openerp.exceptions import Warning as UserError
 from openerp import workflow
 from lxml import etree
 
@@ -92,7 +92,7 @@ class BankingExportSddWizard(models.TransientModel):
             name_maxsize = 140
             root_xml_tag = 'CstmrDrctDbtInitn'
         else:
-            raise Warning(
+            raise UserError(
                 _("Payment Type Code '%s' is not supported. The only "
                   "Payment Type Code supported for SEPA Direct Debit are "
                   "'pain.008.001.02', 'pain.008.001.03' and "
@@ -134,14 +134,14 @@ class BankingExportSddWizard(models.TransientModel):
                 # cf account_banking_payment_export/models/account_payment.py
                 # in the inherit of action_open()
                 if not line.mandate_id:
-                    raise Warning(
+                    raise UserError(
                         _("Missing SEPA Direct Debit mandate on the "
                           "bank payment line with partner '%s' "
                           "(reference '%s').")
                         % (line.partner_id.name, line.name))
                 scheme = line.mandate_id.scheme
                 if line.mandate_id.state != 'valid':
-                    raise Warning(
+                    raise UserError(
                         _("The SEPA Direct Debit mandate with reference '%s' "
                           "for partner '%s' has expired.")
                         % (line.mandate_id.unique_mandate_reference,
@@ -149,7 +149,7 @@ class BankingExportSddWizard(models.TransientModel):
                 if line.mandate_id.type == 'oneoff':
                     seq_type = 'OOFF'
                     if line.mandate_id.last_debit_date:
-                        raise Warning(
+                        raise UserError(
                             _("The mandate with reference '%s' for partner "
                               "'%s' has type set to 'One-Off' and it has a "
                               "last debit date set to '%s', so we can't use "

--- a/account_banking_tests/README.rst
+++ b/account_banking_tests/README.rst
@@ -1,0 +1,51 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Bank Payment Tests
+==================
+
+This addon adds unit tests for the OCA Bank Payment project. Unless you are a
+developer on this project, you do not need to install this module.
+
+The reason to put theses tests in a separate module is that the functionality
+that is being tested is split up into several modules that are not mutually
+dependent on each other. This module contains all the necessary dependencies
+for the tests to run.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/bank-payment/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Stefan Rijnhart <stefan@opener.amsterdam>
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Alexis de Lattre <alexis.delattre@akretion.com>
+* Sandy Carter <sandy.carter@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_banking_tests/__openerp__.py
+++ b/account_banking_tests/__openerp__.py
@@ -1,41 +1,18 @@
-# -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013 Therp BV (<http://therp.nl>)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# coding: utf-8
+# © 2013 Therp B.V. - Stefan Rijnhart
+# © 2016 Opener B.V. - Stefan Rijnhart
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
-    'name': 'Banking Addons - Tests',
+    'name': 'Bank Payment - Tests',
     'version': '8.0.0.1.0',
     'license': 'AGPL-3',
     'author': "Therp BV,Odoo Community Association (OCA)",
-    'website': 'https://launchpad.net/banking-addons',
+    'website': 'https://github.com/oca/bank-payment',
     'category': 'Banking addons',
     'depends': [
         'account_accountant',
         'account_banking_payment_transfer',
         'account_banking_sepa_credit_transfer',
         ],
-    'description': '''
-This addon adds unit tests for the Banking addons. Installing this
-module will not give you any benefit other than having the tests'
-dependencies installed, so that you can run the tests. If you only
-run the tests manually, you don't even have to install this module,
-only its dependencies.
-    ''',
     'installable': True,
 }

--- a/account_banking_tests/tests/__init__.py
+++ b/account_banking_tests/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_amendment
 from . import test_payment_roundtrip

--- a/account_banking_tests/tests/test_amendment.py
+++ b/account_banking_tests/tests/test_amendment.py
@@ -14,9 +14,9 @@ class TestAmendment(TransactionCase):
         self.mandate = self.env.ref(
             'account_banking_sepa_direct_debit.res_partner_12_mandate')
         self.old_bank = self.env.ref(
-                    'account_banking_payment_export.res_partner_12_iban')
+            'account_banking_payment_export.res_partner_12_iban')
         self.new_bank = self.env.ref(
-                    'account_banking_payment_export.res_partner_2_iban')
+            'account_banking_payment_export.res_partner_2_iban')
 
     def create_payment_order(self):
         payment = self.env['payment.order'].create({

--- a/account_banking_tests/tests/test_amendment.py
+++ b/account_banking_tests/tests/test_amendment.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+# © 2016 Opener B.V. - Stefan Rijnhart
+from openerp.tests.common import TransactionCase
+
+
+class TestAmendment(TransactionCase):
+
+    def setUp(self):
+        super(TestAmendment, self).setUp()
+        self.company = self.env.ref('base.main_company')
+        self.mode = self.env.ref(
+            'account_banking_sepa_direct_debit.sepa_direct_debit_mode')
+        self.customer = self.env.ref('base.res_partner_12')
+        self.mandate = self.env.ref(
+            'account_banking_sepa_direct_debit.res_partner_12_mandate')
+        self.old_bank = self.env.ref(
+                    'account_banking_payment_export.res_partner_12_iban')
+        self.new_bank = self.env.ref(
+                    'account_banking_payment_export.res_partner_2_iban')
+
+    def create_payment_order(self):
+        payment = self.env['payment.order'].create({
+            'mode': self.mode.id,
+            'payment_order_type': self.mode.payment_order_type,
+            'date_prefered': 'due',
+            'mode_type': self.mode.type,
+            'line_ids': [(0, 0, {
+                'communication': '123',
+                'amount_currency': 5.0,
+                'partner_id': self.customer.id,
+                'bank_id': self.mandate.partner_bank_id.id,
+                'mandate_id': self.mandate.id,
+            })],
+        })
+        payment.signal_workflow('open')
+        export_wizard_model = payment.mode.type.ir_model_id.model
+        export_wizard = self.env[export_wizard_model].with_context(
+            active_ids=[payment.id]).create({})
+        export_wizard.create_sepa()
+        export_wizard.save_sepa()
+        return payment
+
+    def first_payment_and_write_bank_account(self):
+        """ Create a debit order on the original bank account, then reset
+        the bank account on the mandate and create another debit order """
+        self.assertEqual(self.mandate.recurrent_sequence_type, 'first')
+        self.create_payment_order()
+        self.assertEqual(self.mandate.recurrent_sequence_type, 'recurring')
+        self.mandate.write({'partner_bank_id': self.new_bank.id})
+        self.assertEqual(self.mandate.recurrent_sequence_type, 'first')
+        self.assertEqual(self.mandate.amendment_type, 'account')
+        self.assertEqual(self.mandate.amendment_state, 'next')
+        self.assertEqual(self.mandate.original_debtor_agent,
+                         self.old_bank.bank_bic)
+        self.create_payment_order()
+        self.assertEqual(self.mandate.amendment_state, 'sent')
+        self.assertEqual(self.mandate.recurrent_sequence_type, 'recurring')
+
+    def test_01_further_debit_orders(self):
+        """ Upon the second order on a mandate with an amendment, the amendment
+        is cleared """
+        self.first_payment_and_write_bank_account()
+        self.create_payment_order()
+        self.assertFalse(self.mandate.amendment_type)
+        self.assertFalse(self.mandate.amendment_state)
+        self.assertFalse(self.mandate.original_debtor_agent)
+
+    def test_02_debit_rejected(self):
+        """ When the first order on a mandate with an amendment is rejected,
+        the mandate sequence type and the amendment state are reset. """
+        self.first_payment_and_write_bank_account()
+        self.mandate.amendment_reset()
+        self.assertEqual(self.mandate.recurrent_sequence_type, 'first')
+        self.assertEqual(self.mandate.amendment_type, 'account')
+        self.assertEqual(self.mandate.amendment_state, 'next')
+        self.assertEqual(self.mandate.original_debtor_agent,
+                         self.old_bank.bank_bic)


### PR DESCRIPTION
I'm proposing to refactor the handling of amendments on SEPA mandates differently, by storing the amendment state on the mandate explicitely. This fixes amendments for switching bank accounts within the same bank, and it allows for a reject trigger so that we can send the same amendment at the next try after a debit reject (note that currently these rejection flows are not otherwise supported in this project).

This change comes complete with a migration script for mandates that had their bank accounts switched out since their last debit order, and a couple of unit tests.
