### PR TITLE
[8.0] account_banking_payment_export dot in bank lines view

### DIFF
--- a/account_banking_payment_export/README.rst
+++ b/account_banking_payment_export/README.rst
@@ -18,7 +18,7 @@ for electronic banking. It provides the following technical features:
   payment.mode.type
 * a manual payment mode type is provided as an example, with a default "do
   nothing" wizard
-  
+
 To enable the use of payment order to collect money for customers,
 it adds a payment_order_type (payment|debit) as a basis of direct debit support
 (this field becomes visible when account_direct_debit is installed).
@@ -41,7 +41,7 @@ No configuration required.
 Usage
 =====
 
-This module provides a menu to configure payment order types : Accounting > Configuration > Miscellaneous > Payment Export Types 
+This module provides a menu to configure payment order types : Accounting > Configuration > Miscellaneous > Payment Export Types
 
 For further information, please visit:
 
@@ -51,7 +51,7 @@ Known issues / Roadmap
 ======================
 
  * no known issues
- 
+
 Bug Tracker
 ===========
 
@@ -68,8 +68,8 @@ Contributors
 ------------
 
 * Stéphane Bidoul <stephane.bidoul@acsone.eu>
-* Alexis de Lattre		
-* Pedro M. Baeza     
+* Alexis de Lattre
+* Pedro M. Baeza
 * Adrien Peiffer <adrien.peiffer@acsone.eu>
 * Stefan Rijnhart
 * Laurent Mignon <laurent.mignon@acsone.eu>
@@ -79,6 +79,7 @@ Contributors
 * Raphaël Valyi
 * Sandy Carter
 * Angel Moya <angel.moya@domatix.com>
+* Daniel Rodriguez <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/account_banking_payment_export/views/bank_payment_line.xml
+++ b/account_banking_payment_export/views/bank_payment_line.xml
@@ -45,8 +45,7 @@
             <field name="communication"/>
             <field name="bank_id"/>
             <field name="date"/>
-            <field name="amount_currency" widget="monetary"
-                options="{'currency_field': 'currency'}"
+            <field name="amount_currency"
                 sum="Total Amount"/>
             <field name="currency"/>
             <field name="name"/>


### PR DESCRIPTION
Hi
I have a problem with the bank_line view because the decimal and thousands separator are incorrect, can view this image:
![bank-lines-error](https://cloud.githubusercontent.com/assets/19977041/25695508/b1cc3138-30b3-11e7-8759-48aa4170c6a2.png)
But with this new code view fine this view like this image:
![bank-lines-ok](https://cloud.githubusercontent.com/assets/19977041/25695529/c8bb1616-30b3-11e7-9342-e2322842f657.png)
