### PR TITLE
[10.0][FIX] account_banking_pain_base. Only unidecode unicode objects.

### DIFF
--- a/account_banking_pain_base/__manifest__.py
+++ b/account_banking_pain_base/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "

--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -92,7 +92,8 @@ class AccountPaymentOrder(models.Model):
             # cf section 1.4 "Character set" of the SEPA Credit Transfer
             # Scheme Customer-to-bank guidelines
             if gen_args.get('convert_to_ascii'):
-                value = unidecode(value)
+                if isinstance(value, unicode):
+                    value = unidecode(value)
                 unallowed_ascii_chars = [
                     '"', '#', '$', '%', '&', '*', ';', '<', '>', '=', '@',
                     '[', ']', '^', '_', '`', '{', '}', '|', '~', '\\', '!']


### PR DESCRIPTION
The present code gives warnings when trying to unidecode non unicode strings. This gives yellow branches in runbot. The fix in this branch prevents unneeded warnings (and unneeded tries to decode strings that are utf-8 already).