### PR TITLE
[IMP] Add english lang when a different lang is printed

### DIFF
--- a/account_banking_sepa_direct_debit/i18n/en.po
+++ b/account_banking_sepa_direct_debit/i18n/en.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_banking_sepa_direct_debit
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0c\n"
@@ -87,21 +87,13 @@ msgstr "<em>Type of payment:</em>"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
-msgstr ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
+msgid "To be completed by the creditor"
+msgstr "To be completed by the creditor"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
-msgstr ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
+msgid "To be completed by the debtor"
+msgstr "To be completed by the debtor"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document

--- a/account_banking_sepa_direct_debit/i18n/es.po
+++ b/account_banking_sepa_direct_debit/i18n/es.po
@@ -87,13 +87,13 @@ msgstr "<em>Tipo de pago:</em>"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid "<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be completed by the creditor</span>"
-msgstr "<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">A cumplimentar por el acreedor</span>"
+msgid "To be completed by the creditor"
+msgstr "A cumplimentar por el acreedor"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid "<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be completed by the debtor</span>"
-msgstr "<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">A cumplimentar por el deudor</span>"
+msgid "To be completed by the debtor"
+msgstr "A cumplimentar por el deudor"
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
@@ -349,4 +349,3 @@ msgstr "account.config.settings"
 msgid "to send instructions to your bank to debit your account and (B) your bank to\n"
 "                       debit your account in accordance with the instructions from"
 msgstr "a enviar instrucciones a la entidad del deudor para adeudar su cuenta y (B) a la entidad para efectuar los adeudos en su cuenta siguiendo las instrucciones del acreedor "
-

--- a/account_banking_sepa_direct_debit/i18n/fr.po
+++ b/account_banking_sepa_direct_debit/i18n/fr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_banking_sepa_direct_debit
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
@@ -90,16 +90,12 @@ msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
+msgid "To be completed by the creditor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
+msgid "To be completed by the debtor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/i18n/nl.po
+++ b/account_banking_sepa_direct_debit/i18n/nl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_banking_sepa_direct_debit
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
@@ -90,16 +90,12 @@ msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
+msgid "To be completed by the creditor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
+msgid "To be completed by the debtor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/i18n/pt_BR.po
+++ b/account_banking_sepa_direct_debit/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_banking_sepa_direct_debit
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
@@ -90,16 +90,12 @@ msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
+msgid "To be completed by the creditor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
+msgid "To be completed by the debtor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/i18n/sl.po
+++ b/account_banking_sepa_direct_debit/i18n/sl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * account_banking_sepa_direct_debit
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
@@ -90,16 +90,12 @@ msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the creditor</span>"
+msgid "To be completed by the creditor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.ui.view,arch_db:account_banking_sepa_direct_debit.sepa_direct_debit_mandate_document
-msgid ""
-"<span class=\"col-xs-12 text-right\" style=\"font-size:8px;\">To be "
-"completed by the debtor</span>"
+msgid "To be completed by the debtor"
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -6,6 +6,10 @@
         <t t-set="is_not_english" t-value="doc.partner_id.lang[:2] != 'en'" />
         <div class="page">
             <style type="text/css">
+                h4 {
+                     margin-top: 2px;
+                     margin-bottom: 2px;
+                }
                 .under-line{
                     border-bottom:1px solid;
                 }
@@ -15,8 +19,15 @@
                 .panel-default{
                     border:2px solid;
                 }
+                .panel.panel-default{
+                    margin-bottom: 4px;
+                }
+                .panel-body{
+                    padding: 2px 14px;
+                }
                 p{
-                  font-size: 8px;
+                    margin: 0 0 4px;
+                    font-size: 8px;
                 }
                 .native_lang{
                     font-style: italic;
@@ -53,7 +64,7 @@
                                 <span class="native_lang" t-esc="'(To be completed by the creditor)'"/>
                             </t>
                         </div>
-                        <div class="panel-body mb8">
+                        <div class="panel-body">
                             <div class="col-xs-12">
                                 <em>Mandate Reference:</em>
                                 <t t-if="is_not_english">
@@ -210,7 +221,7 @@
                                         <span class="native_lang native_lang_small" t-esc="'(Recurrent)'"/>
                                     </t>
                                 </input>
-                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                                -
                                 <input type="checkbox" t-att-checked="doc.type=='oneoff' or None">
                                     One-Off
                                     <t t-if="is_not_english">

--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -3,6 +3,7 @@
 
     <template id="sepa_direct_debit_mandate_document">
         <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
+        <t t-set="native_langs" t-value="('en_US', 'en_GB')" />
         <div class="page">
             <style type="text/css">
                 .under-line{
@@ -17,41 +18,104 @@
                 p{
                   font-size: 8px;
                 }
+                .native_lang{
+                    font-style: italic;
+                }
+                .native_lang_small{
+                    font-size: 0.8em;
+                }
             </style>
             <div class="row mt0">
                 <div class="col-xs-3">
                     <img t-if="doc.company_id.logo" t-att-src="'data:image/png;base64,%s' % doc.company_id.logo" style="max-height: 45px;"/>
                 </div>
                 <div class="col-xs-12 text-center">
-                    <h4 t-if="doc.scheme != 'B2B'"><strong>Sepa Direct Debit Mandate</strong></h4>
-                    <h4 t-if="doc.scheme == 'B2B'"><strong>Sepa Business-To-Business Direct debit Mandate</strong></h4>
+                    <h4 t-if="doc.scheme != 'B2B'">
+                        <strong>Sepa Direct Debit Mandate</strong>
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/><span class="native_lang native_lang_small" t-esc="'Sepa Direct Debit Mandate'"/>
+                        </t>
+                    </h4>
+                    <h4 t-if="doc.scheme == 'B2B'">
+                        <strong>Sepa Business-To-Business Direct debit Mandate</strong>
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/><span class="native_lang native_lang_small" t-esc="'Sepa Business-To-Business Direct debit Mandate'"/>
+                        </t>
+                    </h4>
                 </div>
             </div>
             <div class="row mt8">
                 <div class="col-xs-12">
                     <div class="panel panel-default">
-                        <span class="col-xs-12 text-right" style="font-size:8px;">To be completed by the creditor</span>
+                        <div class="col-xs-12 text-right" style="font-size:8px;">
+                            To be completed by the creditor
+                            <t t-if="doc.partner_id.lang not in native_langs">
+                                <span class="native_lang" t-esc="'(To be completed by the creditor)'"/>
+                            </t>
+                        </div>
                         <div class="panel-body mb8">
-                            <div class="col-xs-12"><em>Mandate Reference:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.unique_mandate_reference"/></div>
-                            <div class="col-xs-12"><em>Identifier:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.sepa_creditor_identifier"/></div>
-                            <div class="col-xs-12"><em>Creditor's Name:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.name"/></div>
-                            <div class="col-xs-12"><em>Address:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.street"/></div>
-                            <div class="col-xs-12"><em>Postal Code - City - Town:</em></div>
+                            <div class="col-xs-12">
+                                <em>Mandate Reference:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Mandate Reference)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.unique_mandate_reference"/></div>
+                            <div class="col-xs-12">
+                                <em>Identifier:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Identifier)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.sepa_creditor_identifier"/></div>
+                            <div class="col-xs-12">
+                                <em>Creditor's Name:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Creditor\'s Name)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.name"/></div>
+                            <div class="col-xs-12">
+                                <em>Address:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Address)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.street"/></div>
+                            <div class="col-xs-12">
+                                <em>Postal Code - City - Town:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
+                                </t>
+                            </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line  mt8">
                                 <span t-field="doc.company_id.partner_id.zip"/> -
                                 <span t-field="doc.company_id.partner_id.city"/> -
                                 <span t-field="doc.company_id.partner_id.state_id"/>
                             </div>
-                            <div class="col-xs-12"><em>Country:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.country_id"/></div>
+                            <div class="col-xs-12">
+                                <em>Country:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Country)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.country_id"/></div>
                         </div>
                     </div>
                 </div>
             </div>
             <div class="row mt0">
                 <div class="col-xs-12">
-                    <p>By signing this mandate form, you authorise (A) <strong t-if="doc.scheme == 'B2B'"><span t-field="doc.company_id.name"/></strong>
+                    <p>By signing this mandate form, you authorise (A) <strong t-if="doc.scheme == 'B2B'"> <span t-field="doc.company_id.name"/> </strong>
                        to send instructions to your bank to debit your account and (B) your bank to
-                       debit your account in accordance with the instructions from <strong t-if="doc.scheme == 'B2B'"><span t-field="doc.company_id.name"/></strong>.
+                       debit your account in accordance with the instructions from <strong t-if="doc.scheme == 'B2B'"> <span t-field="doc.company_id.name"/> </strong>.
+                       <t t-if="doc.partner_id.lang not in native_langs">
+                           <br/>
+                           <span class="native_lang" t-esc="'(By signing this mandate form, you authorise (A) '"/>
+                           <t t-if="doc.scheme == 'B2B'"> <span class="native_lang" t-field="doc.company_id.name"/> </t>
+                           <span class="native_lang" t-esc="' to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with the instructions from '"/>
+                           <t t-if="doc.scheme == 'B2B'"> <span class="native_lang" t-field="doc.company_id.name"/> </t>.)
+                       </t>
                     </p>
                 </div>
             </div>
@@ -62,39 +126,112 @@
                         You are not entitled to a refund from your bank after your account has
                         been debited, but you are entitled to request your bank
                         not to debit your account up until the day on which the payment is due.
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/>
+                            <span class="native_lang" t-esc="'(This mandate is only intended for business-to-business transactions. You are not entitled to a refund from your bank after your account has been debited, but you are entitled to request your bank not to debit your account up until the day on which the payment is due.)'"/>
+                        </t>
                     </p>
                     <p t-if="doc.scheme != 'B2B'">
                         As part of your rights, you are entitled to a refund from
                         your bank under the terms and conditions of your agreement
                         with your bank.
                         A refund must be claimed within 8 weeks starting from the date on which your account was debited.
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/>
+                            <span class="native_lang" t-esc="'(As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.)'"/>
+                        </t>
                     </p>
                 </div>
             </div>
             <div class="row">
                 <div class="col-xs-12">
                     <div class="panel panel-default">
-                        <span class="col-xs-12 text-right" style="font-size:8px;">To be completed by the debtor</span>
+                        <div class="col-xs-12 text-right" style="font-size:8px;">
+                            To be completed by the debtor
+                            <t t-if="doc.partner_id.lang not in native_langs">
+                                <span class="native_lang" t-esc="'(To be completed by the debtor)'"/>
+                            </t>
+                        </div>
                         <div class="panel-body">
-                            <div class="col-xs-12"><em>Debtor's Name:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id"/></div>
-                            <div class="col-xs-12"><em>Address of the Debtor:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.street"/></div>
-                            <div class="col-xs-12"><em>Postal Code - City - Town:</em></div>
+                            <div class="col-xs-12">
+                                <em>Debtor's Name:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Debtor\'s Name)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id"/></div>
+                            <div class="col-xs-12">
+                                <em>Address of the Debtor:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Address of the Debtor)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.street"/></div>
+                            <div class="col-xs-12">
+                                <em>Postal Code - City - Town:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
+                                </t>
+                            </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4">
                                 <span t-field="doc.partner_id.zip"/> -
                                 <span t-field="doc.partner_id.city"/> -
                                 <span t-field="doc.partner_id.state_id"/>
                             </div>
-                            <div class="col-xs-12"><em>Country of the debtor:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.country_id"/></div>
-                            <div class="col-xs-12"><em>Swift BIC (up to 8 or 11 characteres):</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.bank_bic"/></div>
-                            <div class="col-xs-12"><em>Account Number - IBAN:</em></div><div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.acc_number"/></div>
-                            <div class="col-xs-12"><em>Type of payment:</em></div>
-                            <div class="col-xs-10 col-xs-offset-2 mt4">
-                                <input type="checkbox" t-att-checked="doc.type=='recurrent' or None">  Recurrent</input>
-                                <input type="checkbox" t-att-checked="doc.type=='oneoff' or None">  One-Off</input>
+                            <div class="col-xs-12">
+                                <em>Country of the debtor:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Country of the debtor)'"/>
+                                </t>
                             </div>
-                            <div class="col-xs-12"><em>Date - Location:</em></div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.country_id"/></div>
+                            <div class="col-xs-12">
+                                <em>Swift BIC (up to 8 or 11 characteres):</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Swift BIC, up to 8 or 11 characteres)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.bank_bic"/></div>
+                            <div class="col-xs-12">
+                                <em>Account Number - IBAN:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Account Number - IBAN)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.acc_number"/></div>
+                            <div class="col-xs-12">
+                                <em>Type of payment:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Type of payment)'"/>
+                                </t>
+                            </div>
+                            <div class="col-xs-10 col-xs-offset-2 mt4">
+                                <input type="checkbox" t-att-checked="doc.type=='recurrent' or None">
+                                    Recurrent
+                                    <t t-if="doc.partner_id.lang not in native_langs">
+                                        <span class="native_lang native_lang_small" t-esc="'(Recurrent)'"/>
+                                    </t>
+                                </input><br/>
+                                <input type="checkbox" t-att-checked="doc.type=='oneoff' or None">
+                                    One-Off
+                                    <t t-if="doc.partner_id.lang not in native_langs">
+                                        <span class="native_lang native_lang_small" t-esc="'(One-Off)'"/>
+                                    </t>
+                                </input>
+                            </div>
+                            <div class="col-xs-12">
+                                <em>Date - Location:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Date - Location)'"/>
+                                </t>
+                            </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt16"/>
-                            <div class="col-xs-12"><em>Signature of the debtor:</em></div>
+                            <div class="col-xs-12">
+                                <em>Signature of the debtor:</em>
+                                <t t-if="doc.partner_id.lang not in native_langs">
+                                    <br/><span class="native_lang native_lang_small" t-esc="'(Signature of the debtor)'"/>
+                                </t>
+                            </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt16"/>
                         </div>
                     </div>
@@ -102,10 +239,22 @@
             </div>
             <div class="row">
                 <div class="col-xs-12 text-center">
-                    <p t-if="doc.scheme != 'B2B'">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.</p>
-                    <p t-if="doc.scheme == 'B2B'">ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.
+                    <p t-if="doc.scheme != 'B2B'">
+                        ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/>
+                            <span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.)'"/>
+                        </t>
+                    </p>
+                    <p t-if="doc.scheme == 'B2B'">
+                        ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.
                         NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT.
-                        THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.</p>
+                        THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.
+                        <t t-if="doc.partner_id.lang not in native_langs">
+                            <br/>
+                            <span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE. NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT. THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.)'"/>
+                        </t>
+                    </p>
                 </div>
             </div>
         </div>

--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -3,7 +3,7 @@
 
     <template id="sepa_direct_debit_mandate_document">
         <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
-        <t t-set="is_not_english" t-value="doc.partner_id.lang[:2] != 'en'" />
+        <t t-set="is_not_english" t-value="doc.partner_id.lang and doc.partner_id.lang[:2] != 'en'" />
         <div class="page">
             <style type="text/css">
                 h4 {

--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -3,7 +3,7 @@
 
     <template id="sepa_direct_debit_mandate_document">
         <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
-        <t t-set="native_langs" t-value="('en_US', 'en_GB')" />
+        <t t-set="is_not_english" t-value="doc.partner_id.lang[:2] != 'en'" />
         <div class="page">
             <style type="text/css">
                 .under-line{
@@ -32,13 +32,13 @@
                 <div class="col-xs-12 text-center">
                     <h4 t-if="doc.scheme != 'B2B'">
                         <strong>Sepa Direct Debit Mandate</strong>
-                        <t t-if="doc.partner_id.lang not in native_langs">
+                        <t t-if="is_not_english">
                             <br/><span class="native_lang native_lang_small" t-esc="'Sepa Direct Debit Mandate'"/>
                         </t>
                     </h4>
                     <h4 t-if="doc.scheme == 'B2B'">
                         <strong>Sepa Business-To-Business Direct debit Mandate</strong>
-                        <t t-if="doc.partner_id.lang not in native_langs">
+                        <t t-if="is_not_english">
                             <br/><span class="native_lang native_lang_small" t-esc="'Sepa Business-To-Business Direct debit Mandate'"/>
                         </t>
                     </h4>
@@ -49,43 +49,43 @@
                     <div class="panel panel-default">
                         <div class="col-xs-12 text-right" style="font-size:8px;">
                             To be completed by the creditor
-                            <t t-if="doc.partner_id.lang not in native_langs">
+                            <t t-if="is_not_english">
                                 <span class="native_lang" t-esc="'(To be completed by the creditor)'"/>
                             </t>
                         </div>
                         <div class="panel-body mb8">
                             <div class="col-xs-12">
                                 <em>Mandate Reference:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Mandate Reference)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Mandate Reference)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.unique_mandate_reference"/></div>
                             <div class="col-xs-12">
                                 <em>Identifier:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Identifier)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Identifier)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.sepa_creditor_identifier"/></div>
                             <div class="col-xs-12">
                                 <em>Creditor's Name:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Creditor\'s Name)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Creditor\'s Name)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.name"/></div>
                             <div class="col-xs-12">
                                 <em>Address:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Address)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Address)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.street"/></div>
                             <div class="col-xs-12">
                                 <em>Postal Code - City - Town:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line  mt8">
@@ -95,8 +95,8 @@
                             </div>
                             <div class="col-xs-12">
                                 <em>Country:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Country)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Country)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.company_id.partner_id.country_id"/></div>
@@ -109,7 +109,7 @@
                     <p>By signing this mandate form, you authorise (A) <strong t-if="doc.scheme == 'B2B'"> <span t-field="doc.company_id.name"/> </strong>
                        to send instructions to your bank to debit your account and (B) your bank to
                        debit your account in accordance with the instructions from <strong t-if="doc.scheme == 'B2B'"> <span t-field="doc.company_id.name"/> </strong>.
-                       <t t-if="doc.partner_id.lang not in native_langs">
+                       <t t-if="is_not_english">
                            <br/>
                            <span class="native_lang" t-esc="'(By signing this mandate form, you authorise (A) '"/>
                            <t t-if="doc.scheme == 'B2B'"> <span class="native_lang" t-field="doc.company_id.name"/> </t>
@@ -126,9 +126,8 @@
                         You are not entitled to a refund from your bank after your account has
                         been debited, but you are entitled to request your bank
                         not to debit your account up until the day on which the payment is due.
-                        <t t-if="doc.partner_id.lang not in native_langs">
-                            <br/>
-                            <span class="native_lang" t-esc="'(This mandate is only intended for business-to-business transactions. You are not entitled to a refund from your bank after your account has been debited, but you are entitled to request your bank not to debit your account up until the day on which the payment is due.)'"/>
+                        <t t-if="is_not_english">
+                            <br/><span class="native_lang" t-esc="'(This mandate is only intended for business-to-business transactions. You are not entitled to a refund from your bank after your account has been debited, but you are entitled to request your bank not to debit your account up until the day on which the payment is due.)'"/>
                         </t>
                     </p>
                     <p t-if="doc.scheme != 'B2B'">
@@ -136,9 +135,8 @@
                         your bank under the terms and conditions of your agreement
                         with your bank.
                         A refund must be claimed within 8 weeks starting from the date on which your account was debited.
-                        <t t-if="doc.partner_id.lang not in native_langs">
-                            <br/>
-                            <span class="native_lang" t-esc="'(As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.)'"/>
+                        <t t-if="is_not_english">
+                            <br/><span class="native_lang" t-esc="'(As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.)'"/>
                         </t>
                     </p>
                 </div>
@@ -148,29 +146,29 @@
                     <div class="panel panel-default">
                         <div class="col-xs-12 text-right" style="font-size:8px;">
                             To be completed by the debtor
-                            <t t-if="doc.partner_id.lang not in native_langs">
+                            <t t-if="is_not_english">
                                 <span class="native_lang" t-esc="'(To be completed by the debtor)'"/>
                             </t>
                         </div>
                         <div class="panel-body">
                             <div class="col-xs-12">
                                 <em>Debtor's Name:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Debtor\'s Name)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Debtor\'s Name)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id"/></div>
                             <div class="col-xs-12">
                                 <em>Address of the Debtor:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Address of the Debtor)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Address of the Debtor)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.street"/></div>
                             <div class="col-xs-12">
                                 <em>Postal Code - City - Town:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Postal Code - City - Town)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4">
@@ -180,56 +178,57 @@
                             </div>
                             <div class="col-xs-12">
                                 <em>Country of the debtor:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Country of the debtor)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Country of the debtor)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_id.country_id"/></div>
                             <div class="col-xs-12">
                                 <em>Swift BIC (up to 8 or 11 characteres):</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Swift BIC, up to 8 or 11 characteres)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Swift BIC, up to 8 or 11 characteres)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.bank_bic"/></div>
                             <div class="col-xs-12">
                                 <em>Account Number - IBAN:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Account Number - IBAN)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Account Number - IBAN)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt4"><span t-field="doc.partner_bank_id.acc_number"/></div>
                             <div class="col-xs-12">
                                 <em>Type of payment:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Type of payment)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Type of payment)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 mt4">
                                 <input type="checkbox" t-att-checked="doc.type=='recurrent' or None">
                                     Recurrent
-                                    <t t-if="doc.partner_id.lang not in native_langs">
+                                    <t t-if="is_not_english">
                                         <span class="native_lang native_lang_small" t-esc="'(Recurrent)'"/>
                                     </t>
-                                </input><br/>
+                                </input>
+                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                                 <input type="checkbox" t-att-checked="doc.type=='oneoff' or None">
                                     One-Off
-                                    <t t-if="doc.partner_id.lang not in native_langs">
+                                    <t t-if="is_not_english">
                                         <span class="native_lang native_lang_small" t-esc="'(One-Off)'"/>
                                     </t>
                                 </input>
                             </div>
                             <div class="col-xs-12">
                                 <em>Date - Location:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Date - Location)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Date - Location)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt16"/>
                             <div class="col-xs-12">
                                 <em>Signature of the debtor:</em>
-                                <t t-if="doc.partner_id.lang not in native_langs">
-                                    <br/><span class="native_lang native_lang_small" t-esc="'(Signature of the debtor)'"/>
+                                <t t-if="is_not_english">
+                                    <span class="native_lang native_lang_small" t-esc="'(Signature of the debtor)'"/>
                                 </t>
                             </div>
                             <div class="col-xs-10 col-xs-offset-2 under-line mt16"/>
@@ -241,18 +240,16 @@
                 <div class="col-xs-12 text-center">
                     <p t-if="doc.scheme != 'B2B'">
                         ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.
-                        <t t-if="doc.partner_id.lang not in native_langs">
-                            <br/>
-                            <span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.)'"/>
+                        <t t-if="is_not_english">
+                            <br/><span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.)'"/>
                         </t>
                     </p>
                     <p t-if="doc.scheme == 'B2B'">
                         ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE.
                         NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT.
                         THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.
-                        <t t-if="doc.partner_id.lang not in native_langs">
-                            <br/>
-                            <span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE. NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT. THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.)'"/>
+                        <t t-if="is_not_english">
+                            <br/><span class="native_lang" t-esc="'(ALL GAPS ARE MANDATORY. ONCE THIS MANDATE HAS BEEN SIGNED MUST BE SENT TO CREDITOR FOR STORAGE. NEVERTHELESS, THE BANK OF DEBTOR REQUIRES DEBTOR’S AUTHORIZATION BEFORE DEBITING B2B DIRECT DEBITS IN THE ACCOUNT. THE DEBTOR WILL BE ABLE TO MANAGE THE MENTIONED AUTHORIZATION THROUGH THE MEANS PROVIDED BY HIS BANK.)'"/>
                         </t>
                     </p>
                 </div>


### PR DESCRIPTION
When a mandate is printed in a different language than english, banks often required (as Spanish case) mandate in two languages: native and english.

This PR adds english language when printed language is not english.
