### PR TITLE
[10.0] Read access on account.payment.method to employees

### DIFF
--- a/account_payment_mode/security/ir.model.access.csv
+++ b/account_payment_mode/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-account.access_account_payment_method,Read access on account.payment.method to Invoice user,account.model_account_payment_method,account.group_account_invoice,1,0,0,0
+account.access_account_payment_method,Read access on account.payment.method to Employees,account.model_account_payment_method,base.group_user,1,0,0,0
 access_account_payment_method_full,Full access on account.payment.method to Financial Manager,account.model_account_payment_method,account.group_account_manager,1,1,1,1
 access_account_payment_mode_read,Read access on account.payment.mode to Employees,model_account_payment_mode,base.group_user,1,0,0,0
 access_account_payment_mode_full,Full access on account.payment.mode to Financial Manager,model_account_payment_mode,account.group_account_manager,1,1,1,1


### PR DESCRIPTION
Read access on account.payment.method to employees (instead of Invoicing group). That way, read access are the same on payment mode and payment method. Payment method is sometimes used in some conditions in reports (not just invoice but also quotations or PO), so giving read access to all employees to this object avoids problems.