### PR TITLE
[10.0] Usability of account_payment_order: access journal entries via top-right button

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.3.2',
+    'version': '10.0.1.3.3',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -91,7 +91,15 @@ class AccountPaymentOrder(models.Model):
     move_ids = fields.One2many(
         'account.move', 'payment_order_id', string='Journal Entries',
         readonly=True)
+    move_count = fields.Integer(
+        compute='_compute_move_count', readonly=True, store=True,
+        string="# of Journal Entries")
     description = fields.Char()
+
+    @api.depends('move_ids')
+    def _compute_move_count(self):
+        for order in self:
+            order.move_count = len(order.move_ids)
 
     @api.multi
     def unlink(self):
@@ -488,3 +496,22 @@ class AccountPaymentOrder(models.Model):
             blines.reconcile_payment_lines()
             if post_move:
                 move.post()
+
+    def open_moves(self):
+        self.ensure_one()
+        action = self.env['ir.actions.act_window'].for_xml_id(
+            'account', 'action_move_journal_line')
+        action.update({
+            'context': self._context,
+            'views': False,
+            'view_id': False,
+            })
+        if self.move_ids:
+            if len(self.move_ids) == 1:
+                action.update({
+                    'view_mode': 'form,tree',
+                    'res_id': self.move_ids[0].id,
+                    })
+            else:
+                action['domain'] = "[('id', 'in', %s)]" % self.move_ids.ids
+        return action

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -98,8 +98,14 @@ class AccountPaymentOrder(models.Model):
 
     @api.depends('move_ids')
     def _compute_move_count(self):
+        move_data = self.env['account.move'].read_group(
+            [('payment_order_id', 'in', self.ids)],
+            ['payment_order_id'], ['payment_order_id'])
+        mapped_data = dict([
+            (move['payment_order_id'][0], move['payment_order_id_count'])
+            for move in move_data])
         for order in self:
-            order.move_count = len(order.move_ids)
+            order.move_count = mapped_data.get(order.id, 0)
 
     @api.multi
     def unlink(self):

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -26,6 +26,14 @@
                 <field name="state" widget="statusbar"/>
             </header>
             <sheet>
+                <div class="oe_button_box" name="button_box">
+                    <button name="open_moves" type="object"
+                        attrs="{'invisible': [('move_count', '=', 0)]}"
+                        class="oe_stat_button" icon="fa-pencil-square-o">
+                        <field name="move_count" string="Journal Entries"
+                            widget="statinfo"/>
+                    </button>
+                </div>
                 <div class="oe_title">
                     <label for="name" class="oe_edit_only"/>
                     <h1><field name="name"/></h1>
@@ -60,9 +68,6 @@
                     <page name="bank-payment-lines" string="Bank Payment Lines">
                         <field name="bank_line_ids"
                             context="{'default_payment_type': payment_type}"/>
-                    </page>
-                    <page name="moves" string="Transfer Journal Entries">
-                        <field name="move_ids"/>
                     </page>
                 </notebook>
             </sheet>


### PR DESCRIPTION
This is a small usability improvement in the module account_payment_order: access journal entries via top-right button (that display the number of moves) instead of a dedicated tab. Advantage: you can access the journal entries full-screen, instead of inside a pop-up.