### PR TITLE
[FIX] only drop column if it exists

### DIFF
--- a/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
+++ b/account_payment_mode/migrations/10.0.1.0.2/pre-migration.py
@@ -7,4 +7,4 @@ def migrate(cr, version):
     if not version:
         return
 
-    cr.execute('ALTER TABLE res_partner_bank DROP COLUMN acc_type')
+    cr.execute('ALTER TABLE res_partner_bank DROP COLUMN IF EXISTS acc_type')


### PR DESCRIPTION
without this, the migration breaks in databases where the field never was stored