### PR TITLE
[12.0] [REF] Payment Order: better performance of draft2open method

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -280,7 +280,12 @@ class AccountPaymentOrder(models.Model):
                             payline.ml_maturity_date,
                             requested_date))
                 # Write requested_date on 'date' field of payment line
-                payline.date = requested_date
+                # norecompute is for avoiding a chained recomputation
+                # payment_line_ids.date
+                # > payment_line_ids.amount_company_currency
+                # > total_company_currency
+                with self.env.norecompute():
+                    payline.date = requested_date
                 # Group options
                 if order.payment_mode_id.group_lines:
                     hashcode = payline.payment_line_hashcode()
@@ -296,6 +301,7 @@ class AccountPaymentOrder(models.Model):
                         'paylines': payline,
                         'total': payline.amount_currency,
                     }
+            order.recompute()
             # Create bank payment lines
             for paydict in list(group_paylines.values()):
                 # Block if a bank payment line is <= 0


### PR DESCRIPTION
Add a norecompute in draft2open to avoid the recomputation of total_company_currency n times (where n is the number of payment lines)