### PR TITLE
Fix structured communication

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -127,7 +127,7 @@ class AccountPaymentLine(models.Model):
         localization modules"""
         # key = value of 'reference_type' field on account_invoice
         # value = value of 'communication_type' field on account_payment_line
-        res = {'none': 'normal'}
+        res = {'none': 'normal', 'structured': 'structured'}
         return res
 
     @api.multi


### PR DESCRIPTION
Adds 'structured' to the invoice_reference_type2communication_type ans the 'structured' type is added by the module itself in account_invoice but breaks the account_move_line.py as explained here: https://github.com/OCA/bank-payment/issues/495