### PR TITLE
[FIX] report should show the invoice number, not the move name

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '11.0.1.2.0',
+    'version': '11.0.1.2.1',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -76,7 +76,7 @@
                                 <span t-esc="get_bank_account_name(line.partner_bank_id)"/>
                             </td>
                             <td class="text-center">
-                                <span t-raw="'%s &lt;br&gt;' % line.move_line_id.move_id.name if line.move_line_id.move_id else ''"/>
+                                <span t-raw="'%s &lt;br&gt;' % line.move_line_id.invoice_id.number or line.move_line_id.move_id.name or ''"/>
                             </td>
                             <td class="text-center">
                                 <span t-field="line.date"/>


### PR DESCRIPTION
When I printed the report, I found that it shows the move name, but in some countries, the move name is not the same that the invoice number.
I think it is easier to show the invoice number.