### PR TITLE
9.0 Add support for multi-currency in the generation of the account move

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -11,8 +11,8 @@ from lxml import etree
 
 class TestSCT(AccountingTestCase):
 
-    def test_sct(self):
-        self.company = self.env['res.company']
+    def setUp(self):
+        super(TestSCT, self).setUp()
         self.account_model = self.env['account.account']
         self.move_model = self.env['account.move']
         self.journal_model = self.env['account.journal']
@@ -23,8 +23,9 @@ class TestSCT(AccountingTestCase):
         self.attachment_model = self.env['ir.attachment']
         self.invoice_model = self.env['account.invoice']
         self.invoice_line_model = self.env['account.invoice.line']
-        company = self.env.ref('base.main_company')
+        self.main_company = self.env.ref('base.main_company')
         self.partner_agrolait = self.env.ref('base.res_partner_2')
+        self.partner_asus = self.env.ref('base.res_partner_1')
         self.partner_c2c = self.env.ref('base.res_partner_12')
         self.account_expense = self.account_model.search([(
             'user_type_id',
@@ -52,24 +53,31 @@ class TestSCT(AccountingTestCase):
             'bank_account_link': 'fixed',
             'fixed_journal_id': self.bank_journal.id,
             })
-        eur_currency_id = self.env.ref('base.EUR').id
-        company.currency_id = eur_currency_id
+        self.eur_currency = self.env.ref('base.EUR')
+        self.usd_currency = self.env.ref('base.USD')
+        self.main_company.currency_id = self.eur_currency.id
+
+    def test_eur_currency_sct(self):
         invoice1 = self.create_invoice(
             self.partner_agrolait.id,
-            'account_payment_mode.res_partner_2_iban', 42.0, 'F1341')
+            'account_payment_mode.res_partner_2_iban', self.eur_currency.id,
+            42.0, 'F1341')
         invoice2 = self.create_invoice(
             self.partner_agrolait.id,
-            'account_payment_mode.res_partner_2_iban', 12.0, 'F1342')
+            'account_payment_mode.res_partner_2_iban', self.eur_currency.id,
+            12.0, 'F1342')
         invoice3 = self.create_invoice(
             self.partner_agrolait.id,
-            'account_payment_mode.res_partner_2_iban', 5.0, 'A1301',
-            'in_refund')
+            'account_payment_mode.res_partner_2_iban', self.eur_currency.id,
+            5.0, 'A1301', 'in_refund')
         invoice4 = self.create_invoice(
             self.partner_c2c.id,
-            'account_payment_mode.res_partner_12_iban', 11.0, 'I1642')
+            'account_payment_mode.res_partner_12_iban', self.eur_currency.id,
+            11.0, 'I1642')
         invoice5 = self.create_invoice(
             self.partner_c2c.id,
-            'account_payment_mode.res_partner_12_iban', 41.0, 'I1643')
+            'account_payment_mode.res_partner_12_iban', self.eur_currency.id,
+            41.0, 'I1643')
         for inv in [invoice1, invoice2, invoice3, invoice4, invoice5]:
             action = inv.create_account_payment_line()
         self.assertEquals(action['res_model'], 'account.payment.order')
@@ -86,7 +94,7 @@ class TestSCT(AccountingTestCase):
         self.assertEquals(len(pay_lines), 3)
         agrolait_pay_line1 = pay_lines[0]
         accpre = self.env['decimal.precision'].precision_get('Account')
-        self.assertEquals(agrolait_pay_line1.currency_id.id, eur_currency_id)
+        self.assertEquals(agrolait_pay_line1.currency_id, self.eur_currency)
         self.assertEquals(
             agrolait_pay_line1.partner_bank_id, invoice1.partner_bank_id)
         self.assertEquals(float_compare(
@@ -101,7 +109,7 @@ class TestSCT(AccountingTestCase):
             ('partner_id', '=', self.partner_agrolait.id)])
         self.assertEquals(len(bank_lines), 1)
         agrolait_bank_line = bank_lines[0]
-        self.assertEquals(agrolait_bank_line.currency_id.id, eur_currency_id)
+        self.assertEquals(agrolait_bank_line.currency_id, self.eur_currency)
         self.assertEquals(float_compare(
             agrolait_bank_line.amount_currency, 49.0, precision_digits=accpre),
             0)
@@ -139,14 +147,92 @@ class TestSCT(AccountingTestCase):
             self.assertEquals(inv.state, 'paid')
         return
 
+    def test_usd_currency_sct(self):
+        invoice1 = self.create_invoice(
+            self.partner_asus.id,
+            'account_payment_mode.res_partner_2_iban', self.usd_currency.id,
+            2042.0, 'Inv9032')
+        invoice2 = self.create_invoice(
+            self.partner_asus.id,
+            'account_payment_mode.res_partner_2_iban', self.usd_currency.id,
+            1012.0, 'Inv9033')
+        for inv in [invoice1, invoice2]:
+            action = inv.create_account_payment_line()
+        self.assertEquals(action['res_model'], 'account.payment.order')
+        self.payment_order = self.payment_order_model.browse(action['res_id'])
+        self.assertEquals(
+            self.payment_order.payment_type, 'outbound')
+        self.assertEquals(
+            self.payment_order.payment_mode_id, self.payment_mode)
+        self.assertEquals(
+            self.payment_order.journal_id, self.bank_journal)
+        pay_lines = self.payment_line_model.search([
+            ('partner_id', '=', self.partner_asus.id),
+            ('order_id', '=', self.payment_order.id)])
+        self.assertEquals(len(pay_lines), 2)
+        asus_pay_line1 = pay_lines[0]
+        accpre = self.env['decimal.precision'].precision_get('Account')
+        self.assertEquals(asus_pay_line1.currency_id, self.usd_currency)
+        self.assertEquals(
+            asus_pay_line1.partner_bank_id, invoice1.partner_bank_id)
+        self.assertEquals(float_compare(
+            asus_pay_line1.amount_currency, 2042, precision_digits=accpre),
+            0)
+        self.assertEquals(asus_pay_line1.communication_type, 'normal')
+        self.assertEquals(asus_pay_line1.communication, 'Inv9032')
+        self.payment_order.draft2open()
+        self.assertEquals(self.payment_order.state, 'open')
+        self.assertEquals(self.payment_order.sepa, False)
+        bank_lines = self.bank_line_model.search([
+            ('partner_id', '=', self.partner_asus.id)])
+        self.assertEquals(len(bank_lines), 1)
+        asus_bank_line = bank_lines[0]
+        self.assertEquals(asus_bank_line.currency_id, self.usd_currency)
+        self.assertEquals(float_compare(
+            asus_bank_line.amount_currency, 3054.0, precision_digits=accpre),
+            0)
+        self.assertEquals(asus_bank_line.communication_type, 'normal')
+        self.assertEquals(
+            asus_bank_line.communication, 'Inv9032-Inv9033')
+        self.assertEquals(
+            asus_bank_line.partner_bank_id, invoice1.partner_bank_id)
+
+        action = self.payment_order.open2generated()
+        self.assertEquals(self.payment_order.state, 'generated')
+        self.assertEquals(action['res_model'], 'ir.attachment')
+        attachment = self.attachment_model.browse(action['res_id'])
+        self.assertEquals(attachment.datas_fname[-4:], '.xml')
+        xml_file = attachment.datas.decode('base64')
+        xml_root = etree.fromstring(xml_file)
+        # print "xml_file=", etree.tostring(xml_root, pretty_print=True)
+        namespaces = xml_root.nsmap
+        namespaces['p'] = xml_root.nsmap[None]
+        namespaces.pop(None)
+        pay_method_xpath = xml_root.xpath(
+            '//p:PmtInf/p:PmtMtd', namespaces=namespaces)
+        self.assertEquals(pay_method_xpath[0].text, 'TRF')
+        sepa_xpath = xml_root.xpath(
+            '//p:PmtInf/p:PmtTpInf/p:SvcLvl/p:Cd', namespaces=namespaces)
+        self.assertEquals(len(sepa_xpath), 0)
+        debtor_acc_xpath = xml_root.xpath(
+            '//p:PmtInf/p:DbtrAcct/p:Id/p:IBAN', namespaces=namespaces)
+        self.assertEquals(
+            debtor_acc_xpath[0].text,
+            self.payment_order.company_partner_bank_id.sanitized_acc_number)
+        self.payment_order.generated2uploaded()
+        self.assertEquals(self.payment_order.state, 'uploaded')
+        for inv in [invoice1, invoice2]:
+            self.assertEquals(inv.state, 'paid')
+        return
+
     def create_invoice(
-            self, partner_id, partner_bank_xmlid, price_unit, reference,
-            type='in_invoice'):
+            self, partner_id, partner_bank_xmlid, currency_id,
+            price_unit, reference, type='in_invoice'):
         invoice = self.invoice_model.create({
             'partner_id': partner_id,
             'reference_type': 'none',
             'reference': reference,
-            'currency_id': self.env.ref('base.EUR').id,
+            'currency_id': currency_id,
             'name': 'test',
             'account_id': self.account_payable.id,
             'type': type,

--- a/account_payment_mode/__openerp__.py
+++ b/account_payment_mode/__openerp__.py
@@ -16,6 +16,7 @@
         'views/account_payment_mode.xml',
         'views/res_partner_bank.xml',
         'views/res_partner.xml',
+        'views/account_journal.xml',
     ],
     'demo': ['demo/payment_demo.xml'],
     'installable': True,

--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -22,3 +22,6 @@ class AccountJournal(models.Model):
         default=_default_outbound_payment_methods)
     inbound_payment_method_ids = fields.Many2many(
         default=_default_inbound_payment_methods)
+    company_partner_id = fields.Many2one(
+        'res.partner', related='company_id.partner_id',
+        readonly=True)  # Used in domain of field bank_account_id

--- a/account_payment_mode/views/account_journal.xml
+++ b/account_payment_mode/views/account_journal.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+
+<!-- FIX of the 'account' module: on the form view of a bank journal,
+allow to link to an existing bank account -->
+<record id="view_account_journal_form" model="ir.ui.view">
+    <field name="name">fix_bank_account_selection.account_journal.form</field>
+    <field name="model">account.journal</field>
+    <field name="inherit_id" ref="account.view_account_journal_form"/>
+    <field name="arch" type="xml">
+        <field name="bank_acc_number" position="attributes">
+            <attribute name="invisible">1</attribute>
+        </field>
+        <field name="bank_acc_number" position="before">
+            <field name="company_partner_id" invisible="1"/>
+            <field name="bank_account_id" domain="[('partner_id', '=', company_partner_id)]"/>
+        </field>
+        <!-- better when related fields are readonly, otherwise the user
+        doesn't understand that he is changing the bank_id on the underlying
+        res.partner.bank object -->
+        <field name="bank_id" position="attributes">
+            <attribute name="readonly">1</attribute>
+        </field>
+    </field>
+</record>
+
+</data>
+</odoo>

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -41,16 +41,16 @@ class AccountPaymentMode(models.Model):
         ('move', 'Move'),
         ], default='due', string="Type of Date Filter")
     group_lines = fields.Boolean(
-        string="Group Lines in Payment Orders", default=True,
-        help="If this mark is checked, the payment order lines will be "
-             "grouped when validating the payment order before exporting the "
-             "bank file. The grouping will be done only if the following "
+        string="Group Transactions in Payment Orders", default=True,
+        help="If this mark is checked, the transaction lines of the "
+             "payment order will be grouped upon confirmation of the payment "
+             "order.The grouping will be done only if the following "
              "fields matches:\n"
              "* Partner\n"
              "* Currency\n"
              "* Destination Bank Account\n"
-             "* Communication Type (structured, free)\n"
              "* Payment Date\n"
+             "and if the 'Communication Type' is 'Free'\n"
              "(other modules can set additional fields to restrict the "
              "grouping.)")
     generate_move = fields.Boolean(

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -33,14 +33,14 @@
                         <field name="date"/>
                         <field name="move_id" required="0"/>
                         <field name="journal_id"/>
-                        <field name="name"/>
                         <field name="partner_id"/>
                         <field name="account_id"/>
                         <field name="date_maturity"/>
-                        <field name="debit" sum="Total Debit"/>
-                        <field name="credit" sum="Total Credit"/>
-                        <field name="amount_currency" invisible="1"/>
-                        <field name="currency_id" invisible="1" />
+                        <field name="debit"/>
+                        <field name="credit"/>
+                        <field name="amount_residual" sum="Total Residual"/>
+                        <field name="amount_currency"/>
+                        <field name="amount_residual_currency"/>
                         <field name="company_currency_id" invisible="1"/>
                     </tree>
                 </field>


### PR DESCRIPTION
Add support for multi-currency in the generation of the account move. 
Take into account all the remaining remarks of Frederic Clementi dated May 30:
- see multi-currency amounts in the wizard to add transaction lines
- add help msg on bank payment lines
