### PR TITLE
[FIX][10.0] account_banking_mandate: onchange return value missing

### DIFF
--- a/account_banking_mandate/__manifest__.py
+++ b/account_banking_mandate/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking Mandate',
     'summary': 'Banking mandates',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'license': 'AGPL-3',
     'author': "Compassion CH, "
               "Tecnativa, "

--- a/account_banking_mandate/models/account_invoice.py
+++ b/account_banking_mandate/models/account_invoice.py
@@ -65,7 +65,7 @@ class AccountInvoice(models.Model):
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
         """Select by default the first valid mandate of the partner"""
-        super(AccountInvoice, self)._onchange_partner_id()
+        res = super(AccountInvoice, self)._onchange_partner_id()
         if (
                 self.type == 'out_invoice' and
                 self.partner_id.customer_payment_mode_id.
@@ -81,6 +81,7 @@ class AccountInvoice(models.Model):
                 self.mandate_id = mandates[0]
         else:
             self.mandate_id = False
+        return res
 
     @api.onchange('payment_mode_id')
     def payment_mode_id_change(self):


### PR DESCRIPTION
This PR fixes the following issue:

**Scenario**
On a fresh database install module "`account`". Do not install "`account_banking_mandate`" yet.
Enable group "`A warning can be set on a partner (Account)`" for the user.
Open the Customer form and display the Internal Notes tab.
Set a blocking message for this customer.
Create a new invoice, set the same Customer as above, verify that the blocking message is shown.

**Bug**
Install module "`account_banking_mandate`".
Create a new invoice, set the same Customer as above, verify that the blocking message is NOT shown anymore.

**Proposal**
Actually the method `def _onchange_partner_id()` calls the super without propagating its returned value (that returned value contains the warning message to be displayed). With this PR, the onchange method propagates the return value got from the super. As a result, the blocking message will be shown correctly.
