### PR TITLE
[9.0] account_payment_sale : change debit account on invoice

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -28,6 +28,8 @@ class SaleOrder(models.Model):
         if self.payment_mode_id:
             vals['payment_mode_id'] = self.payment_mode_id.id
             if self.payment_mode_id.bank_account_link == 'fixed':
-                vals['partner_bank_id'] =\
-                    self.payment_mode_id.fixed_journal_id.bank_account_id.id
+                journal = self.payment_mode_id.fixed_journal_id
+                vals['partner_bank_id'] = journal.bank_account_id.id
+                if journal.default_debit_account_id:
+                    vals['account_id'] = journal.default_debit_account_id.id
         return vals

--- a/account_payment_sale/wizard/sale_make_invoice_advance.py
+++ b/account_payment_sale/wizard/sale_make_invoice_advance.py
@@ -17,8 +17,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if order.payment_mode_id:
             vals['payment_mode_id'] = order.payment_mode_id.id
             if order.payment_mode_id.bank_account_link == 'fixed':
-                vals['partner_bank_id'] =\
-                    order.payment_mode_id.fixed_journal_id.bank_account_id.id
+                journal = order.payment_mode_id.fixed_journal_id
+                vals['partner_bank_id'] = journal.bank_account_id.id
+                if journal.default_debit_account_id:
+                    vals['account_id'] = journal.default_debit_account_id.id
         if vals:
             inv.write(vals)
         return inv


### PR DESCRIPTION
Small PR to update the account on the invoice depending on the payment mode.

The goal here is that, if an invoice is set with a payment mode that uses a fixed journal, the entries created for payment will use the default debit/credit accounts, and to reconcile them with the invoice, they should use the same account.
