### PR TITLE
[10.0][FIX] Don't store acc_type of res.partner.bank

### DIFF
--- a/account_payment_mode/__manifest__.py
+++ b/account_payment_mode/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Account Payment Mode',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'license': 'AGPL-3',
     'author': "Akretion,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/bank-payment',

--- a/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
+++ b/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    cr.execute('ALTER TABLE res_partner_bank DROP COLUMN acc_type')

--- a/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
+++ b/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
@@ -2,6 +2,7 @@
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+
 def migrate(cr, version):
     if not version:
         return

--- a/account_payment_mode/models/res_partner_bank.py
+++ b/account_payment_mode/models/res_partner_bank.py
@@ -8,6 +8,10 @@ from odoo import models, fields
 class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
 
-    # I also have to change the label of the field in the view
-    # I store the field, so that we can do groupby and search on it
-    acc_type = fields.Char(string='Bank Account Type', store=True)
+    # I change the label of the field in the view.
+    # I would also like to store the field to do easy groupby and search,
+    # but it's not possible because the compute method is inherited
+    # in base_iban (and maybe in other modules) and, when the field is
+    # initially computed+stored, it doesn't take into account the
+    # inherits of the method that compute this field
+    acc_type = fields.Char(string='Bank Account Type')

--- a/account_payment_mode/views/res_partner_bank.xml
+++ b/account_payment_mode/views/res_partner_bank.xml
@@ -25,19 +25,5 @@ detect wrong IBANs -->
     </field>
 </record>
 
-<record id="view_partner_bank_search" model="ir.ui.view">
-    <field name="name">account_payment_mode.res_partner_bank_search</field>
-    <field name="model">res.partner.bank</field>
-    <field name="inherit_id" ref="base.view_partner_bank_search"/>
-    <field name="arch" type="xml">
-        <field name="partner_id" position="after">
-            <group string="Group By" name="groupby">
-                <filter name="acc_type_groupby" string="Bank Account Type"
-                    context="{'group_by': 'acc_type'}"/>
-            </group>
-        </field>
-    </field>
-</record>
-
 
 </odoo>


### PR DESCRIPTION
We have a problem due to the fact that account_payment_mode adds store=True on the native computed field acc_type of res.partner.bank
This is particularly visible when you add the module on a database with existing accounts or when you migrate from v8 to v10 for example: even if you have the module base_iban, acc_type = 'bank' on IBAN accounts. This seems to be linked to the fact that when Odoo computes+stores the initial value of the field, it doesn't take into account the inherits of the native compute method, so it will not take into account the inherit in base_iban.

There are maybe better ways to fix this (add a search method ?) ; this PR is a first proposal to address this important problem.