### PR TITLE
[FIX] [account_payment_order] set payment_type for payment modes with newly assigned payment method

### DIFF
--- a/account_payment_order/migrations/9.0.1.0.0/pre-migration.py
+++ b/account_payment_order/migrations/9.0.1.0.0/pre-migration.py
@@ -138,6 +138,15 @@ def migrate_payment_mode_types(env):
             WHERE type = %s""",
             (method.id, row[0]),
         )
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE account_payment_mode
+        SET payment_type = account_payment_method.payment_type
+        FROM account_payment_method
+        WHERE account_payment_mode.payment_method_id=account_payment_method.id
+        AND account_payment_mode.payment_type is NULL
+        """
+    )
 
 
 @openupgrade.migrate(use_env=True)


### PR DESCRIPTION
without this, the related field stays empty and the payment modes in question aren't available on payment orders