### PR TITLE
[FIX] account_banking_payment_transfer: Don't fail when no transfer move

### DIFF
--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -109,12 +109,15 @@ class PaymentOrder(models.Model):
         Called from the workflow to move to the done state when
         all transfer move have been reconciled through bank statements.
         """
-        self.env.cr.execute(
-            '''select id from account_move_line
-            where id in %s and reconcile_id is null''',
-            (tuple(self.get_transfer_move_line_ids()),)
-        )
-        return self.env.cr.rowcount == 0
+        transfer_move_ids = self.get_transfer_move_line_ids()
+        if transfer_move_ids:
+            self.env.cr.execute(
+                '''select id from account_move_line
+                where id in %s and reconcile_id is null''',
+                (tuple(self.get_transfer_move_line_ids()),)
+            )
+            return self.env.cr.rowcount == 0
+        return True
 
     @api.multi
     def test_undo_done(self):

--- a/account_banking_payment_transfer/model/account_payment.py
+++ b/account_banking_payment_transfer/model/account_payment.py
@@ -114,7 +114,7 @@ class PaymentOrder(models.Model):
             self.env.cr.execute(
                 '''select id from account_move_line
                 where id in %s and reconcile_id is null''',
-                (tuple(self.get_transfer_move_line_ids()),)
+                (tuple(transfer_move_ids),)
             )
             return self.env.cr.rowcount == 0
         return True


### PR DESCRIPTION
If you make a payment order with a payment mode without transfer settings,
the test for moving the workflow to done fails with the error:

```
  File "/opt/odoo/auto/addons/account_banking_payment_transfer/model/account_payment.py", line 115, in test_done
    (tuple(self.get_transfer_move_line_ids()),)
  File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 158, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
ValueError: "syntax error at or near ")"
LINE 2:             where id in () and reconcile_id is null
                                 ^
" while evaluating
u'test_done()'
```