### PR TITLE
[9.0][MIG] account_payment_mode: Migration script for force recompute account bank types

### DIFF
--- a/account_payment_mode/migrations/9.0.1.0.0/post-migration.py
+++ b/account_payment_mode/migrations/9.0.1.0.0/post-migration.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    if not version:
+        return
+    # Force recompute acc_type, issue with inheritance chain between base
+    # module and base_iban with this module
+    if openupgrade.is_module_installed(env.cr, 'base_iban'):
+        env['res.partner.bank'].search([])._compute_acc_type()


### PR DESCRIPTION
cc @Tecnativa
This is required in v9 this module does acc_type field store but base_iban module rewrite function "_compute_acc_type" and both of them depend of account, so when the field is recomputed write and wrong acc_type if base_iban is installed.
@pedrobaeza Can you review please??
**base:**
https://github.com/OCA/OCB/blob/9.0/openerp/addons/base/res/res_bank.py#L79
**base_iban:**
https://github.com/OCA/OCB/blob/9.0/addons/base_iban/models/res_partner_bank.py#L48
**account_payment_mode:**
https://github.com/OCA/bank-payment/blob/9.0/account_payment_mode/models/res_partner_bank.py#L13