### PR TITLE
[11.0] [FIX] account_banking_mandate: _onchange_partner_id missing return

### DIFF
--- a/account_banking_mandate/__manifest__.py
+++ b/account_banking_mandate/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking Mandate',
     'summary': 'Banking mandates',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'license': 'AGPL-3',
     'author': "Compassion CH, "
               "Tecnativa, "

--- a/account_banking_mandate/models/account_invoice.py
+++ b/account_banking_mandate/models/account_invoice.py
@@ -73,8 +73,9 @@ class AccountInvoice(models.Model):
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
         """Select by default the first valid mandate of the partner"""
-        super(AccountInvoice, self)._onchange_partner_id()
+        res = super(AccountInvoice, self)._onchange_partner_id()
         self.set_mandate()
+        return res
 
     @api.onchange('payment_mode_id')
     def _onchange_payment_mode_id(self):


### PR DESCRIPTION
Lack of return causes bad behaviour on other modules when this one is installed.