### PR TITLE
[10.0] Add 'post_move' option on account.payment.mode

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -73,7 +73,7 @@ class AccountPaymentMode(models.Model):
         ('date', 'One move per payment date'),
         ('line', 'One move per payment line'),
         ], string='Move Option', default='date')
-    post_move = fields.Boolean(string='Post Move')
+    post_move = fields.Boolean(string='Post Move', default=True)
 
     @api.multi
     @api.constrains(

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -73,6 +73,7 @@ class AccountPaymentMode(models.Model):
         ('date', 'One move per payment date'),
         ('line', 'One move per payment line'),
         ], string='Move Option', default='date')
+    post_move = fields.Boolean(string='Post Move')
 
     @api.multi
     @api.constrains(

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -433,6 +433,7 @@ class AccountPaymentOrder(models.Model):
         """
         self.ensure_one()
         am_obj = self.env['account.move']
+        post_move = self.payment_mode_id.post_move
         # prepare a dict "trfmoves" that can be used when
         # self.payment_mode_id.move_option = date or line
         # key = unique identifier (date or True or line.id)
@@ -459,4 +460,5 @@ class AccountPaymentOrder(models.Model):
             mvals['line_ids'].append((0, 0, trf_ml_vals))
             move = am_obj.create(mvals)
             blines.reconcile_payment_lines()
-            move.post()
+            if post_move:
+                move.post()

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -40,6 +40,7 @@
                     attrs="{'invisible': [('offsetting_account', '!=', 'transfer_account')], 'required': [('offsetting_account', '=', 'transfer_account')]}"/>
                 <field name="move_option"
                     attrs="{'invisible': [('generate_move', '=', False)], 'required': [('generate_move', '=', True)]}"/>
+                <field name="post_move"/>
             </group>
         </group>
     </field>


### PR DESCRIPTION
If you use account_cancel, it's not a problem to auto-post account moves generated upon final validation of the payment order, but for those who don't/can't use account_cancel, it's not a good idea to auto-post account moves.