### PR TITLE
[8.0] Adapts SEPA files to new rules that takes effect in November 19th

### DIFF
--- a/account_banking_pain_base/README.rst
+++ b/account_banking_pain_base/README.rst
@@ -56,7 +56,7 @@ Contributors
 
 * Alexis de Lattre
 * Pedro M. Baeza
-* Stéphane Bidoul              <stephane.bidoul@acsone.eu>
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
 * Ignacio Ibeas - Acysos S.L.
 * Alexandre Fayolle
 * Raphaël Valyi

--- a/account_banking_pain_base/README.rst
+++ b/account_banking_pain_base/README.rst
@@ -56,13 +56,14 @@ Contributors
 
 * Alexis de Lattre
 * Pedro M. Baeza
-* Stéphane Bidoul		<stephane.bidoul@acsone.eu>
+* Stéphane Bidoul              <stephane.bidoul@acsone.eu>
 * Ignacio Ibeas - Acysos S.L.
 * Alexandre Fayolle
 * Raphaël Valyi
 * Sandy Carter
 * Stefan Rijnhart (Therp)
 * Antonio Espinosa <antonioea@antiun.com>
+* Omar Castiñeira <omar@comunitea.com>
 
 Maintainer
 ----------

--- a/account_banking_pain_base/__openerp__.py
+++ b/account_banking_pain_base/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '8.0.0.4.0',
+    'version': '8.0.0.4.1',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "

--- a/account_banking_sepa_credit_transfer/README.rst
+++ b/account_banking_sepa_credit_transfer/README.rst
@@ -72,6 +72,7 @@ Contributors
 * Erwin van der Ploeg
 * Sandy Carter
 * Antonio Espinosa <antonioea@antiun.com>
+* Omar Castiñeira <omar@comunitea.com>
 
 Maintainer
 ----------

--- a/account_banking_sepa_credit_transfer/__openerp__.py
+++ b/account_banking_sepa_credit_transfer/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking SEPA Credit Transfer',
     'summary': 'Create SEPA XML files for Credit Transfers',
-    'version': '8.0.0.5.0',
+    'version': '8.0.0.5.1',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/account_banking_sepa_credit_transfer/wizard/export_sepa.py
+++ b/account_banking_sepa_credit_transfer/wizard/export_sepa.py
@@ -160,13 +160,7 @@ class BankingExportSepaWizard(models.TransientModel):
                     }, gen_args)
             self.generate_party_block(
                 payment_info_2_0, 'Dbtr', 'B',
-                'self.payment_order_ids[0].mode.bank_id.partner_id.'
-                'name',
-                'self.payment_order_ids[0].mode.bank_id.acc_number',
-                'self.payment_order_ids[0].mode.bank_id.bank.bic or '
-                'self.payment_order_ids[0].mode.bank_id.bank_bic',
-                {'self': self},
-                gen_args)
+                self.payment_order_ids[0].mode.bank_id, gen_args)
             charge_bearer_2_24 = etree.SubElement(payment_info_2_0, 'ChrgBr')
             charge_bearer_2_24.text = self.charge_bearer
             transactions_count_2_4 = 0
@@ -201,9 +195,7 @@ class BankingExportSepaWizard(models.TransientModel):
                         % (line.partner_id.name, line.name))
                 self.generate_party_block(
                     credit_transfer_transaction_info_2_27, 'Cdtr',
-                    'C', 'line.partner_id.name', 'line.bank_id.acc_number',
-                    'line.bank_id.bank.bic or '
-                    'line.bank_id.bank_bic', {'line': line}, gen_args)
+                    'C', line.bank_id, gen_args)
                 self.generate_remittance_info_block(
                     credit_transfer_transaction_info_2_27, line, gen_args)
             if pain_flavor in pain_03_to_05:

--- a/account_banking_sepa_direct_debit/README.rst
+++ b/account_banking_sepa_direct_debit/README.rst
@@ -72,6 +72,7 @@ Contributors
 * Sandy Carter
 * Antonio Espinosa <antonioea@antiun.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
+* Omar Castiñeira <omar@comunitea.com>
 
 
 Maintainer

--- a/account_banking_sepa_direct_debit/__openerp__.py
+++ b/account_banking_sepa_direct_debit/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking SEPA Direct Debit',
     'summary': 'Create SEPA files for Direct Debit',
-    'version': '8.0.0.5.0',
+    'version': '8.0.0.5.1',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/account_banking_sepa_direct_debit/wizard/export_sdd.py
+++ b/account_banking_sepa_direct_debit/wizard/export_sdd.py
@@ -212,12 +212,7 @@ class BankingExportSddWizard(models.TransientModel):
 
             self.generate_party_block(
                 payment_info_2_0, 'Cdtr', 'B',
-                'self.payment_order_ids[0].mode.bank_id.partner_id.'
-                'name',
-                'self.payment_order_ids[0].mode.bank_id.acc_number',
-                'self.payment_order_ids[0].mode.bank_id.bank.bic or '
-                'self.payment_order_ids[0].mode.bank_id.bank_bic',
-                {'self': self}, gen_args)
+                self.payment_order_ids[0].mode.bank_id, gen_args)
             charge_bearer_2_24 = etree.SubElement(payment_info_2_0, 'ChrgBr')
             charge_bearer_2_24.text = self.charge_bearer
             creditor_scheme_identification_2_27 = etree.SubElement(
@@ -289,11 +284,7 @@ class BankingExportSddWizard(models.TransientModel):
 
                 self.generate_party_block(
                     dd_transaction_info_2_28, 'Dbtr', 'C',
-                    'line.partner_id.name',
-                    'line.bank_id.acc_number',
-                    'line.bank_id.bank.bic or '
-                    'line.bank_id.bank_bic',
-                    {'line': line}, gen_args)
+                    line.bank_id, gen_args)
 
                 self.generate_remittance_info_block(
                     dd_transaction_info_2_28, line, gen_args)


### PR DESCRIPTION
Hi,

The November 19th takes effect some new rules in SEPA files, the unique rule that affects technically to 8.0 version, because in 9.0 and 10.0 it is done, is the "PstlAdr" in "Dbtr" node, this node is only required when the debtor is from Switzerland, Monaco, San Marino and the French overseas collectivities Mayotte, Saint Pierre and Miquelon.

In 9.0 and 10.0 versions this node is always present in SEPA files if debtor has country, I based my solution in these versions.

Regards.