### PR TITLE
[10.0] Make bank address optional in XML generation

### DIFF
--- a/account_banking_pain_base/models/account_payment_method.py
+++ b/account_banking_pain_base/models/account_payment_method.py
@@ -15,6 +15,14 @@ class AccountPaymentMethod(models.Model):
         help="If active, Odoo will convert each accented character to "
         "the corresponding unaccented character, so that only ASCII "
         "characters are used in the generated PAIN file.")
+    pain_bank_address = fields.Boolean(
+        string='Bank Address in PAIN XML',
+        help="If enabled, the name and address of the bank will be set "
+        "in the appropriate XML tags (if the bank account is linked to a "
+        "bank and if the information is set on the related bank). "
+        "Some banks reject PAIN XML files that contain the name and "
+        "address of the bank, although the ISO 20022 "
+        "standard and the EPC guidelines specify this possibility.")
 
     @api.multi
     def get_xsd_file_path(self):

--- a/account_banking_pain_base/views/account_payment_method.xml
+++ b/account_banking_pain_base/views/account_payment_method.xml
@@ -11,6 +11,8 @@
             <field name="pain_version"/>
             <field name="convert_to_ascii"
                 attrs="{'invisible': [('pain_version', '=', False)]}"/>
+            <field name="pain_bank_address"
+                attrs="{'invisible': [('pain_version', '=', False)]}"/>
         </field>
     </field>
 </record>

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -28,10 +28,11 @@ class AccountPaymentOrder(models.Model):
     def generate_payment_file(self):
         """Creates the SEPA Credit Transfer file. That's the important code!"""
         self.ensure_one()
-        if self.payment_method_id.code != 'sepa_credit_transfer':
+        pay_method = self.payment_method_id
+        if pay_method.code != 'sepa_credit_transfer':
             return super(AccountPaymentOrder, self).generate_payment_file()
 
-        pain_flavor = self.payment_method_id.pain_version
+        pain_flavor = pay_method.pain_version
         if not pain_flavor:
             pain_flavor = 'pain.001.001.03'
         # We use pain_flavor.startswith('pain.001.001.xx')
@@ -71,11 +72,12 @@ class AccountPaymentOrder(models.Model):
         else:
             raise UserError(
                 _("PAIN version '%s' is not supported.") % pain_flavor)
-        xsd_file = self.payment_method_id.get_xsd_file_path()
+        xsd_file = pay_method.get_xsd_file_path()
         gen_args = {
             'bic_xml_tag': bic_xml_tag,
             'name_maxsize': name_maxsize,
-            'convert_to_ascii': self.payment_method_id.convert_to_ascii,
+            'convert_to_ascii': pay_method.convert_to_ascii,
+            'pain_bank_address': pay_method.pain_bank_address,
             'payment_method': 'TRF',
             'file_prefix': 'sct_',
             'pain_flavor': pain_flavor,

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -14,9 +14,10 @@ class AccountPaymentOrder(models.Model):
     def generate_payment_file(self):
         """Creates the SEPA Direct Debit file. That's the important code !"""
         self.ensure_one()
-        if self.payment_method_id.code != 'sepa_direct_debit':
+        pay_method = self.payment_method_id
+        if pay_method.code != 'sepa_direct_debit':
             return super(AccountPaymentOrder, self).generate_payment_file()
-        pain_flavor = self.payment_method_id.pain_version
+        pain_flavor = pay_method.pain_version
         # We use pain_flavor.startswith('pain.008.001.xx')
         # to support country-specific extensions such as
         # pain.008.001.02.ch.01 (cf l10n_ch_sepa)
@@ -42,12 +43,12 @@ class AccountPaymentOrder(models.Model):
                   "Payment Type Code supported for SEPA Direct Debit are "
                   "'pain.008.001.02', 'pain.008.001.03' and "
                   "'pain.008.001.04'.") % pain_flavor)
-        pay_method = self.payment_mode_id.payment_method_id
         xsd_file = pay_method.get_xsd_file_path()
         gen_args = {
             'bic_xml_tag': bic_xml_tag,
             'name_maxsize': name_maxsize,
             'convert_to_ascii': pay_method.convert_to_ascii,
+            'pain_bank_address': pay_method.pain_bank_address,
             'payment_method': 'DD',
             'file_prefix': 'sdd_',
             'pain_flavor': pain_flavor,


### PR DESCRIPTION
Some banks, at least in France, refuse files with bank addresses => new field 'pain_bank_address' on account.payment.method.

Improve bank address block
Other small code improvements

By the way, after some more reading of the EPC guidelines, I'm not fully convinced about the way the generation of the address block was modified by @sbidoul , see my comment on this commit https://github.com/OCA/bank-payment/commit/89f4735d03fb5b98f2c9637694331d6efd209a29 