### PR TITLE
[FIX] payment order: add missing onchange dependencies in move selection wizard

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -140,7 +140,8 @@ class AccountPaymentLineCreate(models.TransientModel):
         return action
 
     @api.onchange(
-        'date_type', 'move_date', 'due_date', 'journal_ids', 'invoice')
+        'date_type', 'move_date', 'due_date', 'journal_ids', 'invoice',
+        'target_move', 'allow_blocked', 'invoice', 'payment_mode')
     def move_line_filters_change(self):
         domain = self._prepare_move_line_domain()
         res = {'domain': {'move_line_ids': domain}}

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -141,7 +141,7 @@ class AccountPaymentLineCreate(models.TransientModel):
 
     @api.onchange(
         'date_type', 'move_date', 'due_date', 'journal_ids', 'invoice',
-        'target_move', 'allow_blocked', 'invoice', 'payment_mode')
+        'target_move', 'allow_blocked', 'payment_mode')
     def move_line_filters_change(self):
         domain = self._prepare_move_line_domain()
         res = {'domain': {'move_line_ids': domain}}


### PR DESCRIPTION
All the criteria used in _prepare_move_line_domain must refresh the domain used when clicking add items in the move lines list.

cc/ @alexis-via 
