### PR TITLE
[11.0][MIG] account_payment_line_cancel

### DIFF
--- a/account_payment_line_cancel/README.rst
+++ b/account_payment_line_cancel/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===================
+Cancel payment line
+===================
+
+This module allows you to cancel and remove a payment line from a payment order when the payment needs to be cancelled (for example when a payment is rejected).
+The module allows you as well to free an invoice that was imported in a payment order and automatically cancel the payment lines that were generated.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go in payment orders
+#. Click on the cancel button of a payment line, to remove it from the payment order.
+
+Or :
+
+#. Go to invoices
+#. Select a few invoices from the tree view
+#. Use the "Free invoices" entry to remove selected invoices from payment orders
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/173/10.0
+
+Known issues / Roadmap
+======================
+
+* Nothing
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/bank-payment/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Marco Monzione <marco.mon@windowslive.com>
+* Emanuel Cino <ecino@compassion.ch>
+* Cyril Sester <cyril.sester@outlook.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* Compassion Switzerland
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_payment_line_cancel/README.rst
+++ b/account_payment_line_cancel/README.rst
@@ -25,7 +25,7 @@ Or :
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/173/10.0
+   :target: https://runbot.odoo-community.org/runbot/173/11.0
 
 Known issues / Roadmap
 ======================
@@ -54,6 +54,7 @@ Contributors
 * Marco Monzione <marco.mon@windowslive.com>
 * Emanuel Cino <ecino@compassion.ch>
 * Cyril Sester <cyril.sester@outlook.com>
+* Maxence Groine <mgroine@fiefmanage.ch>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/account_payment_line_cancel/__init__.py
+++ b/account_payment_line_cancel/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import models
+from . import wizards

--- a/account_payment_line_cancel/__init__.py
+++ b/account_payment_line_cancel/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import models
 from . import wizards

--- a/account_payment_line_cancel/__manifest__.py
+++ b/account_payment_line_cancel/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 Compassion CH (http://www.compassion.ch)
+# @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': 'Account payment line cancel',
+    'version': '10.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/bank-payment',
+    'category': 'Banking addons',
+    'depends': [
+        'account_payment_order',
+        'account_cancel',
+    ],
+    'data': [
+        'views/invoice_view.xml',
+        'views/payment_line_view.xml',
+    ],
+    'installable': True,
+}

--- a/account_payment_line_cancel/__manifest__.py
+++ b/account_payment_line_cancel/__manifest__.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2018 Compassion CH (http://www.compassion.ch)
 # @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Account payment line cancel',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/bank-payment',

--- a/account_payment_line_cancel/i18n/account_payment_line_cancel.pot
+++ b/account_payment_line_cancel/i18n/account_payment_line_cancel.pot
@@ -1,0 +1,122 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_payment_line_cancel
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_line_cancel
+#: code:addons/account_payment_line_cancel/models/account_payment_line.py:98
+#, python-format
+msgid " has been removed, "
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.ui.view,arch_db:account_payment_line_cancel.account_invoice_free_view
+msgid "Cancel"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_payment_line_cancel_reason
+msgid "Cancel reason"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.actions.act_window,name:account_payment_line_cancel.action_account_invoice_free
+#: model:ir.ui.view,arch_db:account_payment_line_cancel.account_invoice_free_view
+msgid "Free Invoices"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.ui.view,arch_db:account_payment_line_cancel.account_invoice_free_view
+msgid "Free Invoices from payment order"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model,name:account_payment_line_cancel.model_account_invoice_free
+msgid "Free invoice wizard"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_id
+msgid "ID"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model,name:account_payment_line_cancel.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model.fields,field_description:account_payment_line_cancel.field_account_invoice_free_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: code:addons/account_payment_line_cancel/models/invoice.py:29
+#, python-format
+msgid "No payment line found !"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.model,name:account_payment_line_cancel.model_account_payment_line
+msgid "Payment Lines"
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: code:addons/account_payment_line_cancel/models/account_payment_line.py:93
+#, python-format
+msgid "The invoice has been removed from "
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.ui.view,arch_db:account_payment_line_cancel.account_invoice_free_view
+msgid "This will extract payment lines corresponding to selected\n"
+"            invoices and put them in a cancelled payment order. This way,\n"
+"            invoices can be added to another payment order."
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: code:addons/account_payment_line_cancel/models/account_payment_line.py:81
+#, python-format
+msgid "no reason given."
+msgstr ""
+
+#. module: account_payment_line_cancel
+#: model:ir.ui.view,arch_db:account_payment_line_cancel.account_invoice_free_view
+msgid "or"
+msgstr ""
+

--- a/account_payment_line_cancel/models/__init__.py
+++ b/account_payment_line_cancel/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import account_payment_line
+from . import  invoice

--- a/account_payment_line_cancel/models/__init__.py
+++ b/account_payment_line_cancel/models/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import account_payment_line
-from . import  invoice
+from . import bank_payment_line
+from . import invoice

--- a/account_payment_line_cancel/models/account_payment_line.py
+++ b/account_payment_line_cancel/models/account_payment_line.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Compassion CH (http://www.compassion.ch)
+# @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, _
+
+
+class AccountCancelPayment(models.Model):
+    _inherit = 'account.payment.line'
+
+    cancel_reason = fields.Char()
+
+    def cancel_line(self):
+        """
+         This method proceed to call private methods to remove payment lines
+         from payment order
+
+        A cancel reason can be put in the cancel_reason field.
+
+        :return: True
+        """
+        # Retrieve all account_move_line(s) associated with the previous
+        # account_payment_line(s).
+        all_account_move_lines = self.mapped('move_line_id')
+        # Add the message to the invoice and to the payment order
+        self._post_cancel_message()
+        # Unreconcile transfer journal entries
+        full_reconcile_ids = all_account_move_lines.mapped(
+            'full_reconcile_id.id')
+        payment_orders = self.mapped('order_id')
+        if full_reconcile_ids:
+            # Retrieve the counterparts of the previous move_lines.
+            # The counter part should always be unique.
+            account_move_line_counterpart = self.env[
+                'account.move.line'].search([
+                    ('full_reconcile_id', 'in', full_reconcile_ids),
+                    ('id', 'not in', all_account_move_lines.ids),
+                    ('move_id.payment_order_id', 'in', payment_orders.ids)])
+
+            # All the move lines with the same reconcile id are unreconciled.
+            account_move_line_counterpart.remove_move_reconcile()
+            # unpost and delete the moves from the journal.
+            account_move_counterpart = account_move_line_counterpart.mapped(
+                'move_id')
+            account_move_counterpart.button_cancel()
+            account_move_counterpart.unlink()
+
+        # Remove bank.payment.line
+        self.mapped('bank_line_id').with_context(force_unlink=True).unlink()
+
+        # Search if there is something left in the payment order.
+        for payment_order in payment_orders:
+            other_lines = self.search_count([
+                ('order_id', '=', payment_order.id),
+                ('id', 'not in', self.ids)
+            ])
+            if not other_lines:
+                payment_order.action_done_cancel()
+
+        # Delete the payment line in the payment order.
+        res = self.unlink()
+        # Force recomputation of total
+        payment_orders._compute_total()
+        if self.env.context.get('cancel_line_from_payment_order'):
+            # to see that the state of the order has changed, we need
+            # to update the whole view. Do that only if necessary.
+            res = {
+                'type': 'ir.actions.client',
+                'tag': 'reload',
+            }
+        return res
+
+    def _post_cancel_message(self):
+        """
+        This method is used to post message on the invoices that have been
+        deleted from the payment order and it post a message too on the
+        payment order for each deleted invoice.
+        """
+        for payment_line in self:
+            cancel_reason = payment_line.cancel_reason or _(
+                u"no reason given.")
+            # Create a link to the invoice that was removed
+            invoice = payment_line.move_line_id.invoice_id
+            order = payment_line.order_id
+            invoice_url = u'<a href="web#id={}&view_type=form&model=' \
+                u'account.invoice">{}</a>'.format(invoice.id,
+                                                  invoice.move_name)
+            payment_order_url = u'<a href="web#id={}&view_type=form&model=' \
+                u'account.payment.order">{}</a>'.format(order.id, order.name)
+            # Add a message to the invoice
+            invoice.message_post(
+                _(u"The invoice has been removed from ") + u"{}, {}"
+                .format(payment_order_url, cancel_reason)
+            )
+            # Add a message to the payment order
+            payment_line.order_id.message_post(
+                invoice_url + _(u" has been removed, ") + cancel_reason)

--- a/account_payment_line_cancel/models/bank_payment_line.py
+++ b/account_payment_line_cancel/models/bank_payment_line.py
@@ -1,0 +1,21 @@
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+from odoo.addons.account_payment_order.models.bank_payment_line \
+    import BankPaymentLine
+
+
+class APLCBankPaymentLine(models.Model):
+    _inherit = "bank.payment.line"
+
+    @api.multi
+    def unlink(self):
+        if not self.env.context.get('force_unlink'):
+            for line in self:
+                order_state = line.order_id.state
+                if order_state == 'uploaded':
+                    raise UserError(_(
+                        "Cannot delete a payment order line whose payment "
+                        "order is in state '{}'. You need to cancel it "
+                        "first.").format(order_state))
+        return super(BankPaymentLine, self).unlink()

--- a/account_payment_line_cancel/models/invoice.py
+++ b/account_payment_line_cancel/models/invoice.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Compassion CH (http://www.compassion.ch)
+# @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, api, _, exceptions
+
+
+class AccountInvoice(models.Model):
+
+    """ Inherit invoice to add invoice freeing functionality. It's about
+        cancelling related payment line. This
+        way, the invoice (properly, invoice's move lines) can be used again
+        in another payment order.
+    """
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def cancel_payment_lines(self):
+        """ This function simply finds related payment lines and cancel them.
+        """
+        mov_line_obj = self.env['account.move.line']
+        pay_line_obj = self.env['account.payment.line']
+        move_ids = self.mapped('move_id.id')
+        move_line_ids = mov_line_obj.search([('move_id', 'in', move_ids)]).ids
+        payment_lines = pay_line_obj.search([
+            ('move_line_id', 'in', move_line_ids)
+        ])
+        if not payment_lines:
+            raise exceptions.UserError(_('No payment line found !'))
+
+        payment_lines.cancel_line()

--- a/account_payment_line_cancel/models/invoice.py
+++ b/account_payment_line_cancel/models/invoice.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Compassion CH (http://www.compassion.ch)
 # @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_payment_line_cancel/readme/CONTRIBUTORS.rst
+++ b/account_payment_line_cancel/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* Marco Monzione <marco.mon@windowslive.com>
+* Emanuel Cino <ecino@compassion.ch>
+* Cyril Sester <cyril.sester@outlook.com>
+* Maxence Groine <mgroine@fiefmanage.ch>

--- a/account_payment_line_cancel/readme/CREDITS.rst
+++ b/account_payment_line_cancel/readme/CREDITS.rst
@@ -1,0 +1,3 @@
+The development of this module has been financially supported by:
+
+* Compassion Switzerland

--- a/account_payment_line_cancel/readme/DESCRIPTION.rst
+++ b/account_payment_line_cancel/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows you to cancel and remove a payment line from a payment order when the payment needs to be cancelled (for example when a payment is rejected).
+The module allows you as well to free an invoice that was imported in a payment order and automatically cancel the payment lines that were generated.

--- a/account_payment_line_cancel/readme/USAGE.rst
+++ b/account_payment_line_cancel/readme/USAGE.rst
@@ -1,0 +1,10 @@
+To use this module, you need to:
+
+#. Go in payment orders
+#. Click on the cancel button of a payment line, to remove it from the payment order.
+
+Or :
+
+#. Go to invoices
+#. Select a few invoices from the tree view
+#. Use the "Free invoices" entry to remove selected invoices from payment orders

--- a/account_payment_line_cancel/tests/__init__.py
+++ b/account_payment_line_cancel/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import test_payment_cancel

--- a/account_payment_line_cancel/tests/__init__.py
+++ b/account_payment_line_cancel/tests/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import test_payment_cancel

--- a/account_payment_line_cancel/tests/test_payment_cancel.py
+++ b/account_payment_line_cancel/tests/test_payment_cancel.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Compassion CH (http://www.compassion.ch)
+# @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import tools, fields
+from odoo.tests import TransactionCase
+from odoo.modules.module import get_resource_path
+
+
+class TestPaymentCancel(TransactionCase):
+    def _load(self, module, *args):
+        tools.convert_file(
+            self.cr, 'account_asset',
+            get_resource_path(module, *args),
+            {}, 'init', False, 'test', self.registry._assertion_report)
+
+    def test_free_invoice(self):
+        self._load('account', 'test', 'account_minimal_test.xml')
+        journal = self.env['account.journal'].search([
+            ('code', '=', 'TEXJ')], limit=1)
+        account = self.env['account.account'].search([
+            ('code', '=', 'X1012')], limit=1)
+        product = self.env.ref('product.product_product_24')
+        account_line = self.env['account.account'].search([
+            ('code', '=', 'X2020')], limit=1)
+
+        # Create invoice
+        invoice = self.env['account.invoice'].create({
+            'journal_id': journal.id,
+            'currency_id': self.env.ref('base.USD').id,
+            'account_id': account.id,
+            'type': 'in_invoice',
+            'partner_id': self.env.ref('base.res_partner_address_31').id,
+            'date_invoice': fields.Datetime.now(),
+            'invoice_line_ids': [(0, 0, {
+                'product_id': product.id,
+                'name': product.name,
+                'account_id': account_line.id,
+                'quantity': 1,
+                'price_unit': product.standard_price
+            })]
+        })
+        invoice.action_invoice_open()
+        payorder_id = invoice.create_account_payment_line().get('res_id')
+        payment_order = self.env['account.payment.order'].browse(payorder_id)
+        payment_order.journal_id = journal
+
+        # Confirm payment order
+        payment_order.draft2open()
+        # Generate payment file
+        payment_order.open2generated()
+        # File successfully uploaded
+        payment_order.generated2uploaded()
+
+        # The invoice should be paid
+        self.assertEquals(invoice.state, 'paid')
+
+        # Make journal cancellable
+        journal.update_posted = True
+        wizard = self.env['account.invoice.free'].with_context(
+            active_ids=invoice.ids).create({})
+        wizard.invoice_free()
+
+        # Test if the move related to the invoice are deleted after the invoice
+        # is freed.
+        account_move = self.env['account.move'].search(
+            [('payment_order_id', '=', payment_order.id)])
+
+        self.assertFalse(account_move)
+
+        # Test if the order is in cancel state.
+        self.assertEqual(payment_order.state, 'cancel')
+
+        # Test if the invoice is in open state.
+        self.assertEqual(invoice.state, 'open')

--- a/account_payment_line_cancel/tests/test_payment_cancel.py
+++ b/account_payment_line_cancel/tests/test_payment_cancel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Compassion CH (http://www.compassion.ch)
 # @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_payment_line_cancel/views/invoice_view.xml
+++ b/account_payment_line_cancel/views/invoice_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 Compassion (http://www.compassion.ch)
+  @author: Cyril Sester <cyril.sester@outlook.com>
+  The licence is in the file __openerp__.py
+-->
+<odoo>
+    <record id="account_invoice_free_view" model="ir.ui.view">
+      <field name="name">account.invoice.free.form</field>
+      <field name="model">account.invoice.free</field>
+      <field name="arch" type="xml">
+        <form string="Free Invoices from payment order">
+          <p class="oe_grey">
+            This will extract payment lines corresponding to selected
+            invoices and put them in a cancelled payment order. This way,
+            invoices can be added to another payment order.
+          </p>
+          <footer>
+            <button string="Free Invoices" name="invoice_free" type="object" default_focus="1" class="oe_highlight"/>
+            or
+            <button string="Cancel" class="oe_link" special="cancel"/>
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <act_window id="action_account_invoice_free"
+
+      key2="client_action_multi" name="Free Invoices"
+      res_model="account.invoice.free" src_model="account.invoice"
+      view_mode="form" target="new" view_type="form" />
+</odoo>

--- a/account_payment_line_cancel/views/payment_line_view.xml
+++ b/account_payment_line_cancel/views/payment_line_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_payment_line_cancel_view" model="ir.ui.view">
+        <field name="name">account.payment.line.cancel.tree</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="payment_type" position="after">
+                <button name="cancel_line" type="object" icon="fa-undo" context="{'cancel_line_from_payment_order': 1}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_payment_line_cancel/wizards/__init__.py
+++ b/account_payment_line_cancel/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import invoice_free_wizard

--- a/account_payment_line_cancel/wizards/__init__.py
+++ b/account_payment_line_cancel/wizards/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import invoice_free_wizard

--- a/account_payment_line_cancel/wizards/invoice_free_wizard.py
+++ b/account_payment_line_cancel/wizards/invoice_free_wizard.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Compassion CH (http://www.compassion.ch)
+# @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, api
+
+
+class AccountInvoiceFree(models.TransientModel):
+
+    ''' Wizard to free invoices. When job is done, user is redirected on new
+        payment order.
+    '''
+    _name = 'account.invoice.free'
+    _description = 'Free invoice wizard'
+
+    @api.multi
+    def invoice_free(self):
+        inv_obj = self.env['account.invoice']
+        invoices = inv_obj.browse(self.env.context.get('active_ids'))
+        return invoices.cancel_payment_lines()

--- a/account_payment_line_cancel/wizards/invoice_free_wizard.py
+++ b/account_payment_line_cancel/wizards/invoice_free_wizard.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Compassion CH (http://www.compassion.ch)
 # @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).


### PR DESCRIPTION
Small modification added to the 10.0 branch code in order to add a message with all the info about a cancelled payment line in the payment order when cancelling a payment line that is not linked to an invoice.