### PR TITLE
[IMP] Define SEPA category purpose on payment mode

### DIFF
--- a/account_banking_pain_base/models/banking_export_pain.py
+++ b/account_banking_pain_base/models/banking_export_pain.py
@@ -210,7 +210,17 @@ class BankingExportPain(models.AbstractModel):
             sequence_type_2_14 = etree.SubElement(
                 payment_type_info_2_6, 'SeqTp')
             sequence_type_2_14.text = sequence_type
-
+        # Set CtgyPurp for pain.001.001.002 and pain.001.001.003
+        if gen_args.get('pain_flavor') == 'pain.001.001.02' or gen_args.get(
+                'pain_flavor') == 'pain.001.001.03' or gen_args.get(
+                'pain_flavor') == 'pain.001.001.04' or gen_args.get(
+                'pain_flavor') == 'pain.001.001.05':
+            category_purpose_2_14 = etree.SubElement(
+                payment_type_info_2_6, 'CtgyPurp')
+            category_purpose_code_2_14 = etree.SubElement(
+                category_purpose_2_14, 'Cd')
+            category_purpose_code_2_14.text = gen_args.get(
+                'category_purpose_code')
         if gen_args['payment_method'] == 'DD':
             request_date_tag = 'ReqdColltnDt'
         else:

--- a/account_banking_sepa_credit_transfer/__openerp__.py
+++ b/account_banking_sepa_credit_transfer/__openerp__.py
@@ -19,6 +19,7 @@
     'data': [
         'wizard/export_sepa_view.xml',
         'data/payment_type_sepa_sct.xml',
+        'views/payment_mode.xml'
     ],
     'demo': [
         'demo/sepa_credit_transfer_demo.xml'

--- a/account_banking_sepa_credit_transfer/models/payment_mode.py
+++ b/account_banking_sepa_credit_transfer/models/payment_mode.py
@@ -2,7 +2,7 @@
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models
+from openerp import models, fields
 
 
 class PaymentMode(models.Model):
@@ -14,3 +14,35 @@ class PaymentMode(models.Model):
             if self.type.code and self.type.code.startswith('pain.001'):
                 res = 'sepa_credit_transfer'
         return res
+
+    sepa_category_purpose = fields.Selection([
+        ('CORT', "[CORT] Transaction is related to settlement of a trade, "
+            "eg a foreign exchange deal or a securities transaction."),
+        ('SALA', "[SALA] Transaction is the payment of salaries."),
+        ('TREA', "[TREA] Transaction is related to treasury operations. "
+            "E.g. financial contract settlement."),
+        ('CASH', "[CASH] Transaction is a general cash management "
+            "instruction."),
+        ('DIVI', "[DIVI] Transaction is the payment of dividends."),
+        ('GOVT', "[GOVT] Transaction is a payment to or from a "
+            "government department."),
+        ('INTE', "[INTE] Transaction is the payment of interest."),
+        ('LOAN', "[LOAN] Transaction is related to the transfer of "
+            "a loan to a borrower."),
+        ('PENS', "[PENS] Transaction is the payment of pension."),
+        ('SECU', "[SECU] Transaction is the payment of securities."),
+        ('SUPP', "[SUPP] Transaction is related to a payment to a supplier."),
+        ('SSBE', "[SSBE] Transaction is a social security benefit, ie payment "
+            "made by a government to support individuals."),
+        ('TAXS', "[TAXS] Transaction is the payment of taxes."),
+        ('TRAD', "[TRAD] Transaction is related to the payment of a trade "
+            "finance transaction."),
+        ('VATX', "[VATX] Transaction is the payment of value added tax."),
+        ('HEDG', "[HEDG] Transaction is related to the payment of a hedging "
+            "operation."),
+        ('INTC', "[INTC] Transaction is an intra-company payment, ie, a "
+            "payment between two companies belonging to the same group."),
+        ('WHLD', "[WHLD] Transaction is the payment of withholding tax."),
+    ], string='SEPA Category Purpose Type', required=False, size=4,
+        help="Select the appropiate SEPA category for transactions made "
+        "under this payment type. Only appplicable for SEPA Credit Transfers.")

--- a/account_banking_sepa_credit_transfer/views/payment_mode.xml
+++ b/account_banking_sepa_credit_transfer/views/payment_mode.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_payment_mode_form_add_category">
+            <field name="name">add.category.in.payment.mode.form</field>
+            <field name="model">payment.mode</field>
+            <field name="inherit_id" ref="account_banking_payment_export.view_payment_mode_form_inherit"/>
+            <field name="arch" type="xml">
+                <field name="type" position="after">    
+                    <field name="sepa_category_purpose" attrs="{'invisible': [('sepa_type', '!=', 'sepa_credit_transfer')]}"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_banking_sepa_credit_transfer/wizard/export_sepa.py
+++ b/account_banking_sepa_credit_transfer/wizard/export_sepa.py
@@ -60,6 +60,8 @@ class BankingExportSepaWizard(models.TransientModel):
     def create_sepa(self):
         """Creates the SEPA Credit Transfer file. That's the important code!"""
         pain_flavor = self.payment_order_ids[0].mode.type.code
+        category_purpose_code = \
+            self.payment_order_ids[0].mode.sepa_category_purpose
         convert_to_ascii = \
             self.payment_order_ids[0].mode.convert_to_ascii
         if pain_flavor == 'pain.001.001.02':
@@ -111,6 +113,7 @@ class BankingExportSepaWizard(models.TransientModel):
             'pain_xsd_file':
             'account_banking_sepa_credit_transfer/data/%s.xsd'
             % pain_flavor,
+            'category_purpose_code': category_purpose_code,
         }
         pain_ns = {
             'xsi': 'http://www.w3.org/2001/XMLSchema-instance',

--- a/account_banking_tests/tests/test_payment_roundtrip.py
+++ b/account_banking_tests/tests/test_payment_roundtrip.py
@@ -237,6 +237,7 @@ class TestPaymentRoundtrip(TransactionCase):
                 'transfer_journal_id': transfer_journal_id,
                 'transfer_move_option': transfer_move_option,
                 'type': payment_mode_type_id,
+                'sepa_category_purpose': 'SALA',
                 })
 
     def setup_payment(self, reg, cr, uid):


### PR DESCRIPTION
This PR defines the **SEPA category purpose** code on the payment mode, according to **ISO 20022**:
 https://www.iso20022.org/standardsrepository/public/wqt/Description/mx/dico/codesets/_ZzX8ldp-Ed-ak6NoX_4Aeg_-191357927

Basically what this code does, is that enables you to add a category on a credit transfer, so you can specify if the transaction corresponds to a payment of salaries, taxes, etc. 

I want to credit @pedrorgil from Otherway Creatives, because I just adapted the code I found on one of his repositories.