### PR TITLE
[ADD] Bank name and bic to report_invoice

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Payment Partner',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'category': 'Banking addons',
     'license': 'AGPL-3',
     'summary': 'Adds payment mode on partners and invoices',

--- a/account_payment_partner/views/report_invoice.xml
+++ b/account_payment_partner/views/report_invoice.xml
@@ -9,6 +9,8 @@
             </p>
             <p t-if="o.partner_bank_id">
                 <strong>Bank Account:</strong>
+                <span t-field="o.partner_bank_id.bank_id.name" />
+                <span t-field="o.partner_bank_id.bank_id.bic" />
                 <span t-field="o.partner_bank_id.acc_number" />
             </p>
         </xpath>

--- a/account_payment_partner/views/report_invoice.xml
+++ b/account_payment_partner/views/report_invoice.xml
@@ -9,8 +9,7 @@
             </p>
             <p t-if="o.partner_bank_id">
                 <strong>Bank Account:</strong>
-                <span t-field="o.partner_bank_id.bank_id.name" />
-                <span t-field="o.partner_bank_id.bank_id.bic" />
+                <t t-esc="o.partner_bank_id.bank_id.name + ('' if not o.partner_bank_id.bank_id.bic else ' (' + o.partner_bank_id.bank_id.bic + ')')" />
                 <span t-field="o.partner_bank_id.acc_number" />
             </p>
         </xpath>


### PR DESCRIPTION
In account_payment_partner on the account invoice report.
Adds the bank name and BIC next to the existing account number.