### PR TITLE
[9.0][FIX] account_payment_order: unbind payment transfer moves without deleting them

### DIFF
--- a/account_payment_order/models/__init__.py
+++ b/account_payment_order/models/__init__.py
@@ -8,3 +8,4 @@ from . import account_move
 from . import account_move_line
 from . import account_invoice
 from . import res_bank
+from . import bank_statement_line

--- a/account_payment_order/models/bank_statement_line.py
+++ b/account_payment_order/models/bank_statement_line.py
@@ -2,7 +2,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import api, fields, models, _
+from openerp import api, models
 
 
 class BankStatementLine(models.Model):

--- a/account_payment_order/models/bank_statement_line.py
+++ b/account_payment_order/models/bank_statement_line.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models, _
+
+
+class BankStatementLine(models.Model):
+
+    _inherit = 'account.bank.statement.line'
+
+    @api.multi
+    def button_cancel_reconciliation(self):
+        """ Unbind moves that are linked to bank.payment.line
+            without cancelling nor deleting them.
+        """
+        moves_to_unbind = self.env['account.move']
+        move_lines_to_unbind = self.env['account.move.line']
+        for rec in self:
+            for move in rec.journal_entry_ids:
+                if any([l.bank_payment_line_id for l in move.line_ids]):
+                    moves_to_unbind |= move
+                    move_lines_to_unbind |= move.line_ids.filtered(
+                        lambda l: l.statement_id == self.statement_id)
+        if moves_to_unbind:
+            moves_to_unbind.write({'statement_line_id': False})
+        if move_lines_to_unbind:
+            move_lines_to_unbind.write({'statement_id': False})
+        return super(BankStatementLine, self).button_cancel_reconciliation()


### PR DESCRIPTION
When unreconciling a bank statement line that is matched with a bank
account move lines linked to a bank.payment.line, it must be unbound,
not deleted as the standard Odoo method would do.

Note the standard Odoo method has such protection for their native
payment lines.