### PR TITLE
9.0 FIX crash when selecting a customer that has no mandate + small improvements

### DIFF
--- a/account_banking_mandate/models/account_invoice.py
+++ b/account_banking_mandate/models/account_invoice.py
@@ -59,7 +59,8 @@ class AccountInvoice(models.Model):
                 ('state', '=', 'valid'),
                 ('partner_id', '=', self.commercial_partner_id.id),
                 ])
-            self.mandate_id = mandates[0]
+            if mandates:
+                self.mandate_id = mandates[0]
         else:
             self.mandate_id = False
 

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -23,7 +23,7 @@ class AccountMoveLine(models.Model):
         aplo = self.env['account.payment.line']
         # default values for communication_type and communication
         communication_type = 'normal'
-        communication = self.move_id.ref or '-'
+        communication = self.move_id.ref or self.move_id.name
         # change these default values if move line is linked to an invoice
         if self.invoice_id:
             if self.invoice_id.reference_type != 'none':

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -23,7 +23,7 @@ class AccountMoveLine(models.Model):
         aplo = self.env['account.payment.line']
         # default values for communication_type and communication
         communication_type = 'normal'
-        communication = self.move_id.name or '-'
+        communication = self.move_id.ref or '-'
         # change these default values if move line is linked to an invoice
         if self.invoice_id:
             if self.invoice_id.reference_type != 'none':

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -8,21 +8,29 @@
     <field name="model">account.payment.mode</field>
     <field name="inherit_id" ref="account_payment_mode.account_payment_mode_form"/>
     <field name="arch" type="xml">
+        <field name="payment_type" position="after">
+            <field name="payment_order_ok"/>
+        </field>
         <group name="main" position="after">
-            <group name="payment_order_options" string="Options for Payment Orders">
-                <field name="payment_order_ok"/>
+            <group name="payment_order_options"
+                string="Options for Payment Orders"
+                attrs="{'invisible': [('payment_order_ok', '=', False)]}">
                 <field name="no_debit_before_maturity"
                     attrs="{'invisible': ['|', ('payment_type', '!=', 'inbound'), ('payment_order_ok', '!=', True)]}"/>
                 <field name="group_lines"/>
             </group>
-            <group name="payment_order_create_defaults" string="Select Move Lines to Pay - Default Values">
+            <group name="payment_order_create_defaults"
+                    string="Select Move Lines to Pay - Default Values"
+                    attrs="{'invisible': [('payment_order_ok', '=', False)]}">
                 <field name="default_journal_ids" widget="many2many_tags"/>
                 <field name="default_payment_mode"/>
                 <field name="default_target_move" widget="radio"/>
                 <field name="default_invoice"/>
                 <field name="default_date_type"/>
             </group>
-            <group name="accounting-config" string="Accounting Entries Options">
+            <group name="accounting-config"
+                    string="Accounting Entries Options"
+                    attrs="{'invisible': [('payment_order_ok', '=', False)]}">
                 <field name="generate_move"/>
                 <field name="offsetting_account" widget="radio"
                     attrs="{'required': [('generate_move', '=', True)], 'invisible': [('generate_move', '=', False)]}"/>


### PR DESCRIPTION
This PR changes 3 things:
- FIX crash when selecting a customer that has a direct debit payment mode but no mandate
- Hide many fields when payment_order_ok is False on a payment_mode (usability improvement)
- Fix payment line communication when the move line is not linked to an invoice (problem found when porting donation_debit_debit to v9)

This PR is needed to make the unittests of my PR to port the donation modules to v9 work https://github.com/OCA/donation/pull/13 (requires the last change in my list of 3 changes)
