### PR TITLE
[FIX] Ensure that the test finds only one bank journal

### DIFF
--- a/account_payment_order/tests/test_payment_order.py
+++ b/account_payment_order/tests/test_payment_order.py
@@ -49,7 +49,7 @@ class TestPaymentOrder(TransactionCase):
 
         payment_order = self.env['account.payment.order'].search([])
         bank_journal = self.env['account.journal'].search(
-            [('type', '=', 'bank')])
+            [('type', '=', 'bank')], limit=1)
         # Set journal to allow cancelling entries
         bank_journal.update_posted = True
 


### PR DESCRIPTION
Previously it was possible to find multiple bank journals,
which caused singleton errors when the test tried to set values
on them.