### PR TITLE
[FIX] 8.0 - account_direct_debit - 'pay_mode' undefined if 'payment_type=None'

### DIFF
--- a/account_direct_debit/models/account_move_line.py
+++ b/account_direct_debit/models/account_move_line.py
@@ -35,4 +35,4 @@ class AccountMoveLine(models.Model):
                                 break
                 return line2bank
         return super(AccountMoveLine, self).line2bank(
-            cr, uid, ids, payment_type=pay_mode.id, context=context)
+            cr, uid, ids, payment_type=payment_type, context=context)


### PR DESCRIPTION
Not sure about the fix, the fact is that if `payment_type` is None, `pay_mode` is then undefined.
