### PR TITLE
[IMP] set a filename according to the name of the mandate

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -34,11 +34,13 @@ class AccountBankingMandate(models.Model):
             'account.banking.mandate'))
     unique_mandate_reference = fields.Char(
         string='Unique Mandate Reference', track_visibility='onchange')
+
     signature_date = fields.Date(string='Date of Signature of the Mandate',
                                  track_visibility='onchange')
     scan = fields.Binary(string='Scan of the Mandate')
     last_debit_date = fields.Date(string='Date of the Last Debit',
                                   readonly=True)
+    filename = fields.Char(string='Filename', readonly=True)
     state = fields.Selection([
         ('draft', 'Draft'),
         ('valid', 'Valid'),
@@ -95,6 +97,8 @@ class AccountBankingMandate(models.Model):
             vals['unique_mandate_reference'] = \
                 self.env['ir.sequence'].next_by_code(
                     'account.banking.mandate') or 'New'
+            vals['filename'] = '{}.pdf'.format(
+                    vals['unique_mandate_reference'])
         return super(AccountBankingMandate, self).create(vals)
 
     @api.multi

--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -37,7 +37,8 @@
                         invisible="context.get('mandate_bank_partner_view')"
                         readonly="True"/>
                     <field name="signature_date"/>
-                    <field name="scan"/>
+                    <field name="scan" filename="filename"/>
+                    <field name="filename" invisible="True"/>
                     <field name="last_debit_date"/>
                 </group>
                 <group name="payment_lines" string="Related Payment Lines">


### PR DESCRIPTION
Actually, the file store in the mandate is not named correctly, so the user cannot open it if he wants to download it from the odoo interface.