### PR TITLE
[10.0][IMP] Add Italian SEPA SDD CBI Support

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -163,10 +163,16 @@ class AccountPaymentOrder(models.Model):
     def generate_pain_nsmap(self):
         self.ensure_one()
         pain_flavor = self.payment_mode_id.payment_method_id.pain_version
-        nsmap = {
-            'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-            None: 'urn:iso:std:iso:20022:tech:xsd:%s' % pain_flavor,
-        }
+        if pain_flavor.startswith('CBIBdySDDReq'):
+            nsmap = {
+                'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                None: 'urn:CBI:xsd:%s' % pain_flavor,
+            }
+        else:
+            nsmap = {
+                'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                None: 'urn:iso:std:iso:20022:tech:xsd:%s' % pain_flavor,
+            }
         return nsmap
 
     @api.multi
@@ -176,7 +182,37 @@ class AccountPaymentOrder(models.Model):
 
     @api.model
     def generate_group_header_block(self, parent_node, gen_args):
-        group_header = etree.SubElement(parent_node, 'GrpHdr')
+        # CBI Italy
+        # <CBIBdySDDReq xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        #               xmlns="urn:CBI:xsd:CBIBdySDDReq.00.01.00"
+        #               xsi:schemaLocation="urn:CBI:xsd:CBIBdySDDReq.00.01.00 CBIBdySDDReq.00.01.00.xsd">
+        #     <PhyMsgInf>
+        #         <PhyMsgTpCd>INC-SDDB-01</PhyMsgTpCd>
+        #         <NbOfLogMsg>1</NbOfLogMsg>
+        #     </PhyMsgInf>
+        #     <CBIEnvelSDDReqLogMsg>
+        #         <CBISDDReqLogMsg>
+        #             <GrpHdr xmlns="urn:CBI:xsd:CBISDDReqLogMsg.00.01.00">
+        if gen_args.get('pain_flavor').startswith('CBIBdySDDReq'):
+            phyMsgInf = etree.SubElement( parent_node, 'PhyMsgInf' )
+            phyMsgTpCd = etree.SubElement( phyMsgInf, 'PhyMsgTpCd' )
+            if self.scheme == 'CORE':
+                phyMsgTpCd.text = 'INC-SDDC-01'
+            elif self.scheme == 'B2B':
+                phyMsgTpCd.text = 'INC-SDDB-01'
+            else:
+                raise UserError(_('Invalid CBI Debit Order Scheme {}'.format(self.scheme)))
+            numLogMsg = etree.SubElement( phyMsgInf, 'NbOfLogMsg' )
+            #numLogMsg = etree.SubElement( phyMsgInf, 'NumLogMsg' )
+            numLogMsg.text = '1'  # Normally only 1 CBIEnvelSDDLogMsg
+            CBIEnvelSDDReqLogMsg = etree.SubElement( parent_node, 'CBIEnvelSDDReqLogMsg' )
+            CBISDDReqLogMsg = etree.SubElement( CBIEnvelSDDReqLogMsg, 'CBISDDReqLogMsg' )
+            payment_root = CBISDDReqLogMsg
+            group_header = etree.SubElement( CBISDDReqLogMsg, 'GrpHdr',
+                                             attrib={'xmlns': 'urn:CBI:xsd:CBISDDReqLogMsg.%s' % gen_args.get('pain_flavor').split('.',1)[1]} )
+        else:
+            group_header = etree.SubElement(parent_node, 'GrpHdr')
+            payment_root = group_header
         message_identification = etree.SubElement(
             group_header, 'MsgId')
         message_identification.text = self._prepare_field(
@@ -199,14 +235,18 @@ class AccountPaymentOrder(models.Model):
             grouping = etree.SubElement(group_header, 'Grpg')
             grouping.text = 'GRPD'
         self.generate_initiating_party_block(group_header, gen_args)
-        return group_header, nb_of_transactions, control_sum
+        return group_header, nb_of_transactions, control_sum, payment_root
 
     @api.model
     def generate_start_payment_info_block(
             self, parent_node, payment_info_ident,
             priority, local_instrument, category_purpose, sequence_type,
             requested_date, eval_ctx, gen_args):
-        payment_info = etree.SubElement(parent_node, 'PmtInf')
+        if gen_args.get('pain_flavor').startswith('CBIBdySDDReq'):
+            payment_info = etree.SubElement( parent_node, 'PmtInf',
+                                             attrib={'xmlns': 'urn:CBI:xsd:CBISDDReqLogMsg.%s' % gen_args.get('pain_flavor').split('.',1)[1]} )
+        else:
+            payment_info = etree.SubElement(parent_node, 'PmtInf')
         payment_info_identification = etree.SubElement(
             payment_info, 'PmtInfId')
         payment_info_identification.text = self._prepare_field(
@@ -216,7 +256,8 @@ class AccountPaymentOrder(models.Model):
         payment_method.text = gen_args['payment_method']
         nb_of_transactions = False
         control_sum = False
-        if gen_args.get('pain_flavor') != 'pain.001.001.02':
+        # But not for Italy!?
+        if gen_args.get('pain_flavor') not in ('pain.001.001.02', 'CBIBdySDDReq.00.01.00' ):
             batch_booking = etree.SubElement(payment_info, 'BtchBookg')
             batch_booking.text = unicode(self.batch_booking).lower()
         # The "SEPA Customer-to-bank
@@ -303,6 +344,11 @@ class AccountPaymentOrder(models.Model):
                 iniparty_org_other_scheme_name = etree.SubElement(
                     iniparty_org_other_scheme, 'Prtry')
                 iniparty_org_other_scheme_name.text = initiating_party_scheme
+            if gen_args.get('pain_flavor').startswith('CBIBdySDDReq') and \
+                    (not initiating_party_issuer or initiating_party_issuer != 'CBI'):
+                raise UserError(
+                    _("Missing 'Initiating Party Issuer' must be set to 'CBI' "
+                      "for the company '%s'.") % self.company_id.name)
             if initiating_party_issuer:
                 iniparty_org_other_issuer = etree.SubElement(
                     iniparty_org_other, 'Issr')
@@ -338,6 +384,45 @@ class AccountPaymentOrder(models.Model):
         In some localization (l10n_ch_sepa for example), they need the
         bank_line argument"""
         assert order in ('B', 'C'), "Order can be 'B' or 'C'"
+
+        # Italian CBI Creditor uses the node below:
+        #
+        # <CdtrAgt>
+        #   <FinInstnId>
+        #     <ClrSysMmbId>
+        #       <MmbId>ABI_CODE</MmbId>
+        #     </ClrSysMmbId>
+        #   </FinInstnId>
+        # </CdtrAgt>
+        #
+        # Debitor adds form in case the bank account isn't Italian
+        #
+        # <DbtrAgt>
+        #   <FinInstnId>
+        #     <BIC>SWIFT/BIC</BIC>
+        #   </FinInstnId>
+        # </DbtrAgt>
+        #
+        if gen_args.get( 'pain_flavor' ).startswith('CBIBdySDDReq'):
+            if party_type == 'Cdtr':
+                party_agent = etree.SubElement( parent_node, '%sAgt' % party_type )
+                party_agent_institution = etree.SubElement(
+                    party_agent, 'FinInstnId' )
+                party_agent_clr_sys_mmbid = etree.SubElement(
+                    party_agent_institution, 'ClrSysMmbId' )
+                party_agent_mmbid = etree.SubElement(
+                    party_agent_clr_sys_mmbid, 'MmbId' )
+                if partner_bank.bank_abi:
+                    party_agent_mmbid.text = partner_bank.bank_abi
+                else:
+                    party_agent_mmbid.text = 'NOTPROVIDED'
+                return True
+            else:
+                # If it's an Italian Bank we are done
+                if partner_bank.acc_type == 'iban' and partner_bank.sanitized_acc_number.upper().startswith('IT'):
+                    return True
+                # else: For not Italian banks it's necessary to specify the DbtrAgt node
+
         if partner_bank.bank_bic:
             party_agent = etree.SubElement(parent_node, '%sAgt' % party_type)
             party_agent_institution = etree.SubElement(

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -21,6 +21,7 @@
     ],
     'data': [
         'views/account_banking_mandate_view.xml',
+        'views/account_payment_order.xml',
         'views/res_config.xml',
         'views/account_payment_mode.xml',
         'data/mandate_expire_cron.xml',

--- a/account_banking_sepa_direct_debit/data/CBIBdySDDReq.00.01.00.xsd
+++ b/account_banking_sepa_direct_debit/data/CBIBdySDDReq.00.01.00.xsd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 (x64) (http://www.altova.com) by Ivana Gargiulo (CONSORZIO CUSTOMER TO BUSINESS INTERACTION - CBI) -->
+<!-- Entrata in vigore: 20/11/2016 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:LMSG="urn:CBI:xsd:CBISDDReqLogMsg.00.01.00" xmlns="urn:CBI:xsd:CBIBdySDDReq.00.01.00" targetNamespace="urn:CBI:xsd:CBIBdySDDReq.00.01.00" elementFormDefault="qualified">
+	<!-- Namespace import -->
+	<xs:import namespace="urn:CBI:xsd:CBISDDReqLogMsg.00.01.00" schemaLocation="CBISDDReqLogMsg.00.01.00.xsd"/>
+	<!--xs:import namespace="urn:CBI:xsd:CBISgnInf.001.04" schemaLocation="CBISgnInf.001.04.xsd"/-->
+	<xs:element name="CBIBdySDDReq" type="CBIBdySDDReq.00.01.00"/>
+	<!-- Message Body structure definition -->
+	<xs:complexType name="CBIBdySDDReq.00.01.00">
+		<xs:sequence>
+			<xs:element name="PhyMsgInf" type="PhysicalMsgInfoType">
+				<xs:annotation>
+					<xs:documentation>1.3.1. - Informazioni generali sul messaggio fisico</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CBIEnvelSDDReqLogMsg" type="CBIEnvelSDDLogMsg.00.01.00" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>1.3.2. - Blocco contenente il messaggio logico CBI. E' strutturato per poter contenere anche la firma digitale secondo le regole riportate nel documento FIRMA-MO-001. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIEnvelSDDLogMsg.00.01.00">
+		<xs:choice>
+			<xs:element name="CBISDDReqLogMsg" type="LMSG:CBISDDReqLogMsg.00.01.00">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1. - Messaggio logico CBI di richiesta incasso SDD </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<!--xs:element name="CBISgnInf" type="SGNT:CBISgnInf.001.04">
+				<xs:annotation>
+					<xs:documentation>1.3.2.2. - Blocco contenente la firma digitale secondo le specifiche CBI</xs:documentation>
+				</xs:annotation>
+			</xs:element-->
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="PhysicalMsgInfoType">
+		<xs:sequence>
+			<xs:element name="PhyMsgTpCd">
+				<xs:annotation>
+					<xs:documentation>1.3.1.1 - Tipologia di messaggio fisico, espressa in forma codificata</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="INC-SDDC-01"/>
+						<xs:enumeration value="INC-SDDB-01"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="NbOfLogMsg" type="xs:positiveInteger">
+				<xs:annotation>
+					<xs:documentation>1.3.1.2 - Indica il numero di messaggi logici contenuti nel messaggio fisico. Deve coincidere con il numero dei blocchi 1.3.2.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrgnlPhyMsgInfAndStsType">
+		<xs:sequence>
+			<xs:element name="IdE2EMsg">
+				<xs:annotation>
+					<xs:documentation>IdE2E presente nell'header di servizio del messaggio fisico referenziato </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="XMLCreDt">
+				<xs:annotation>
+					<xs:documentation>XMLCreDt presente nell'header di servizio del messaggio fisico referenziato </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Status" type="StatusType">
+				<xs:annotation>
+					<xs:documentation>Riporta informazioni circa lo stato del messaggio fisico referenziato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StatusType">
+		<xs:choice>
+			<xs:element name="StsOK" type="xs:string"/>
+			<xs:sequence>
+				<xs:element name="StsKO" type="xs:string"/>
+				<xs:element name="ErrorDescr" type="Max256Text"/>
+				<xs:element name="ElmNm" type="Max256Text" minOccurs="0"/>
+			</xs:sequence>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="Max256Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="256"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/account_banking_sepa_direct_debit/data/CBISDDReqLogMsg.00.01.00.xsd
+++ b/account_banking_sepa_direct_debit/data/CBISDDReqLogMsg.00.01.00.xsd
@@ -1,0 +1,983 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 (x64) (http://www.altova.com) by Ivana Gargiulo (CONSORZIO CUSTOMER TO BUSINESS INTERACTION - CBI) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:CBI:xsd:CBISDDReqLogMsg.00.01.00" targetNamespace="urn:CBI:xsd:CBISDDReqLogMsg.00.01.00" elementFormDefault="qualified">
+	<xs:element name="CBISDDReqLogMsg" type="CBISDDReqLogMsg.00.01.00"/>
+	<!-- CBI Logical SDD Request message structure definition -->
+	<xs:complexType name="CBISDDReqLogMsg.00.01.00">
+		<xs:sequence>
+			<xs:element name="GrpHdr" type="CBIGroupHeader2">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1. - Blocco contenente le informazioni generali sul messaggio logico di richiesta incasso</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PmtInf" type="PaymentInstructionInformation2" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.2. - Blocco contenente le informazioni di accredito</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIGroupHeader2">
+		<xs:sequence>
+			<xs:element name="MsgId" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1.1
+Identificativo del messaggio logico. Deve essere univoco a parità di azienda mittente e data di creazione </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CreDtTm" type="ISODateTime">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1.2
+Data e ora di creazione del messaggio logico</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NbOfTxs" type="Max15NumericText">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1.3
+Numero di transazioni DD incluse nel messaggio logico</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CtrlSum" type="DecimalNumber">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1.4
+Somma di controllo. Deve  coincidere con la somma degli importi delle disposizioni di incasso contenute nella richiesta</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InitgPty" type="CBIPartyIdentification1">
+				<xs:annotation>
+					<xs:documentation>1.3.2.1.1.5.
+Mittente della richiesta di incasso</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstructionInformation2">
+		<xs:sequence>
+			<xs:element name="PmtInfId" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>Identificativo informazioni di accredito</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PmtMtd" type="PaymentMethod2Code">
+				<xs:annotation>
+					<xs:documentation>Metodo di pagamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Accredito cumulativo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PmtTpInf" type="CBIPaymentTypeInformation2_1">
+				<xs:annotation>
+					<xs:documentation>Informazioni tipo di pagamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ReqdColltnDt" type="ISODate">
+				<xs:annotation>
+					<xs:documentation>Data scadenza richiesta dal mittente</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Cdtr" type="CBIPartyIdentification3">
+				<xs:annotation>
+					<xs:documentation>Titolare c/c di accredito / beneficiario</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtrAcct" type="CBICashAccount7">
+				<xs:annotation>
+					<xs:documentation>Conto del creditore</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtrAgt" type="CBIBranchAndFinancialInstitutionIdentification1">
+				<xs:annotation>
+					<xs:documentation>Banca Passiva sulla quale risiede il c/c di accredito</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UltmtCdtr" type="CBIPartyIdentification3" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Creditore effettivo. Se presente deve essere diverso dal creditore; il controllo viene effettuato sul campo Nm</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChrgBr" type="CBIChargeBearerTypeCode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tipologia Commissioni</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChrgsAcct" type="CBICashAccount7" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Conto su cui sono addebitate le spese associate alle transazioni richieste</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtrSchmeId" type="CBIPartyIdentification2">
+				<xs:annotation>
+					<xs:documentation>Identificativo schema creditore </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DrctDbtTxInf" type="DirectDebitTransactionInformation1" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Informazioni relative alle singole transazioni (disposizioni)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DirectDebitTransactionInformation1">
+		<xs:sequence>
+			<xs:element name="PmtId" type="CBIPaymentIdentification1">
+				<xs:annotation>
+					<xs:documentation>Identificativi transazione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PmtTpInf" type="CBIPaymentTypeInformation2" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informazioni sul tipo di transazione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InstdAmt" type="ActiveOrHistoricCurrencyAndAmount">
+				<xs:annotation>
+					<xs:documentation>Importo della singola transazione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChrgBr" type="CBIChargeBearerTypeCode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tipologia commissioni, specifica quale parte sosterrà le commissioni associate alla transazione  </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DrctDbtTx" type="DirectDebitTransaction1">
+				<xs:annotation>
+					<xs:documentation>Informazioni sul mandato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UltmtCdtr" type="CBIPartyIdentification3" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Creditore effettivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DbtrAgt" type="CBIBranchAndFinancialInstitutionIdentification3" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Banca del Debitore</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Dbtr" type="CBIPartyIdentification4">
+				<xs:annotation>
+					<xs:documentation>Titolare c/c addebito</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DbtrAcct" type="CBICashAccount7">
+				<xs:annotation>
+					<xs:documentation>Coordinate bancarie di addebito</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UltmtDbtr" type="CBIPartyIdentification4" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Debitore effettivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InstrForCdtrAgt" type="Max140Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Istruzioni per Banca titolare del c/c di accredito bilateralmente concordate tra banca e cliente e rese in testo libero (max 140 caratteri)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Purp" type="CBIPurpose1Choice" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Causale della transazione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RgltryRptg" type="CBIRegulatoryReporting1" minOccurs="0" maxOccurs="3">
+				<xs:annotation>
+					<xs:documentation>Comunicazioni valutarie</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RmtInf" type="RemittanceInformation5" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informazioni di riconciliazione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--*********************************
+    Complex common data types
+**********************************-->
+	<xs:complexType name="ActiveOrHistoricCurrencyAndAmount">
+		<xs:simpleContent>
+			<xs:extension base="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+				<xs:attribute name="Ccy" type="ActiveOrHistoricCurrencyCode" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="AccountIdentification3Choice">
+		<xs:sequence>
+			<xs:element name="IBAN" type="IBAN2007Identifier">
+				<xs:annotation>
+					<xs:documentation>IBAN</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AmendmentInformationDetails1">
+		<xs:sequence>
+			<xs:element name="OrgnlMndtId" type="Max35Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identificativo mandato originario</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlCdtrSchmeId" type="CBIPartyIdentification6" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identificativo schema creditore originario</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlCdtrAgt" type="BranchAndFinancialInstitutionIdentification4" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Banca di accredito originaria</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlDbtr" type="CBIPartyIdentification4" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Debitore originario</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlDbtrAcct" type="CBICashAccount7" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Coordinate bancarie di addebito originarie</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlDbtrAgt" type="BranchAndFinancialInstitutionIdentification3" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Banca originaria del Debitore</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlFnlColltnDt" type="ISODate" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Data originaria della richiesta di incasso</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrgnlFrqcy" type="Frequency1Code" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Frequenza originaria</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification3">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentification7"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification4">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="CBIFinancialInstitutionIdentification7"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIBranchAndFinancialInstitutionIdentification1">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="CBIFinancialInstitutionIdentification1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIBranchAndFinancialInstitutionIdentification3">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="CBIFinancialInstitutionIdentification5Choice"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBICashAccount7">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentification3Choice">
+				<xs:annotation>
+					<xs:documentation>Identificativo conto</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIClearingSystemMemberIdentification1">
+		<xs:sequence>
+			<xs:element name="MmbId" type="Max35Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIFinancialInstitutionIdentification1">
+		<xs:sequence>
+			<xs:element name="ClrSysMmbId" type="CBIClearingSystemMemberIdentification1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIFinancialInstitutionIdentification7">
+		<xs:sequence>
+			<xs:element name="BIC" type="BICIdentifier" minOccurs="0"/>
+			<xs:element name="ClrSysMmbId" type="CBIClearingSystemMemberIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIFinancialInstitutionIdentification5Choice">
+		<xs:sequence>
+			<xs:element name="BIC" type="BICIdentifier"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIGenericIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIGenericIdentification2">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIIdType1">
+		<xs:sequence>
+			<xs:element name="OrgId" type="CBIOrganisationIdentification1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Othr" type="CBIGenericIdentification1" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIOrganisationIdentification2">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="BICOrBEI" type="AnyBICIdentifier"/>
+				<xs:element name="Othr" type="CBIGenericIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIParty1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="OrgId" type="CBIOrganisationIdentification2"/>
+				<xs:element name="PrvtId" type="CBIPersonIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIParty4Choice">
+		<xs:sequence>
+			<xs:element name="PrvtId" type="CBIPersonIdentification2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPartyIdentification1">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="Id" type="CBIIdType1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPartyIdentification2">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="CBIPostalAddress6" minOccurs="0"/>
+			<xs:element name="Id" type="CBIParty4Choice"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPartyIdentification3">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text"/>
+			<xs:element name="PstlAdr" type="CBIPostalAddress6" minOccurs="0"/>
+			<xs:element name="Id" type="CBIParty1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPartyIdentification4">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text"/>
+			<xs:element name="PstlAdr" type="CBIPostalAddress6" minOccurs="0"/>
+			<xs:element name="Id" type="CBIParty1Choice" minOccurs="0"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPartyIdentification6">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="CBIPostalAddress6" minOccurs="0"/>
+			<xs:element name="Id" type="CBIParty4Choice" minOccurs="0"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPaymentIdentification1">
+		<xs:sequence>
+			<xs:element name="InstrId" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>Identificativo univoco assegnato all'istruzione dal Mittente nei confronti della sua Banca</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EndToEndId" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>Identificativo URI assegnato dal Mittente e che identifica la singola disposizione di incasso per tutta la catena fino al Debitore.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPaymentTypeInformation2">
+		<xs:sequence>
+			<xs:element name="CtgyPurp" type="PaymentCategoryPurpose1Code">
+				<xs:annotation>
+					<xs:documentation>Finalità dell'incasso.
+Identifica le causali di alto livello dell'instruzione, basate su un set predefinito di categorie</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPaymentTypeInformation2_1">
+		<xs:sequence>
+			<xs:element name="SvcLvl" type="CBIServiceLevel3Choice">
+				<xs:annotation>
+					<xs:documentation>Livelli di servizio specifici</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LclInstrm" type="LocalInstrument1Choice">
+				<xs:annotation>
+					<xs:documentation>Strumento specifico di comunità </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SeqTp" type="SequenceType1Code">
+				<xs:annotation>
+					<xs:documentation>Tipo  sequenza di incasso </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CtgyPurp" type="PaymentCategoryPurpose1Code" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Strumento specifico di comunità </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Othr" type="CBIGenericIdentification1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPersonIdentification2">
+		<xs:sequence>
+			<xs:element name="Othr" type="CBIGenericIdentification2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPostalAddress6">
+		<xs:sequence>
+			<xs:element name="AdrTp" type="AddressType2Code" minOccurs="0"/>
+			<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+			<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+			<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIPurpose1Choice">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalPurposeCode">
+				<xs:annotation>
+					<xs:documentation>Causale in forma codificata. Gli unici valori ammessi sono quelli riportati nella tabella ISO ExternalPurposeCode pubblicata sul sito ISO20022 all'indirizzo http://www.iso20022.org/Payments_External_Code_Lists.page</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIRegulatoryReporting1">
+		<xs:sequence>
+			<xs:element name="DbtCdtRptgInd" type="CBIRegulatoryReportingType2Code"/>
+			<xs:element name="Dtls" type="CBIStructuredRegulatoryReporting1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIServiceLevel3Choice">
+		<xs:sequence>
+			<xs:element name="Cd" type="CBIServiceLevel2Code">
+				<xs:annotation>
+					<xs:documentation>Codifica di servizio</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CBIStructuredRegulatoryReporting1">
+		<xs:sequence>
+			<xs:element name="Cd" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="INF"/>
+						<xs:enumeration value="SNR"/>
+						<xs:enumeration value="CVA"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Inf" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ContactDetails2">
+		<xs:sequence>
+			<xs:element name="NmPrfx" type="NamePrefix1Code" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PhneNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="MobNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="FaxNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="EmailAdr" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="Othr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceInformation2">
+		<xs:sequence>
+			<xs:element name="Tp" type="CreditorReferenceType2" minOccurs="0"/>
+			<xs:element name="Ref" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="DocumentType3Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType2">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="CreditorReferenceType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DateAndPlaceOfBirth">
+		<xs:sequence>
+			<xs:element name="BirthDt" type="ISODate"/>
+			<xs:element name="PrvcOfBirth" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CityOfBirth" type="Max35Text"/>
+			<xs:element name="CtryOfBirth" type="CountryCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DirectDebitTransaction1">
+		<xs:sequence>
+			<xs:element name="MndtRltdInf" type="MandateRelatedInformation1">
+				<xs:annotation>
+					<xs:documentation>Informazioni specifiche relative al  mandato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PreNtfctnId" type="Max35Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Identificativo pre-notifica</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PreNtfctnDt" type="ISODate" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Data pre-notifica</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentAdjustment1">
+		<xs:sequence>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="CdtDbtInd" type="CreditDebitCode" minOccurs="0"/>
+			<xs:element name="Rsn" type="Max4Text" minOccurs="0"/>
+			<xs:element name="AddtlInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification7">
+		<xs:sequence>
+			<xs:element name="BIC" type="BICIdentifier" minOccurs="0"/>
+			<xs:element name="ClrSysMmbId" type="CBIClearingSystemMemberIdentification1" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericFinancialIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="OrganisationIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalInstrument1Choice">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalLocalInstrumentCode">
+				<xs:annotation>
+					<xs:documentation>Codice strumento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MandateRelatedInformation1">
+		<xs:sequence>
+			<xs:element name="MndtId" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>Identificativo mandato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DtOfSgntr" type="ISODate">
+				<xs:annotation>
+					<xs:documentation>Data di sottoscrizione</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AmdmntInd" type="TrueFalseIndicator" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indicatore di rettifica/variazione mandato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AmdmntInfDtls" type="AmendmentInformationDetails1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Dettagli relativi alle modifiche </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ElctrncSgntr" type="Max1025Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Firma digitale/Riferimento al mandato</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FrstColltnDt" type="ISODate" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Data della prima richiesta di incasso</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FnlColltnDt" type="ISODate" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Data della ultima richiesta di incasso</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Frqcy" type="Frequency1Code" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Frequenza incassi</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentification4">
+		<xs:sequence>
+			<xs:element name="BICOrBEI" type="AnyBICIdentifier" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalOrganisationIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification32">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="CBIPostalAddress6" minOccurs="0"/>
+			<xs:element name="Id" type="Party6Choice" minOccurs="0"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+			<xs:element name="CtctDtls" type="ContactDetails2" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Party6Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="OrgId" type="OrganisationIdentification4"/>
+				<xs:element name="PrvtId" type="PersonIdentification5"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentCategoryPurpose1Code">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentification5">
+		<xs:sequence>
+			<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalPersonIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentInformation3">
+		<xs:sequence>
+			<xs:element name="Tp" type="ReferredDocumentType2" minOccurs="0"/>
+			<xs:element name="Nb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RltdDt" type="ISODate" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="DocumentType5Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType2">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="ReferredDocumentType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceAmount1">
+		<xs:sequence>
+			<xs:element name="DuePyblAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="DscntApldAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="CdtNoteAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="AdjstmntAmtAndRsn" type="DocumentAdjustment1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformation5">
+		<xs:sequence>
+			<xs:element name="Ustrd" type="Max140Text" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Strd" type="StructuredRemittanceInformation7" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceLevel3Choice">
+		<xs:sequence>
+			<xs:element name="Cd" type="ServiceLevel2Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformation7">
+		<xs:sequence>
+			<xs:element name="RfrdDocInf" type="ReferredDocumentInformation3" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RfrdDocAmt" type="RemittanceAmount1" minOccurs="0"/>
+			<xs:element name="CdtrRefInf" type="CreditorReferenceInformation2" minOccurs="0"/>
+			<xs:element name="Invcr" type="PartyIdentification32" minOccurs="0"/>
+			<xs:element name="Invcee" type="PartyIdentification32" minOccurs="0"/>
+			<xs:element name="AddtlRmtInf" type="Max140Text" minOccurs="0" maxOccurs="3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--*********************************
+    Simple common data types
+**********************************-->
+	<xs:simpleType name="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+			<xs:fractionDigits value="5"/>
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{3,3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AddressType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ADDR"/>
+			<xs:enumeration value="PBOX"/>
+			<xs:enumeration value="HOME"/>
+			<xs:enumeration value="BIZZ"/>
+			<xs:enumeration value="MLTO"/>
+			<xs:enumeration value="DLVY"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AnyBICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BatchBookingIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="BICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CBIChargeBearerTypeCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SLEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CBIRegulatoryReportingType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRED"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CBIServiceLevel2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SEPA"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CreditDebitCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRDT"/>
+			<xs:enumeration value="DBIT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DecimalNumber">
+		<xs:restriction base="xs:decimal">
+			<xs:fractionDigits value="17"/>
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentType3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RADM"/>
+			<xs:enumeration value="RPIN"/>
+			<xs:enumeration value="FXDR"/>
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="PUOR"/>
+			<xs:enumeration value="SCOR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentType5Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="MSIN"/>
+			<xs:enumeration value="CNFA"/>
+			<xs:enumeration value="DNFA"/>
+			<xs:enumeration value="CINV"/>
+			<xs:enumeration value="CREN"/>
+			<xs:enumeration value="DEBN"/>
+			<xs:enumeration value="HIRI"/>
+			<xs:enumeration value="SBIN"/>
+			<xs:enumeration value="CMCN"/>
+			<xs:enumeration value="SOAC"/>
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="BOLD"/>
+			<xs:enumeration value="VCHR"/>
+			<xs:enumeration value="AROI"/>
+			<xs:enumeration value="TSUT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCategoryPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalLocalInstrumentCode">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalOrganisationIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPersonIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPurposeCode">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Frequency1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="YEAR"/>
+			<xs:enumeration value="MNTH"/>
+			<xs:enumeration value="QURT"/>
+			<xs:enumeration value="MIAN"/>
+			<xs:enumeration value="WEEK"/>
+			<xs:enumeration value="DAIL"/>
+			<xs:enumeration value="ADHO"/>
+			<xs:enumeration value="INDA"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IBAN2007Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ISODate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="ISODateTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="Max4Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max15NumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max16Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="16"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max70Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="70"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max140Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="140"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max1025Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="1025"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max2048Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="2048"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NamePrefix1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DOCT"/>
+			<xs:enumeration value="MIST"/>
+			<xs:enumeration value="MISS"/>
+			<xs:enumeration value="MADM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PaymentMethod2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DD"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PhoneNumber">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\+[0-9]{1,3}-[0-9()+\-]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SequenceType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="FRST"/>
+			<xs:enumeration value="RCUR"/>
+			<xs:enumeration value="FNAL"/>
+			<xs:enumeration value="OOFF"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ServiceLevel2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SEPA"/>
+			<xs:enumeration value="SDVA"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TrueFalseIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+</xs:schema>

--- a/account_banking_sepa_direct_debit/models/account_payment_method.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_method.py
@@ -13,6 +13,7 @@ class AccountPaymentMethod(models.Model):
         ('pain.008.001.03', 'pain.008.001.03'),
         ('pain.008.001.04', 'pain.008.001.04'),
         ('pain.008.003.02', 'pain.008.003.02 (direct debit in Germany)'),
+        ('CBIBdySDDReq.00.01.00', 'CBIBdySDDReq.00.01.00 (CBI SDD Italy)'),
         ])
 
     @api.multi
@@ -20,7 +21,7 @@ class AccountPaymentMethod(models.Model):
         self.ensure_one()
         if self.pain_version in [
                 'pain.008.001.02', 'pain.008.001.03', 'pain.008.001.04',
-                'pain.008.003.02']:
+                'pain.008.003.02', 'CBIBdySDDReq.00.01.00']:
             path = 'account_banking_sepa_direct_debit/data/%s.xsd'\
                 % self.pain_version
             return path

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -2,7 +2,7 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models, _
+from odoo import api, models, fields, _
 from odoo.exceptions import UserError
 from lxml import etree
 
@@ -10,13 +10,21 @@ from lxml import etree
 class AccountPaymentOrder(models.Model):
     _inherit = 'account.payment.order'
 
+    scheme = fields.Selection([
+        ('CORE', 'Basic (CORE)'),
+        ('B2B', 'Enterprise (B2B)')],
+        string='Scheme', default=lambda self: self.env.user.company_id.sepa_payment_order_schema,
+        track_visibility='onchange')
+
     @api.multi
     def generate_payment_file(self):
         """Creates the SEPA Direct Debit file. That's the important code !"""
         self.ensure_one()
         if self.payment_method_id.code != 'sepa_direct_debit':
             return super(AccountPaymentOrder, self).generate_payment_file()
+        pain_split = self.payment_method_id.pain_version.split('-',1)
         pain_flavor = self.payment_method_id.pain_version
+        pain_variant = pain_split[1] if len(pain_split) > 1 else ''
         # We use pain_flavor.startswith('pain.008.001.xx')
         # to support country-specific extensions such as
         # pain.008.001.02.ch.01 (cf l10n_ch_sepa)
@@ -36,12 +44,16 @@ class AccountPaymentOrder(models.Model):
             bic_xml_tag = 'BICFI'
             name_maxsize = 140
             root_xml_tag = 'CstmrDrctDbtInitn'
+        elif pain_flavor.startswith('CBIBdySDDReq'):
+            bic_xml_tag = 'BIC'
+            name_maxsize = 70
+            root_xml_tag = False
         else:
             raise UserError(
                 _("Payment Type Code '%s' is not supported. The only "
                   "Payment Type Code supported for SEPA Direct Debit are "
-                  "'pain.008.001.02', 'pain.008.001.03' and "
-                  "'pain.008.001.04'.") % pain_flavor)
+                  "'pain.008.001.02', 'pain.008.001.03', "
+                  "'pain.008.001.04' and 'CBIBdySDDReq.00.01.00'.") % pain_flavor)
         pay_method = self.payment_mode_id.payment_method_id
         xsd_file = pay_method.get_xsd_file_path()
         gen_args = {
@@ -55,10 +67,18 @@ class AccountPaymentOrder(models.Model):
         }
         nsmap = self.generate_pain_nsmap()
         attrib = self.generate_pain_attrib()
-        xml_root = etree.Element('Document', nsmap=nsmap, attrib=attrib)
-        pain_root = etree.SubElement(xml_root, root_xml_tag)
+        if pain_flavor.startswith( 'CBIBdySDDReq' ):
+            xml_root = etree.Element('CBIBdySDDReq', nsmap=nsmap, attrib=attrib)
+            xml_root.attrib['{{{xsi}}}schemaLocation'.format(xsi=nsmap['xsi'])] = 'urn:CBI:xsd:{pain_flavor} {pain_flavor}.xsd'.\
+                format(pain_flavor=pain_flavor)
+        else:
+            xml_root = etree.Element('Document', nsmap=nsmap, attrib=attrib)
+        if root_xml_tag:
+            pain_root = etree.SubElement(xml_root, root_xml_tag)
+        else:
+            pain_root = xml_root
         # A. Group header
-        group_header, nb_of_transactions_a, control_sum_a = \
+        group_header, nb_of_transactions_a, control_sum_a, payment_root = \
             self.generate_group_header_block(pain_root, gen_args)
         transactions_count_a = 0
         amount_control_sum_a = 0.0
@@ -118,7 +138,7 @@ class AccountPaymentOrder(models.Model):
             # B. Payment info
             payment_info, nb_of_transactions_b, control_sum_b = \
                 self.generate_start_payment_info_block(
-                    pain_root,
+                    payment_root,
                     "self.name + '-' + "
                     "sequence_type + '-' + requested_date.replace('-', '')  "
                     "+ '-' + priority + '-' + category_purpose",
@@ -156,11 +176,18 @@ class AccountPaymentOrder(models.Model):
                     payment_info, 'DrctDbtTxInf')
                 payment_identification = etree.SubElement(
                     dd_transaction_info, 'PmtId')
-                instruction_identification = etree.SubElement(
-                    payment_identification, 'InstrId')
-                instruction_identification.text = self._prepare_field(
-                    'Instruction Identification', 'line.name',
-                    {'line': line}, 35, gen_args=gen_args)
+                if pain_flavor == 'pain.008.001.02.ch.01':
+                    instruction_identification = etree.SubElement(
+                        payment_identification, 'InstrId')
+                    instruction_identification.text = self._prepare_field(
+                        'Instruction Identification', 'line.name',
+                        {'line': line}, 35, gen_args=gen_args)
+                if pain_flavor.startswith('CBIBdySDDReq'):
+                    instruction_identification = etree.SubElement(
+                        payment_identification, 'InstrId')
+                    instruction_identification.text = self._prepare_field(
+                        'Instruction Identification', 'line.name',
+                        {'line': line}, 6, gen_args=gen_args)
                 end2end_identification = etree.SubElement(
                     payment_identification, 'EndToEndId')
                 end2end_identification.text = self._prepare_field(
@@ -222,8 +249,9 @@ class AccountPaymentOrder(models.Model):
                 self.generate_remittance_info_block(
                     dd_transaction_info, line, gen_args)
 
-            nb_of_transactions_b.text = unicode(transactions_count_b)
-            control_sum_b.text = '%.2f' % amount_control_sum_b
+            if nb_of_transactions_b:
+                nb_of_transactions_b.text = unicode(transactions_count_b)
+                control_sum_b.text = '%.2f' % amount_control_sum_b
         nb_of_transactions_a.text = unicode(transactions_count_a)
         control_sum_a.text = '%.2f' % amount_control_sum_a
 

--- a/account_banking_sepa_direct_debit/models/res_company.py
+++ b/account_banking_sepa_direct_debit/models/res_company.py
@@ -20,6 +20,11 @@ class ResCompany(models.Model):
              "checkum\n- a 3-letters business code\n- a country-specific "
              "identifier")
 
+    sepa_payment_order_schema = fields.Selection([
+        ('CORE', 'Basic (CORE)'),
+        ('B2B', 'Enterprise (B2B)')],
+        string='Payment Order Scheme', default="CORE")
+
     @api.multi
     @api.constrains('sepa_creditor_identifier')
     def _check_sepa_creditor_identifier(self):

--- a/account_banking_sepa_direct_debit/models/res_config.py
+++ b/account_banking_sepa_direct_debit/models/res_config.py
@@ -10,3 +10,7 @@ class AccountConfigSettings(models.TransientModel):
 
     sepa_creditor_identifier = fields.Char(
         related='company_id.sepa_creditor_identifier')
+
+    sepa_payment_order_schema = fields.Selection(
+        related='company_id.sepa_payment_order_schema'
+    )

--- a/account_banking_sepa_direct_debit/views/account_payment_order.xml
+++ b/account_banking_sepa_direct_debit/views/account_payment_order.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_payment_order_form_inherit" model="ir.ui.view">
+        <field name="name">account.payment.order.form.inherit</field>
+        <field name="model">account.payment.order</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='journal_id']" position="before">
+                <field name="scheme"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="account_payment_order_tree_inherit" model="ir.ui.view">
+        <field name="name">account.payment.order.tree.inherit</field>
+        <field name="model">account.payment.order</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_order_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_mode_id']" position="after">
+                <field name="scheme"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_banking_sepa_direct_debit/views/res_config.xml
+++ b/account_banking_sepa_direct_debit/views/res_config.xml
@@ -10,6 +10,7 @@
         <group name="pain" position="inside">
             <field name="sepa_creditor_identifier"
                 placeholder="Write the ICS of your company"/>
+            <field name="sepa_payment_order_schema"/>
         </group>
     </field>
 </record>


### PR DESCRIPTION
Hi,

with this PR I've added the Italian CBI SEPA SDD support. It's currently working since several months now without any issue on several Italian banks.

In particular there is one change which need to be discussed, the  because I haven't found a different way to address it. Actually I've added the scheme selection under account.payment.order because this is necessary as per payment order, so I would like to know if you have a different approach for that.
