### PR TITLE
[10.0][CHG] account_payment_partner: Prevent to delete bank account linked on invoices.

### DIFF
--- a/account_payment_partner/models/account_invoice.py
+++ b/account_payment_partner/models/account_invoice.py
@@ -16,6 +16,7 @@ class AccountInvoice(models.Model):
     bank_account_required = fields.Boolean(
         related='payment_mode_id.payment_method_id.bank_account_required',
         readonly=True)
+    partner_bank_id = fields.Many2one(ondelete='restrict')
 
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):


### PR DESCRIPTION
This module adds a conditional require attribute on the bank account field on invoices.
Despite this, it can be deleted.
So, this commit prevents to delete a bank account once it's linked to an invoice.