### PR TITLE
[10.0] Add filter on partners on wizard "Create Payment Lines from Journal Items"

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '10.0.1.5.0',
+    'version': '10.0.1.6.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -19,7 +19,7 @@
                 <field name="due_date" attrs="{'required': [('date_type', '=', 'due')], 'invisible': [('date_type', '!=', 'due')]}"/>
                 <field name="journal_ids"
                    widget="many2many_tags"
-                   placeholder="Keep empty to use all journals"/>
+                   placeholder="Keep empty for using all journals"/>
                 <field name="partner_ids"
                    widget="many2many_tags"
                    placeholder="Keep empty to use all partners"/>

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -19,7 +19,10 @@
                 <field name="due_date" attrs="{'required': [('date_type', '=', 'due')], 'invisible': [('date_type', '!=', 'due')]}"/>
                 <field name="journal_ids"
                    widget="many2many_tags"
-                    placeholder="Keep empty for using all journals"/>
+                   placeholder="Keep empty to use all journals"/>
+                <field name="partner_ids"
+                   widget="many2many_tags"
+                   placeholder="Keep empty to use all partners"/>
                 <field name="payment_mode"/>
                 <field name="target_move" widget="radio"/>
                 <field name="invoice"/>


### PR DESCRIPTION
This feature was present in v8.0, cf https://github.com/OCA/bank-payment/blob/8.0/account_banking_payment_export/wizard/payment_order_create.py#L34  and some users liked it... so let's put it in v10 too !