### PR TITLE
Remove internal_type=other restriction for transfer account

### DIFF
--- a/account_payment_order/README.rst
+++ b/account_payment_order/README.rst
@@ -66,8 +66,8 @@ Contributors
 * Erwin van der Ploeg
 * Raphaël Valyi
 * Sandy Carter
-* Angel Moya <angel.moya@domatix.com
-* Jose Maria Alzaga <jose.alzaga@aselcis.com
+* Angel Moya <angel.moya@domatix.com>
+* Jose Maria Alzaga <jose.alzaga@aselcis.com>
 
 Maintainer
 ----------

--- a/account_payment_order/README.rst
+++ b/account_payment_order/README.rst
@@ -66,7 +66,8 @@ Contributors
 * Erwin van der Ploeg
 * Raphaël Valyi
 * Sandy Carter
-* Angel Moya <angel.moya@domatix.com>
+* Angel Moya <angel.moya@domatix.com
+* Jose Maria Alzaga <jose.alzaga@aselcis.com
 
 Maintainer
 ----------

--- a/account_payment_order/__openerp__.py
+++ b/account_payment_order/__openerp__.py
@@ -4,6 +4,7 @@
 # © 2013-2014 ACSONE SA (<http://acsone.eu>).
 # © 2014-2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Akretion (<http://www.akretion.com>).
+# © 2016 Aselcis Consulting (<http://www.aselcis.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -14,6 +15,7 @@
               "Therp BV, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Akretion, "
+              "Aselcis, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/bank-payment',
     'category': 'Banking addons',

--- a/account_payment_order/__openerp__.py
+++ b/account_payment_order/__openerp__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '9.0.1.1.0',
+    'version': '9.0.1.1.1',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -61,9 +61,9 @@ class AccountPaymentMode(models.Model):
         ], string='Offsetting Account', default='bank_account')
     transfer_account_id = fields.Many2one(
         'account.account', string='Transfer Account',
-        domain=[('internal_type', '=', 'other'), ('reconcile', '=', True)],
+        domain=[('reconcile', '=', True)],
         help="Pay off lines in 'file uploaded' payment orders with a move on "
-        "this account. You can only select accounts of type regular "
+        "this account. You can only select accounts "
         "that are marked for reconciliation")
     transfer_journal_id = fields.Many2one(
         'account.journal', string='Transfer Journal',


### PR DESCRIPTION
module: account_payment_order
Related to issue: Cannot use type receivable or payable account as transfer account #309