### PR TITLE
Update account_move_line.py

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -47,6 +47,12 @@ class AccountMoveLine(models.Model):
             # in this case
         if payment_order.payment_type == 'outbound':
             amount_currency *= -1
+        #Add the bank account of the partner automatically to a pay order created from journal entries. Set to False
+        if self.partner_id.bank_ids:
+            partner_bank = self.partner_id.bank_ids[0]
+        else:
+            partner_bank = False
+        self.partner_bank_id = partner_bank
         vals = {
             'order_id': payment_order.id,
             'partner_bank_id': self.partner_bank_id.id,


### PR DESCRIPTION
Fix to issue #329 
When creating a SEPA credit transfer to suppliers with the function "create payment lines from journal items", the partner bank account is not written in the table and it has to be added manually.