### PR TITLE
[10.0] account_payment_order: allow blocking direct payment on invoices

### DIFF
--- a/account_payment_order/README.rst
+++ b/account_payment_order/README.rst
@@ -34,6 +34,9 @@ This module also adds a button *Add to Payment Order* on supplier invoices and a
 
 You can print a Payment Order via the menu Accounting > Payments > Payment Orders and then select the payment oder to print.
 
+You can block the usage of a journal through the Register Payment wizard on an invoice by un-checking the flag "Allow Direct Payment"
+in the advanced settings of the journal.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/173/10.0
@@ -72,6 +75,7 @@ Contributors
 * Jose María Alzaga <jose.alzaga@aselcis.com>
 * Meyomesse Gilles <meyomesse.gilles@gmail.com>
 * Carlos Dauden
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
 
 Maintainer
 ----------

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -28,6 +28,7 @@
         'security/ir.model.access.csv',
         'wizard/account_payment_line_create_view.xml',
         'wizard/account_invoice_payment_line_multi_view.xml',
+        'views/account_view.xml',
         'views/account_payment_mode.xml',
         'views/account_payment_order.xml',
         'views/account_payment_line.xml',

--- a/account_payment_order/models/__init__.py
+++ b/account_payment_order/models/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from . import account
+from . import account_payment
 from . import account_payment_mode
 from . import account_payment_order
 from . import account_payment_line

--- a/account_payment_order/models/account.py
+++ b/account_payment_order/models/account.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © 2013-2017 ACSONE SA (<http://acsone.eu>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    allow_direct_payment = fields.Boolean(
+        help="But checking this option, you allow to use this journal through"
+             " the Register Payment feature directly on an invoice",
+        default=True
+    )

--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © 2013-2017 ACSONE SA (<http://acsone.eu>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.onchange('payment_type')
+    def _onchange_payment_type(self):
+        res = super(AccountPayment, self)._onchange_payment_type()
+        res['domain']['journal_id'].append(('allow_direct_payment', '=', True))
+        return res

--- a/account_payment_order/views/account_view.xml
+++ b/account_payment_order/views/account_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="name">view_account_journal_form</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <field name="show_on_dashboard" position="after">
+                <field name="allow_direct_payment" attrs="{'invisible': [('type', 'not in', ['bank', 'cash'])]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds a flag on cash and banks journals.
This flag prevents the usage of the journal through the Register Payment wizard on an invoice.
The default value is False.