### PR TITLE
[10.0] Several small usability improvements

### DIFF
--- a/account_payment_mode/views/account_payment_mode.xml
+++ b/account_payment_mode/views/account_payment_mode.xml
@@ -10,12 +10,11 @@
                 <field name="name"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="active"/>
-                <field name="payment_method_id" widget="selection"/>
+                <field name="payment_method_id"/>
                 <field name="payment_type"/>
                 <field name="bank_account_link"/>
                 <field name="fixed_journal_id"
-                    attrs="{'invisible': [('bank_account_link', '!=', 'fixed')], 'required': [('bank_account_link', '=', 'fixed')]}"
-                    widget="selection"/>
+                    attrs="{'invisible': [('bank_account_link', '!=', 'fixed')], 'required': [('bank_account_link', '=', 'fixed')]}"/>
                 <field name="variable_journal_ids"
                     attrs="{'invisible': [('bank_account_link', '!=', 'variable')], 'required': [('bank_account_link', '=', 'variable')]}"
                     widget="many2many_tags"/>

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -119,7 +119,7 @@ class AccountPaymentLine(models.Model):
             self.partner_id = False
             self.partner_bank_id = False
             self.amount_currency = 0.0
-            self.currency_id = False
+            self.currency_id = self.env.user.company_id.currency_id
             self.communication = False
 
     def invoice_reference_type2communication_type(self):

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -102,7 +102,8 @@
     <field name="model">account.payment.order</field>
     <field name="arch" type="xml">
         <search string="Search Payment Orders">
-            <field name="description"/>
+            <field name="description" filter_domain="['|', ('name', 'ilike', self), ('description', 'ilike', self)]" string="Name or Description"/>
+            <field name="journal_id"/>
             <filter name="draft" string="Draft" domain="[('state', '=', 'draft')]"/>
             <filter name="open" string="Confirmed" domain="[('state', '=', 'open')]"/>
             <filter name="generated" string="File Generated" domain="[('state', '=', 'generated')]"/>


### PR DESCRIPTION
- when manually encoding a payment line, get company currency as default currency
- Search on payment order numbers
- Direct search on bank journal name in payment orders
- remove widget="selection" on account.payement.mode : this object is rarely modified, so widget='selection' is not a time saver, but we miss the HTML link, which can be pretty convenient to check the configuration.