### PR TITLE
[8.0] No payment date in the past (backport from v9/v10)

### DIFF
--- a/account_banking_payment_export/models/account_payment.py
+++ b/account_banking_payment_export/models/account_payment.py
@@ -137,6 +137,9 @@ class PaymentOrder(models.Model):
                     requested_date = order.date_scheduled or today
                 else:
                     requested_date = today
+                # No payment date in the past
+                if requested_date < today:
+                    requested_date = today
                 # Write requested_date on 'date' field of payment line
                 payline.date = requested_date
                 # Group options


### PR DESCRIPTION
On a payment order, when using "Preferred Date" = "Due", there is a risk to have maturity dates in the past and thereforce payment dates in the past in the SEPA XML file... which some bank dislike.

This patch will put the current date instead. This is a backport of a modification I made in v9.