### PR TITLE
[10.0][IMP] account_banking*: Show identifiers at payment mode level

### DIFF
--- a/account_banking_pain_base/README.rst
+++ b/account_banking_pain_base/README.rst
@@ -25,7 +25,18 @@ This module is part of the OCA/bank-payment suite.
 Configuration
 =============
 
-No configuration required.
+#. Go to Accounting > Configuration > Settings.
+#. On the fields "Initiating Party Issuer" and "Initiating Party Identifier",
+   in the section *SEPA/PAIN*, you can fill the corresponding identifiers.
+
+If your country requires several identifiers (like Spain), you must:
+
+#. Go to *Accounting > Configuration > Settings*.
+#. On the section *SEPA/PAIN*, check the mark "Multiple identifiers".
+#. Now go to *Accounting > Configuration > Management > Payment Modes*.
+#. Create a payment mode for your specific bank.
+#. Fill the specific identifiers on the fields "Initiating Party Identifier"
+   and "Initiating Party Issuer".
 
 Usage
 =====
@@ -34,7 +45,7 @@ See 'readme' files of the OCA/bank-payment suite.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/173/9.0
+   :target: https://runbot.odoo-community.org/runbot/173/10.0
 
 Known issues / Roadmap
 ======================
@@ -70,10 +81,12 @@ Maintainer
 
 .. image:: http://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_banking_pain_base/__manifest__.py
+++ b/account_banking_pain_base/__manifest__.py
@@ -1,26 +1,26 @@
 # -*- coding: utf-8 -*-
-# © 2013-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
-# © 2014 Tecnativa - Pedro M. Baeza
-# © 2016 Tecnativa - Antonio Espinosa
+# Copyright 2013-2016 Akretion - Alexis de Lattre
+# Copyright 2014-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2016 Tecnativa - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "
               "Tecnativa, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/bank-payment',
-    'contributors': ['Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>'],
     'category': 'Hidden',
     'depends': ['account_payment_order'],
     'external_dependencies': {
         'python': ['unidecode', 'lxml'],
     },
     'data': [
+        'security/security.xml',
         'views/account_payment_line.xml',
         'views/account_payment_order.xml',
         'views/bank_payment_line_view.xml',

--- a/account_banking_pain_base/models/account_config_settings.py
+++ b/account_banking_pain_base/models/account_config_settings.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, fields
@@ -12,3 +13,10 @@ class AccountConfigSettings(models.TransientModel):
         related='company_id.initiating_party_issuer')
     initiating_party_identifier = fields.Char(
         related='company_id.initiating_party_identifier')
+    group_pain_multiple_identifier = fields.Boolean(
+        string='Multiple identifiers',
+        implied_group='account_banking_pain_base.'
+                      'group_pain_multiple_identifier',
+        help="Enable this option if your country requires several SEPA/PAIN "
+             "identifiers like in Spain.",
+    )

--- a/account_banking_pain_base/security/security.xml
+++ b/account_banking_pain_base/security/security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="group_pain_multiple_identifier" model="res.groups">
+        <field name="name">SEPA/PAIN Identifiers on Payment Modes</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+</odoo>
+

--- a/account_banking_pain_base/views/account_config_settings.xml
+++ b/account_banking_pain_base/views/account_config_settings.xml
@@ -12,9 +12,10 @@
     <field name="inherit_id" ref="account.view_account_config_settings"/>
     <field name="arch" type="xml">
         <xpath expr="//separator[@name='analytic_account']" position="before">
-            <group name="pain">
+            <group name="pain" string="SEPA/PAIN">
                 <field name="initiating_party_identifier"/>
                 <field name="initiating_party_issuer"/>
+                <field name="group_pain_multiple_identifier"/>
             </group>
         </xpath>
     </field>

--- a/account_banking_pain_base/views/account_payment_mode.xml
+++ b/account_banking_pain_base/views/account_payment_mode.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright (C) 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
-  © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
+  Copyright 2015-2017 Tecnativa
   License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
@@ -13,9 +13,8 @@
     <field name="inherit_id" ref="account_payment_order.account_payment_mode_form"/>
     <field name="arch" type="xml">
         <group name="main" position="inside">
-            <!-- To be set visible in the localisation modules that need it -->
-            <field name="initiating_party_identifier" invisible="1"/>
-            <field name="initiating_party_issuer" invisible="1"/>
+            <field name="initiating_party_identifier" groups="account_banking_pain_base.group_pain_multiple_identifier"/>
+            <field name="initiating_party_issuer" groups="account_banking_pain_base.group_pain_multiple_identifier"/>
         </group>
     </field>
 </record>

--- a/account_banking_sepa_direct_debit/README.rst
+++ b/account_banking_sepa_direct_debit/README.rst
@@ -33,10 +33,32 @@ This module is part of the OCA/bank-payment suite.
 Configuration
 =============
 
-Create a Payment Mode dedicated to SEPA Direct Debit and select the
-Payment Method *SEPA Direct Debit for customers* (which is automatically
-created upon module installation) and check that this payment method
-uses the proper version of PAIN.
+For setting the SEPA creditor identifier:
+
+#. Go to Accounting > Configuration > Settings.
+#. On the field "SEPA Creditor Identifier" in the section *SEPA/PAIN*, you can
+   fill the corresponding identifier.
+
+If your country requires several identifiers (like Spain), you must:
+
+#. Go to *Accounting > Configuration > Settings*.
+#. On the section *SEPA/PAIN*, check the mark "Multiple identifiers".
+#. Now go to *Accounting > Configuration > Management > Payment Modes*.
+#. Create a payment mode for your specific bank.
+#. Fill the specific identifier on the field "SEPA Creditor Identifier".
+
+For defining a payment mode that uses SEPA direct debit:
+
+#. Go to *Accounting > Configuration > Management > Payment Modes*.
+#. Create a record.
+#. Select the Payment Method *SEPA Direct Debit for customers* (which is
+   automatically created upon module installation).
+#. Check that this payment method uses the proper version of PAIN.
+#. If not, go *Accounting > Configuration > Management > Payment Methods*.
+#. Locate the "SEPA Direct Debit for customers" record and open it.
+#. Change the "PAIN version" according your needs.
+#. If you need to handle several PAIN versions, just duplicate the payment
+   method adjusting this field on each for having them.
 
 Usage
 =====
@@ -83,10 +105,12 @@ Maintainer
 
 .. image:: http://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-# © 2013-2016 Akretion (www.akretion.com)
-# © 2014 Tecnativa - Pedro M. Baeza
-# © 2016 Tecnativa - Antonio Espinosa
+# Copyright 2013-2016 Akretion (www.akretion.com)
+# Copyright 2014-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2016 Tecnativa - Antonio Espinosa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Banking SEPA Direct Debit',
     'summary': 'Create SEPA files for Direct Debit',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Tecnativa, "

--- a/account_banking_sepa_direct_debit/models/account_payment_mode.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_mode.py
@@ -21,13 +21,6 @@ class AccountPaymentMode(models.Model):
              "- a 3-letters business code\n"
              "- a country-specific identifier")
 
-    def _sepa_type_get(self):
-        res = super(AccountPaymentMode, self)._sepa_type_get()
-        if not res:
-            if self.type.code and self.type.code.startswith('pain.008'):
-                res = 'sepa_direct_debit'
-        return res
-
     @api.multi
     @api.constrains('sepa_creditor_identifier')
     def _check_sepa_creditor_identifier(self):

--- a/account_banking_sepa_direct_debit/views/account_payment_mode.xml
+++ b/account_banking_sepa_direct_debit/views/account_payment_mode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- © 2015 Antiun Ingenieria S.L. - Antonio Espinosa
-     © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+<!-- Copyright 2015-2017 Tecnativa
+     Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
 <odoo>
 
@@ -11,10 +11,7 @@
     <field name="inherit_id" ref="account_banking_pain_base.account_payment_mode_form"/>
     <field name="arch" type="xml">
         <group name="main" position="inside">
-            <field name="sepa_creditor_identifier" invisible="1"/>
-            <!-- This field should be set visible by localization modules
-            for countries that may have several sepa_creditor_identifier for
-            the same company (I guess only Spain) -->
+            <field name="sepa_creditor_identifier" groups="account_banking_pain_base.group_pain_multiple_identifier"/>
         </group>
     </field>
 </record>


### PR DESCRIPTION
There's not too much sense to have a mini localization module that shows these fields as they are totally optional. Even more, if you have a multi-company DB with several localizations, including one that needs these fields, then it will be shown in the rest of the companies too.

@alexis-via please accept this. They were shown on 8.0, and you made this trick for hiding them on v9. It's not fair to require an extra l10n_es_* module for showing them.

cc @sbidoul 