### PR TITLE
[IMP] account_payment_order: Display partner account type in payment …

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -58,6 +58,10 @@ class AccountPaymentLine(models.Model):
     # v8 field : state
     bank_line_id = fields.Many2one(
         'bank.payment.line', string='Bank Payment Line', readonly=True)
+    partner_bank_type = fields.Char(
+        related='partner_bank_id.acc_type',
+        readonly=True,
+    )
 
     _sql_constraints = [(
         'name_company_unique',

--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -45,6 +45,7 @@
             <field name="partner_id"/>
             <field name="communication"/>
             <field name="partner_bank_id"/>
+            <field name="partner_bank_type" />
             <field name="ml_maturity_date"/>
             <field name="date"/>
             <field name="amount_currency" string="Amount"/>


### PR DESCRIPTION
…order line tree view.

Currently, a payment order is considered as SEPA  only if all partner accounts are IBAN valid and the currency on all payment line is Euro.

with this commit, it's easier to understand why a payment order it's not in SEPA format.

