### PR TITLE
[8.0][FIX] account_payment_sale_stock: get invoice payment mode from picking

### DIFF
--- a/account_payment_sale_stock/__openerp__.py
+++ b/account_payment_sale_stock/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Account Payment Sale Stock module for OpenERP

--- a/account_payment_sale_stock/models/stock_picking.py
+++ b/account_payment_sale_stock/models/stock_picking.py
@@ -25,11 +25,20 @@ class StockPicking(models.Model):
     @api.model
     def _create_invoice_from_picking(self, picking, vals):
         # This will assure that stock_dropshipping_dual_invoice will work
-        inv_type = self.env.context.get('inv_type', 'out_invoice')
-        if picking and picking.sale_id and inv_type == 'out_invoice':
+        if picking and picking.sale_id:
             sale_order = picking.sale_id
             if sale_order.payment_mode_id:
                 vals['partner_bank_id'] = sale_order.payment_mode_id.bank_id.id
                 vals['payment_mode_id'] = sale_order.payment_mode_id.id
+            #a second chance to get the payment mode if not found at sale_order
+            if 'payment_mode_id' not in vals or not vals['payment_mode_id']:
+                #partner to invoice is not always the same partner of
+                #the picking, so we get the partner from vals
+                partner = self.env['res.partner'].browse(vals['partner_id'])
+                #and then we get the payment mode from partner
+                vals['payment_mode_id'] = partner.customer_payment_mode.id
+                if partner.customer_payment_mode.bank_id:
+                    vals['partner_bank_id'] = \
+                        partner.customer_payment_mode.bank_id.id
         return super(StockPicking, self)._create_invoice_from_picking(
             picking, vals)


### PR DESCRIPTION
When creating invoice from picking, if payment mode is not found on sale order, we should try to get it from partner's payment mode.