### PR TITLE
[ADD] Allow for multiple SEPA payment methods with different versions

### DIFF
--- a/account_banking_pain_base/models/account_payment_method.py
+++ b/account_banking_pain_base/models/account_payment_method.py
@@ -22,3 +22,11 @@ class AccountPaymentMethod(models.Model):
         self.ensure_one()
         raise UserError(_(
             "No XSD file path found for payment method '%s'") % self.name)
+
+    _sql_constraints = [(
+        # Extending this constraint from account_payment_mode
+        'code_payment_type_unique',
+        'unique(code, payment_type, pain_version)',
+        'A payment method of the same type already exists with this code'
+        ' and PAIN version'
+    )]


### PR DESCRIPTION
Currently, I cannot have multiple outbound SEPA payment methods, which is unfortunate if one has multiple banks that support different SEPA versions. The culprit is this constraint: https://github.com/OCA/bank-payment/blob/9.0/account_payment_mode/models/account_payment_method.py#L33. I am proposing to extend that constraint in this module to pain_version in the unicity check.