### PR TITLE
10.0 [FIX] account_payment_partner: Invoice report

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Payment Partner',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'category': 'Banking addons',
     'license': 'AGPL-3',
     'summary': 'Adds payment mode on partners and invoices',

--- a/account_payment_partner/views/report_invoice.xml
+++ b/account_payment_partner/views/report_invoice.xml
@@ -9,7 +9,9 @@
             </p>
             <p t-if="o.partner_bank_id">
                 <strong>Bank Account:</strong>
-                <t t-esc="o.partner_bank_id.bank_id.name + ('' if not o.partner_bank_id.bank_id.bic else ' (' + o.partner_bank_id.bank_id.bic + ')')" />
+                <t t-if="o.partner_bank_id.bank_id">
+                    <t t-esc="o.partner_bank_id.bank_id.name + ('' if not o.partner_bank_id.bank_id.bic else ' (' + o.partner_bank_id.bank_id.bic + ')')" />
+                </t>
                 <span t-field="o.partner_bank_id.acc_number" />
             </p>
         </xpath>


### PR DESCRIPTION
**Actual behaviour**
- If you print the report and if the field `bank_id` of the `partner_bank_id` is not set, you'll have a traceback. It's because the `bank_id` field is not mandatory.
So the report try to concatenate `False` (due to not filled value) with a `string` and raise an exception.

**Fix**
- Just use a `t-if` to check if the value is set.