### PR TITLE
[10.0] Add field default_date_prefered on payment mode

### DIFF
--- a/account_banking_sepa_direct_debit/demo/sepa_direct_debit_demo.xml
+++ b/account_banking_sepa_direct_debit/demo/sepa_direct_debit_demo.xml
@@ -21,7 +21,7 @@
     <field name="format">sepa</field>
     <field name="type">recurrent</field>
     <field name="recurrent_sequence_type">first</field>
-    <field name="signature_date">2014-02-01</field>
+    <field name="signature_date" eval="time.strftime('%Y-01-01')"/>
     <field name="state">valid</field>
 </record>
 

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.1.3',
+    'version': '10.0.1.2.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_invoice.py
+++ b/account_payment_order/models/account_invoice.py
@@ -34,6 +34,8 @@ class AccountInvoice(models.Model):
     def _prepare_new_payment_order(self):
         self.ensure_one()
         vals = {'payment_mode_id': self.payment_mode_id.id}
+        # other important fields are set by the inherit of create
+        # in account_payment_order.py
         return vals
 
     @api.multi

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -40,6 +40,12 @@ class AccountPaymentMode(models.Model):
         ('due', 'Due'),
         ('move', 'Move'),
         ], default='due', string="Type of Date Filter")
+    # default option for account.payment.order
+    default_date_prefered = fields.Selection([
+        ('now', 'Immediately'),
+        ('due', 'Due Date'),
+        ('fixed', 'Fixed Date'),
+        ], string='Default Payment Execution Date')
     group_lines = fields.Boolean(
         string="Group Transactions in Payment Orders", default=True,
         help="If this mark is checked, the transaction lines of the "

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -141,6 +141,10 @@ class AccountPaymentOrder(models.Model):
             vals['payment_type'] = payment_mode.payment_type
             if payment_mode.bank_account_link == 'fixed':
                 vals['journal_id'] = payment_mode.fixed_journal_id.id
+            if (
+                    'date_prefered' not in vals and
+                    payment_mode.default_date_prefered):
+                vals['date_prefered'] = payment_mode.default_date_prefered
         return super(AccountPaymentOrder, self).create(vals)
 
     @api.onchange('payment_mode_id')
@@ -157,6 +161,8 @@ class AccountPaymentOrder(models.Model):
                 jrl_ids = self.payment_mode_id.variable_journal_ids.ids
                 res['domain']['journal_id'] = "[('id', 'in', %s)]" % jrl_ids
         self.journal_id = journal_id
+        if self.payment_mode_id.default_date_prefered:
+            self.date_prefered = self.payment_mode_id.default_date_prefered
         return res
 
     @api.multi

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -142,7 +142,7 @@ class AccountPaymentOrder(models.Model):
             if payment_mode.bank_account_link == 'fixed':
                 vals['journal_id'] = payment_mode.fixed_journal_id.id
             if (
-                    'date_prefered' not in vals and
+                    not vals.get('date_prefered') and
                     payment_mode.default_date_prefered):
                 vals['date_prefered'] = payment_mode.default_date_prefered
         return super(AccountPaymentOrder, self).create(vals)

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -16,6 +16,7 @@
                 attrs="{'invisible': [('payment_order_ok', '=', False)]}">
                 <field name="no_debit_before_maturity"
                     attrs="{'invisible': ['|', ('payment_type', '!=', 'inbound'), ('payment_order_ok', '!=', True)]}"/>
+                <field name="default_date_prefered"/>
                 <field name="group_lines"/>
             </group>
             <group name="payment_order_create_defaults"


### PR DESCRIPTION
This new field "default_date_prefered" on payment mode allows to set the default value of the field "date_prefered" on payment orders create with that payment mode.