### PR TITLE
Use bank.payment.line reference in Payment Order Move Lines

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.5.0',
+    'version': '10.0.1.6.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -375,6 +375,8 @@ class AccountPaymentOrder(models.Model):
             ref = _('Payment order %s') % self.name
         else:
             ref = _('Debit order %s') % self.name
+        if bank_lines and len(bank_lines) == 1:
+            ref += " - " + bank_lines.name
         if self.payment_mode_id.offsetting_account == 'bank_account':
             journal_id = self.journal_id.id
         elif self.payment_mode_id.offsetting_account == 'transfer_account':


### PR DESCRIPTION
When closing an account.payment.order the move generated have in the reference field, the name of the payment order.

When payment are not grouped by date it generates a lot of moves that have the same reference and we propose to use instead the bank.payment.line reference in order to differentiate those moves.

We think it makes more sense for reconciling. If several bank.payment.line are groupped in a same move we do not change the previous behaviour.