### PR TITLE
Remove type=other restriction in transfer account

### DIFF
--- a/account_banking_payment_transfer/README.rst
+++ b/account_banking_payment_transfer/README.rst
@@ -63,6 +63,7 @@ Contributors
 * Matt Choplin
 * Alexandre Fayolle
 * Danimar Ribeiro
+* Jose Maria Alzaga <jose.alzaga@aselcis.com>
 
 Maintainer
 ----------

--- a/account_banking_payment_transfer/__openerp__.py
+++ b/account_banking_payment_transfer/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Account Banking - Payments Transfer Account',
-    'version': '8.0.0.3.0',
+    'version': '8.0.0.3.1',
     'license': 'AGPL-3',
     'author': "Banking addons community,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/banking',

--- a/account_banking_payment_transfer/__openerp__.py
+++ b/account_banking_payment_transfer/__openerp__.py
@@ -2,6 +2,7 @@
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<http://therp.nl>)
 # © 2013-2014 ACSONE SA (<http://acsone.eu>).
+# © 2016 Aselcis Consulting (<http://www.aselcis.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/account_banking_payment_transfer/model/payment_mode.py
+++ b/account_banking_payment_transfer/model/payment_mode.py
@@ -2,6 +2,7 @@
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<http://therp.nl>)
 # © 2014 Akretion (www.akretion.com)
+# © 2016 Aselcis (www.aselcis.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
@@ -12,7 +13,7 @@ class PaymentMode(models.Model):
 
     transfer_account_id = fields.Many2one(
         'account.account', string='Transfer account',
-        domain=[('type', '!=', 'view'),('reconcile', '=', True)],
+        domain=[('type', '!=', 'view'), ('reconcile', '=', True)],
         help='Pay off lines in sent orders with a move on this '
         'account. You can only select accounts of type regular '
         'that are marked for reconciliation')

--- a/account_banking_payment_transfer/model/payment_mode.py
+++ b/account_banking_payment_transfer/model/payment_mode.py
@@ -12,7 +12,7 @@ class PaymentMode(models.Model):
 
     transfer_account_id = fields.Many2one(
         'account.account', string='Transfer account',
-        domain=[('type', '=', 'other'), ('reconcile', '=', True)],
+        domain=[('type', '!=', 'view'),('reconcile', '=', True)],
         help='Pay off lines in sent orders with a move on this '
         'account. You can only select accounts of type regular '
         'that are marked for reconciliation')

--- a/account_banking_payment_transfer/view/payment_mode.xml
+++ b/account_banking_payment_transfer/view/payment_mode.xml
@@ -13,11 +13,10 @@
                 <xpath expr="/form/group[@col='4']" position="inside">
                     <group name="trf-move-config" string="Transfer move settings" colspan="2">
                         <field name="transfer_account_id"
-                               domain="[('type', '=', 'other'),
+                               domain="[('type', '!=', 'view'),
                                        ('reconcile', '=', True),
                                        ('company_id', '=', company_id)]"
                                context="{
-                                   'default_type': 'other',
                                    'default_reconcile': True,
                                    'default_company_id': company_id}"
                                />


### PR DESCRIPTION
module: account_banking_payment_transfer
Related to issue: Cannot use type receivable or payable account as transfer account #309 https://github.com/OCA/bank-payment/issues/309