### PR TITLE
[FIX] default_partner_id added on partner_bank if it is created.

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '11.0.1.2.1',
+    'version': '11.0.1.2.2',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -19,6 +19,7 @@
                     <field name="currency_id"/>
                     <field name="partner_id"/>
                     <field name="partner_bank_id"
+                           context="{'default_partner_id': partner_id}"
                            domain="[('partner_id', '=', partner_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                            attrs="{'required': [('bank_account_required', '=', True)]}"
                     />


### PR DESCRIPTION
If you create the bank account on the order it is created on the current company. Now it is assigned to the partner of the invoice.