### PR TITLE
[FIX] account_banking_payment_export: Change sequence and noupdate

### DIFF
--- a/account_banking_payment_export/data/bank_payment_line_seq.xml
+++ b/account_banking_payment_export/data/bank_payment_line_seq.xml
@@ -6,7 +6,7 @@
 -->
 
 <openerp>
-<data>
+<data noupdate="1">
 
 <record id="bank_payment_line_seq_type" model="ir.sequence.type">
     <field name="name">Bank Payment Line</field>
@@ -16,7 +16,7 @@
 <record id="bank_payment_line_seq" model="ir.sequence">
     <field name="name">Bank Payment Line</field>
     <field name="code">bank.payment.line</field>
-    <field name="prefix">L</field>
+    <field name="prefix">BPL</field>
     <field name="padding">5</field>
     <field name="number_next">1</field>
     <field name="company_id" eval="False"/>


### PR DESCRIPTION
The new bank.payment.line sequence has the same prefix as the old payment.line, 
so this makes that installations coming from the previous version where there were
no bank.payment.line, in an effective way this provokes to restart the numbering
of the references sent to the bank and thus the possibility of duplicating numbers.

The implicit noupdate="0" also does the same effect of restarting the numbering.
