### PR TITLE
[10.0] Added Instruction Identification (InstrId)

### DIFF
--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -129,6 +129,11 @@ class AccountPaymentOrder(models.Model):
                     payment_info, 'CdtTrfTxInf')
                 payment_identification = etree.SubElement(
                     credit_transfer_transaction_info, 'PmtId')
+                instruction_identification = etree.SubElement(
+                    payment_identification, 'InstrId')
+                instruction_identification.text = self._prepare_field(
+                    'Instruction Identification', 'line.name',
+                    {'line': line}, 35, gen_args=gen_args)
                 end2end_identification = etree.SubElement(
                     payment_identification, 'EndToEndId')
                 end2end_identification.text = self._prepare_field(


### PR DESCRIPTION
Some banks (or at least BCV - Banque Cantonale Vaudoise) require the presence of the field Instruction Identification ( CdtTrfTxInf/PmtId/InstrId ), as described in item 2.29 of document "Swiss Implementation Guidelines Customer Credit Transfer Initiation (pain.001)".

The documentation provided by SIX also recommends its use:
"Recommendation: Should be used and be unique within the B-Level. Only the SWIFT character set is permitted for this element (see section 2.4.1)."

The max allowed length of the field is 35 characters which is being respected in this patch and on the principle of simplicity the field contains the same value as "End to End Identification" which uses the Odoo field "bank.payment.line.name".

This was tested with Credit Suisse, Post Finance and BCV as mentioned.

More information about "Instruction Identification", copied from the specification:
ISO Definition: Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.
Usage: the instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction.