### PR TITLE
[FIX] we need to decorate the onchange handler with @api.multi

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -12,6 +12,7 @@ class SaleOrder(models.Model):
         'account.payment.mode', string='Payment Mode',
         domain=[('payment_type', '=', 'inbound')])
 
+    @api.multi
     @api.onchange('partner_id')
     def onchange_partner_id(self):
         res = super(SaleOrder, self).onchange_partner_id()


### PR DESCRIPTION
...otherwise, `website_sale` will choke because it calls the onchange handler with v7 api: https://github.com/OCA/OCB/blob/9.0/addons/website_sale/controllers/main.py#L634