### PR TITLE
[11.0][FIX] account_payment_partner: impossible to define if there was no company in partner

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Payment Partner',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Banking addons',
     'license': 'AGPL-3',
     'summary': 'Adds payment mode on partners and invoices',

--- a/account_payment_partner/models/res_partner.py
+++ b/account_payment_partner/models/res_partner.py
@@ -13,14 +13,12 @@ class ResPartner(models.Model):
     supplier_payment_mode_id = fields.Many2one(
         'account.payment.mode', string='Supplier Payment Mode',
         company_dependent=True,
-        domain="[('payment_type', '=', 'outbound'), "
-               "('company_id', '=', company_id)]",
+        domain="[('payment_type', '=', 'outbound')]",
         help="Select the default payment mode for this supplier.")
     customer_payment_mode_id = fields.Many2one(
         'account.payment.mode', string='Customer Payment Mode',
         company_dependent=True,
-        domain="[('payment_type', '=', 'inbound'), "
-               "('company_id', '=', company_id)]",
+        domain="[('payment_type', '=', 'inbound')]",
         help="Select the default payment mode for this customer.")
 
     @api.model


### PR DESCRIPTION
If there is a partner defined for all possible companies it does not allow to define a payment mode. I'm not sure if this is the best way, but it works.

cc @carlosdauden @jbeficent @alexis-via @pedrobaeza @sbidoul @etobella 