### PR TITLE
[10.0]Fix payment method onchange with multicompany

### DIFF
--- a/account_payment_mode/__manifest__.py
+++ b/account_payment_mode/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Account Payment Mode',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/bank-payment',

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -117,10 +117,14 @@ class AccountPaymentMode(models.Model):
             aj_ids = []
             if self.payment_method_id.payment_type == 'outbound':
                 aj_ids = ajo.search([
-                    ('type', 'in', ('purchase_refund', 'purchase'))]).ids
+                    ('type', 'in', ('purchase_refund', 'purchase')),
+                    ('company_id', '=', self.company_id.id)
+                ]).ids
             elif self.payment_method_id.payment_type == 'inbound':
                 aj_ids = ajo.search([
-                    ('type', 'in', ('sale_refund', 'sale'))]).ids
+                    ('type', 'in', ('sale_refund', 'sale')),
+                    ('company_id', '=', self.company_id.id)
+                ]).ids
             self.default_journal_ids = [(6, 0, aj_ids)]
 
     @api.onchange('generate_move')


### PR DESCRIPTION
Current behaviour :
 - When selecting a payment method, all the journals matching payment_method_id.payment_type are selected.

Desired behaviour :
 - When selecting a payment method, as the payment mode has a company_id required, we only want the journals matching payment_method_id.payment_type and the self.company_id.
