### PR TITLE
[10.0][FIX] Split account move generated for SEPA direct debits per sequence_type

### DIFF
--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -8,7 +8,7 @@
 {
     'name': 'Account Banking SEPA Direct Debit',
     'summary': 'Create SEPA files for Direct Debit',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Tecnativa, "

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -260,10 +260,11 @@ class AccountPaymentOrder(models.Model):
             first_mandates.write({
                 'recurrent_sequence_type': 'recurring',
                 })
-            first_mandates.message_post(_(
-                "Automatically switched from <b>First</b> to <b>Recurring</b> "
-                "when the debit order "
-                "<a href=# data-oe-model=account.payment.order "
-                "data-oe-id=%d>%s</a> has been marked as uploaded.")
-                % (order.id, order.name))
+            for first_mandate in first_mandates:
+                first_mandate.message_post(_(
+                    "Automatically switched from <b>First</b> to "
+                    "<b>Recurring</b> when the debit order "
+                    "<a href=# data-oe-model=account.payment.order "
+                    "data-oe-id=%d>%s</a> has been marked as uploaded.")
+                    % (order.id, order.name))
         return res

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -2,7 +2,7 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api, _
+from odoo import api, models, _
 from odoo.exceptions import UserError
 from lxml import etree
 
@@ -227,32 +227,43 @@ class AccountPaymentOrder(models.Model):
             xml_root, gen_args)
 
     @api.multi
-    def finalize_sepa_file_creation(self, xml_root, gen_args):
-        """Save the SEPA Direct Debit file: mark all payments in the file
-        as 'sent'. Write 'last debit date' on mandate and set oneoff
-        mandate to expired.
+    def generated2uploaded(self):
+        """Write 'last debit date' on mandates
+        Set mandates from first to recurring
+        Set oneoff mandates to expired
         """
+        # I call super() BEFORE updating the sequence_type
+        # from first to recurring, so that the account move
+        # is generated BEFORE, which will allow the split
+        # of the account move per sequence_type
+        res = super(AccountPaymentOrder, self).generated2uploaded()
         abmo = self.env['account.banking.mandate']
-        to_expire_mandates = abmo.browse([])
-        first_mandates = abmo.browse([])
-        all_mandates = abmo.browse([])
-        for bline in self.bank_line_ids:
-            if bline.mandate_id in all_mandates:
-                continue
-            all_mandates += bline.mandate_id
-            if bline.mandate_id.type == 'oneoff':
-                to_expire_mandates += bline.mandate_id
-            elif bline.mandate_id.type == 'recurrent':
-                seq_type = bline.mandate_id.recurrent_sequence_type
-                if seq_type == 'final':
+        for order in self:
+            to_expire_mandates = abmo.browse([])
+            first_mandates = abmo.browse([])
+            all_mandates = abmo.browse([])
+            for bline in order.bank_line_ids:
+                if bline.mandate_id in all_mandates:
+                    continue
+                all_mandates += bline.mandate_id
+                if bline.mandate_id.type == 'oneoff':
                     to_expire_mandates += bline.mandate_id
-                elif seq_type == 'first':
-                    first_mandates += bline.mandate_id
-        all_mandates.write(
-            {'last_debit_date': fields.Date.context_today(self)})
-        to_expire_mandates.write({'state': 'expired'})
-        first_mandates.write({
-            'recurrent_sequence_type': 'recurring',
-            })
-        return super(AccountPaymentOrder, self).finalize_sepa_file_creation(
-            xml_root, gen_args)
+                elif bline.mandate_id.type == 'recurrent':
+                    seq_type = bline.mandate_id.recurrent_sequence_type
+                    if seq_type == 'final':
+                        to_expire_mandates += bline.mandate_id
+                    elif seq_type == 'first':
+                        first_mandates += bline.mandate_id
+            all_mandates.write(
+                {'last_debit_date': order.date_generated})
+            to_expire_mandates.write({'state': 'expired'})
+            first_mandates.write({
+                'recurrent_sequence_type': 'recurring',
+                })
+            first_mandates.message_post(_(
+                "Automatically switched from <b>First</b> to <b>Recurring</b> "
+                "when the debit order "
+                "<a href=# data-oe-model=account.payment.order "
+                "data-oe-id=%d>%s</a> has been marked as uploaded.")
+                % (order.id, order.name))
+        return res


### PR DESCRIPTION
In v8, the account move generated for SEPA direct debit was split per sequence type.
With the current code, it was not working any more because the mandates were switched from 'first' to 'recurring' upon generation of the payment file, but the move was generated later when the debit order is marked as uploaded (so, at that step, all mandates were seen as recurring).

With this PR, the mandates are switched from first to recurring AFTER generation of the account move. So the split of the account move per sequence_type is working again. And it's much better to do it at that step because, if you cancel the debit order when it is at the "generated" step, you will keep your mandates unchanged, which is a good thing.