### PR TITLE
[ADD] after openupgrade's rename, we also need to call our hook in the migration script

### DIFF
--- a/account_payment_mode/migrations/9.0.1.0.0/pre-migration.py
+++ b/account_payment_mode/migrations/9.0.1.0.0/pre-migration.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# © 2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.addons.account_payment_mode.hooks import migrate_from_8
+
+
+def migrate(cr, version=None):
+    # also support cases where openupgrade renamed the old module
+    migrate_from_8(cr)


### PR DESCRIPTION
See discussion in https://github.com/OCA/OpenUpgrade/pull/656