### PR TITLE
Correct SK (Slovakia) IBAN number spec

### DIFF
--- a/account_banking/sepa/iban.py
+++ b/account_banking/sepa/iban.py
@@ -255,7 +255,7 @@ class IBAN(str):
         'SI': BBANFormat('CCCCCAAAAAAAAVV', '%C-%A%V', ),
         # Slovakia uses two different format for local display. We stick with
         # their formal BBAN specs
-        'SK': BBANFormat('BBBBPPPPPPAAAAAAAAAAAA', '%B%P%A'),
+        'SK': BBANFormat('BBBBAAAAAAAAAAAAAAAA', '%B%A'),
         # San Marino: No information for display of BBAN, so stick with IBAN
         'SM': BBANFormat('WBBBBBCCCCCCAAAAAAAAAAAAV', '%I'),
         'TN': BBANFormat('BBCCCAAAAAAAAAAAAAVV', '%B %C %A %V'),


### PR DESCRIPTION
When importing a bank statement with a payment from a bank account from Slovakia (SK), the import crashed, because the BBAN format in sepa.py did not meet the IBAN specs for Slovakia. I adapted in this pull request.