### PR TITLE
[IMP] account_payment_partner: Fill payment mode in invoices if none is provided

### DIFF
--- a/account_banking_mandate/__openerp__.py
+++ b/account_banking_mandate/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking Mandate',
     'summary': 'Banking mandates',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'license': 'AGPL-3',
     'author': "Compassion CH, "
               "Tecnativa, "

--- a/account_payment_partner/__openerp__.py
+++ b/account_payment_partner/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Payment Partner',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'category': 'Banking addons',
     'license': 'AGPL-3',
     'summary': 'Adds payment mode on partners and invoices',


### PR DESCRIPTION
Using same method as in upstream, payment mode is filled on invoice creation if no payment method is provided. This way, we don't need to install _account_payment_sale_ if we don't want to handle several payment modes at sales level. Even more, if we install the module later and we have already existing
sales orders without payment mode filled, those orders will be invoiced with the customer payment mode.