### PR TITLE
[8.0][FIX] Add signature_date for _check_valid_state constraint

### DIFF
--- a/account_banking_mandate/__openerp__.py
+++ b/account_banking_mandate/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking Mandate',
     'summary': 'Banking mandates',
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.2.1',
     'license': 'AGPL-3',
     'author': "Compassion CH, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -91,7 +91,7 @@ class AccountBankingMandate(models.Model):
                       ) % mandate.unique_mandate_reference)
 
     @api.multi
-    @api.constrains('state', 'partner_bank_id')
+    @api.constrains('state', 'partner_bank_id', 'signature_date')
     def _check_valid_state(self):
         for mandate in self:
             if mandate.state == 'valid':


### PR DESCRIPTION
We have had problems with users not being able to generate payment files because of "suddenly" missing signature date's for valid mandates. 

I think it is best to also add "signature_date" as a constrains parameter to the "_check_valid_state" constraint on account.banking.mandate, it makes sense that if "signature_date" is part of the constraint check itself to also check the constraint when the field updates.

For our case it would prevent the mandate from removing the "signature_date" when the mandate is still considered "valid"