### PR TITLE
[9.0] fix 2 issues on form view for payment order

### DIFF
--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -35,10 +35,10 @@
                             domain="[('payment_order_ok', '=', True), ('payment_type', '=', payment_type)]"
                             widget="selection"/>
                         <field name="journal_id" widget="selection"
-                            domain="[('id', 'in', allowed_journal_ids and allowed_journal_ids[0] and allowed_journal_ids[0][2] or False)]"/>
+                            domain="[('id', 'in', allowed_journal_ids and allowed_journal_ids[0] and allowed_journal_ids[0][2] or [])]"/>
                         <field name="allowed_journal_ids" invisible="1"/>
                         <field name="bank_account_link" invisible="1"/>
-                        <field name="company_partner_bank_id" widget="selection"/>
+                        <field name="company_partner_bank_id"/>
                         <field name="company_id" groups="base.group_multi_company"/>
                         <field name="payment_type" invisible="0"/>
                         <field name="bank_line_count"/>


### PR DESCRIPTION
2 small fixes for issues I had with the form view:
- the first line is to avoid a warning in the log : Odoo checks for `[('id', 'in', False)]` domains, so I put an empty list instead.
- the second fix is hard to reproduce, not sure how it happened : sometimes (and never on the same fixed journal), I get "Unknown" as the related field's value, even if defined. And it never happens when I remove the "selection" widget (since the field is read-only, I do not think there are any consequences for removing the widget).