### PR TITLE
[FIX] account_payment_order: Take payment mode from move

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.3.3',
+    'version': '10.0.1.3.4',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_invoice.py
+++ b/account_payment_order/models/account_invoice.py
@@ -47,6 +47,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def _prepare_new_payment_order(self, payment_mode=None):
         self.ensure_one()
+        if payment_mode is None:
+            payment_mode = self.env['account.payment.mode']
         vals = {
             'payment_mode_id': payment_mode.id or self.payment_mode_id.id,
         }
@@ -57,7 +59,6 @@ class AccountInvoice(models.Model):
     @api.multi
     def create_account_payment_line(self):
         apoo = self.env['account.payment.order']
-        aplo = self.env['account.payment.line']
         result_payorder_ids = []
         action_payment_type = 'debit'
         for inv in self:

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -15,6 +15,11 @@ class AccountMoveLine(models.Model):
     bank_payment_line_id = fields.Many2one(
         'bank.payment.line', string='Bank Payment Line',
         readonly=True)
+    payment_line_ids = fields.One2many(
+        comodel_name='account.payment.line',
+        inverse_name='move_line_id',
+        string="Payment lines",
+    )
 
     @api.multi
     def _prepare_payment_line_vals(self, payment_order):


### PR DESCRIPTION
When adding to a payment order from invoices, the payment mode considered is the one in the invoice, but once you have confirmed it, you can't change it, so if you change the payment mode in the journal
items, it doesn't make the difference.

With this change, this is taken into account for adding to the payment order properly.

@Tecnativa