### PR TITLE
[10.0] Creation/Modification of bank info only for Account Payment group

### DIFF
--- a/account_payment_order/security/ir.model.access.csv
+++ b/account_payment_order/security/ir.model.access.csv
@@ -2,3 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_payment_order,Full access on account.payment.order to Payment Manager,model_account_payment_order,group_account_payment,1,1,1,1
 access_account_payment_line,Full access on account.payment.line to Payment Manager,model_account_payment_line,group_account_payment,1,1,1,1
 access_bank_payment_line,Full access on bank.payment.line to Payment Manager,model_bank_payment_line,group_account_payment,1,1,1,1
+base.access_res_partner_bank_group_partner_manager,Full access on res.partner.bank to Account Payment group,base.model_res_partner_bank,group_account_payment,1,1,1,1
+base.access_res_bank_group_partner_manager,Full access on res.bank to Account Payment group,base.model_res_bank,group_account_payment,1,1,1,1


### PR DESCRIPTION
By default in Odoo, members of the group *Contact Creation* can create and modify bank accounts ; this can be a risk, as explained in this mail : https://lists.launchpad.net/openerp-community/msg01035.html

With this module, only the members of the group *Accounting / Payments* can create and modify bank accounts. Now that we took back control of the base account payment features, I think it's time to have that configuration by default.