### PR TITLE
[9.0] account_payment_order: Don't allow deletion of an uploaded payment order + allow to cancel an uploaded payment order

### DIFF
--- a/account_payment_order/__openerp__.py
+++ b/account_payment_order/__openerp__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '9.0.1.1.2',
+    'version': '9.0.1.2.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -99,9 +99,10 @@ class AccountPaymentOrder(models.Model):
     def unlink(self):
         for order in self:
             if order.state == 'uploaded':
-                raise ValidationError(_(
+                raise UserError(_(
                     "You cannot delete an uploaded payment order. You can "
                     "cancel it in order to do so."))
+        return super(AccountPaymentOrder, self).unlink()
 
     @api.multi
     @api.constrains('payment_type', 'payment_mode_id')

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -96,6 +96,14 @@ class AccountPaymentOrder(models.Model):
         readonly=True)
 
     @api.multi
+    def unlink(self):
+        for order in self:
+            if order.state == 'uploaded':
+                raise ValidationError(_(
+                    "You cannot delete an uploaded payment order. You can "
+                    "cancel it in order to do so."))
+
+    @api.multi
     @api.constrains('payment_type', 'payment_mode_id')
     def payment_order_constraints(self):
         for order in self:
@@ -173,6 +181,16 @@ class AccountPaymentOrder(models.Model):
             'date_done': fields.Date.context_today(self),
             'state': 'done',
             })
+        return True
+
+    @api.multi
+    def action_done_cancel(self):
+        for move in self.move_ids:
+            move.button_cancel()
+            for move_line in move.line_ids:
+                move_line.remove_move_reconcile()
+            move.unlink()
+        self.action_cancel()
         return True
 
     @api.multi

--- a/account_payment_order/models/bank_payment_line.py
+++ b/account_payment_order/models/bank_payment_line.py
@@ -155,3 +155,14 @@ class BankPaymentLine(models.Model):
             lines_to_rec += payment_line.move_line_id
 
         lines_to_rec.reconcile()
+
+    @api.multi
+    def unlink(self):
+        for line in self:
+            order_state = line.order_id.state
+            if order_state == 'uploaded':
+                raise UserError(_(
+                    'Cannot delete a payment order line whose payment order is'
+                    ' in state \'%s\'. You need to cancel it first.')
+                    % order_state)
+        return super(BankPaymentLine, self).unlink()

--- a/account_payment_order/tests/__init__.py
+++ b/account_payment_order/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_payment_order

--- a/account_payment_order/tests/test_payment_order.py
+++ b/account_payment_order/tests/test_payment_order.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import UserError
+
+
+class TestPaymentOrder(TransactionCase):
+
+    def setUp(self):
+        super(TestPaymentOrder, self).setUp()
+        self.invoice = self._create_supplier_invoice()
+
+    def _create_supplier_invoice(self):
+        invoice_account = self.env['account.account'].search(
+            [('user_type_id', '=', self.env.ref(
+                'account.data_account_type_payable').id)],
+            limit=1).id
+        invoice_line_account = self.env['account.account'].search(
+            [('user_type_id', '=', self.env.ref(
+                'account.data_account_type_expenses').id)],
+            limit=1).id
+
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.env.ref('base.res_partner_4').id,
+            'account_id': invoice_account,
+            'type': 'in_invoice',
+            'payment_mode_id': self.env.ref(
+                'account_payment_mode.payment_mode_outbound_ct1').id
+        })
+
+        self.env['account.invoice.line'].create({
+            'product_id': self.env.ref('product.product_product_4').id,
+            'quantity': 1.0,
+            'price_unit': 100.0,
+            'invoice_id': invoice.id,
+            'name': 'product that cost 100',
+            'account_id': invoice_line_account,
+        })
+
+        return invoice
+
+    def test_cancel_payment_order(self):
+        # Open invoice
+        self.invoice.signal_workflow('invoice_open')
+        # Add to payment order
+        self.invoice.create_account_payment_line()
+
+        payment_order = self.env['account.payment.order'].search([])
+        bank_journal = self.env['account.journal'].search(
+            [('type', '=', 'bank')])
+        # Set journal to allow cancelling entries
+        bank_journal.update_posted = True
+
+        payment_order.write({
+            'journal_id': bank_journal.id
+        })
+
+        self.assertEquals(len(payment_order.payment_line_ids), 1)
+        self.assertEquals(len(payment_order.bank_line_ids), 0)
+
+        # Open payment order
+        payment_order.draft2open()
+
+        self.assertEquals(len(payment_order.bank_line_ids), 1)
+
+        # Generate and upload
+        payment_order.open2generated()
+        payment_order.generated2uploaded()
+
+        self.assertEquals(payment_order.state, 'uploaded')
+        with self.assertRaises(UserError):
+            payment_order.unlink()
+
+        bank_line = payment_order.bank_line_ids
+
+        with self.assertRaises(UserError):
+            bank_line.unlink()
+
+        payment_order.action_done_cancel()
+        self.assertEquals(payment_order.state, 'cancel')
+
+        payment_order.unlink()
+        self.assertEquals(len(self.env['account.payment.order'].search([])), 0)

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -22,6 +22,8 @@
                     string="Back to Draft" />
                 <button name="action_cancel" type="object" states="draft,open,generated"
                     string="Cancel Payments"/>
+                <button name="action_done_cancel" type="object" states="uploaded"
+                    string="Cancel Payments"/>
                 <field name="state" widget="statusbar"/>
             </header>
             <sheet>


### PR DESCRIPTION
Replaces #376 as there's no possibility of uploading changes in it (and the commit history in the other PR was a bit dirty).

I have fixed also 2 little things (a return and the import of the tests), so if everything goes right, I will merge directly, assuming the previous approval + my approval.