### PR TITLE
FIX : check if there are an partner in account bank

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -139,5 +139,4 @@ class AccountPaymentLine(models.Model):
         if self.bank_account_required and not self.partner_bank_id.partner_id:
             raise UserError(_(
                 'Missing Partner in bank account : %s') % 
-                            self.partner_bank_id.acc_number
-        )
+                            self.partner_bank_id.acc_number)

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -136,7 +136,7 @@ class AccountPaymentLine(models.Model):
         if self.bank_account_required and not self.partner_bank_id:
             raise UserError(_(
                 'Missing Partner Bank Account on payment line %s') % self.name)
-        if not self.partner_bank_id.partner_id:
+        if self.bank_account_required and not self.partner_bank_id.partner_id:
             raise UserError(_(
                 'Missing Partner in bank account : %s') % self.partner_bank_id.acc_number
         ))

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -138,5 +138,6 @@ class AccountPaymentLine(models.Model):
                 'Missing Partner Bank Account on payment line %s') % self.name)
         if self.bank_account_required and not self.partner_bank_id.partner_id:
             raise UserError(_(
-                'Missing Partner in bank account : %s') % self.partner_bank_id.acc_number
-        ))
+                'Missing Partner in bank account : %s') % 
+                            self.partner_bank_id.acc_number
+        )

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -136,3 +136,7 @@ class AccountPaymentLine(models.Model):
         if self.bank_account_required and not self.partner_bank_id:
             raise UserError(_(
                 'Missing Partner Bank Account on payment line %s') % self.name)
+        if not self.partner_bank_id.partner_id:
+            raise UserError(_(
+                'Missing Partner in bank account : %s') % self.partner_bank_id.acc_number
+        ))


### PR DESCRIPTION
if there are not partner in res.partner.bank, `def generate_party_block(` make un error when `_prepare_field` is call.