### PR TITLE
[IMP] account_payment_order: extensibility of _prepare_move

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -330,7 +330,7 @@ class AccountPaymentOrder(models.Model):
         return True
 
     @api.multi
-    def _prepare_move(self):
+    def _prepare_move(self, bank_lines=None):
         if self.payment_type == 'outbound':
             ref = _('Payment order %s') % self.name
         else:
@@ -433,7 +433,7 @@ class AccountPaymentOrder(models.Model):
                 trfmoves[hashcode] = bline
 
         for hashcode, blines in trfmoves.iteritems():
-            mvals = self._prepare_move()
+            mvals = self._prepare_move(blines)
             total_company_currency = total_payment_currency = 0
             for bline in blines:
                 total_company_currency += bline.amount_company_currency


### PR DESCRIPTION
Pass the list of bank lines to _prepare_move so it is possible to customize the move (eg it's name) based on the lines being paid.
