### PR TITLE
[10.0][account_banking_mandate] if a mandate is linked to the bank account used, put it automatically on the payment line

### DIFF
--- a/account_banking_mandate/README.rst
+++ b/account_banking_mandate/README.rst
@@ -60,6 +60,7 @@ Contributors
 * Alexandre Fayolle
 * Stéphane Bidoul <stephane.bidoul@acsone.eu>
 * Sergio Teruel (Incaser) <sergio@incaser.es>
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
 
 Maintainer
 ----------

--- a/account_banking_mandate/__manifest__.py
+++ b/account_banking_mandate/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking Mandate',
     'summary': 'Banking mandates',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'license': 'AGPL-3',
     'author': "Compassion CH, "
               "Tecnativa, "

--- a/account_banking_mandate/models/account_move_line.py
+++ b/account_banking_mandate/models/account_move_line.py
@@ -19,4 +19,11 @@ class AccountMoveLine(models.Model):
         if payment_order.payment_type == 'inbound' and self.mandate_id:
             vals['mandate_id'] = self.mandate_id.id
             vals['partner_bank_id'] = self.mandate_id.partner_bank_id.id
+        partner_bank_id = vals.get('partner_bank_id', False)
+        if partner_bank_id and 'mandate_id' not in vals:
+            mandate = self.env['account.banking.mandate'].search(
+                [('partner_bank_id', '=', partner_bank_id),
+                 ('state', '=', 'valid')], limit=1)
+            if mandate:
+                vals['mandate_id'] = mandate.id
         return vals


### PR DESCRIPTION
In 8.0, if a mandate was linked to a banking account, when creating a payment line with this account, the mandate was automatically set: https://github.com/OCA/bank-payment/blob/8.0/account_banking_mandate/models/payment_line.py#L36

Unfortunately this behavior was lost during migration process. 

This PR intends to re-introduce it.

Thanks to @jbeficent for its help.