### PR TITLE
Remove internal_type=other restriction for transfer account

### DIFF
--- a/account_payment_order/README.rst
+++ b/account_payment_order/README.rst
@@ -67,6 +67,7 @@ Contributors
 * Raphaël Valyi
 * Sandy Carter
 * Angel Moya <angel.moya@domatix.com>
+* Jose María Alzaga <jose.alzaga@aselcis.com>
 
 Maintainer
 ----------

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -4,16 +4,18 @@
 # © 2013-2014 ACSONE SA (<http://acsone.eu>).
 # © 2014-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Akretion (<http://www.akretion.com>).
+# © 2016 Aselcis (<http://www.aselcis.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "
               "Tecnativa, "
               "Akretion, "
+              "Aselcis, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/bank-payment',
     'category': 'Banking addons',

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -61,9 +61,9 @@ class AccountPaymentMode(models.Model):
         ], string='Offsetting Account', default='bank_account')
     transfer_account_id = fields.Many2one(
         'account.account', string='Transfer Account',
-        domain=[('internal_type', '=', 'other'), ('reconcile', '=', True)],
+        domain=[('reconcile', '=', True)],
         help="Pay off lines in 'file uploaded' payment orders with a move on "
-        "this account. You can only select accounts of type regular "
+        "this account. You can only select accounts "
         "that are marked for reconciliation")
     transfer_journal_id = fields.Many2one(
         'account.journal', string='Transfer Journal',


### PR DESCRIPTION
module: account_payment_order
Related to issue: Cannot use type receivable or payable account as transfer account #309