### PR TITLE
[FIX][9.0] Migration script

### DIFF
--- a/account_payment_order/__openerp__.py
+++ b/account_payment_order/__openerp__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '9.0.1.2.0',
+    'version': '9.0.1.3.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/migrations/9.0.1.0.0/pre-migration.py
+++ b/account_payment_order/migrations/9.0.1.0.0/pre-migration.py
@@ -61,21 +61,17 @@ column_renames_payment_transfer = {
 
 # They are being handled after module rename, so source module name is correct
 EXISTING_PAYMENT_MODE_TYPE_XML_IDS = {
-    'account_payment_order.manual_bank_tranfer': (
-        'account.account_payment_method_manual_out',
-    ),
-    'account_payment_order.manual_direct_debit': (
-        'account.account_payment_method_manual_in',
-    ),
+    'account_payment_order.manual_bank_tranfer':
+    'account.account_payment_method_manual_out',
+    'account_payment_order.manual_direct_debit':
+    'account.account_payment_method_manual_in'
 }
 
 TO_CREATE_PAYMENT_MODE_TYPE_XML_IDS = {
-    'account_banking_sepa_direct_debit.export_sdd_008_001_02': (
-        'account_banking_sepa_direct_debit.sepa_direct_debit',
-    ),
-    'account_banking_sepa_credit_transfer.export_sepa_sct_001_001_03': (
-        'account_banking_sepa_credit_transfer.sepa_credit_transfer',
-    ),
+    'account_banking_sepa_direct_debit.export_sdd_008_001_02':
+    'account_banking_sepa_direct_debit.sepa_direct_debit',
+    'account_banking_sepa_credit_transfer.export_sepa_sct_001_001_03':
+    'account_banking_sepa_credit_transfer.sepa_credit_transfer',
 }
 
 
@@ -108,7 +104,7 @@ def migrate_payment_mode_types(env):
         # the same goal
         imr = imr_obj.search([
             ('res_id', '=', row[0]),
-            ('model', '=', 'payment_mode_type'),
+            ('model', '=', 'payment.mode.type'),
         ])
         xml_id = "%s.%s" % (imr.module, imr.name)
         if xml_id in EXISTING_PAYMENT_MODE_TYPE_XML_IDS:


### PR DESCRIPTION
Model name is invalid, and xml ids map to tuples of length 1 instead of a string because of trailing commas.