### PR TITLE
[10.0] Explicit error when bank account is missing on bank journal

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.1.2',
+    'version': '10.0.1.1.3',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -202,6 +202,12 @@ class AccountPaymentOrder(models.Model):
             if not order.journal_id:
                 raise UserError(_(
                     'Missing Bank Journal on payment order %s.') % order.name)
+            if (
+                    order.payment_method_id.bank_account_required and
+                    not order.journal_id.bank_account_id):
+                raise UserError(_(
+                    "Missing bank account on bank journal '%s'.")
+                    % order.journal_id.display_name)
             if not order.payment_line_ids:
                 raise UserError(_(
                     'There are no transactions on payment order %s.')


### PR DESCRIPTION
Without this PR, when the bank account is not set on the bank journal, you get an error when generating the SEPA XML file which says "Cannot compute 'Company Name'"... and it's very difficult to understand the root cause of the problem. I had this error this morning during my test and that's why I made this PR.

PR from the Barcelona code sprint !