### PR TITLE
[12.0] [IMP] Payment Order: due on field in payment line wizard

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -15,6 +15,7 @@
             <group name="main">
                 <field name="order_id" invisible="1"/>
                 <field name="date_type"/>
+                <field name="due_on"/>
                 <field name="move_date" attrs="{'required': [('date_type', '=', 'move')], 'invisible': [('date_type', '!=', 'move')]}"/>
                 <field name="due_date" attrs="{'required': [('date_type', '=', 'due')], 'invisible': [('date_type', '!=', 'due')]}"/>
                 <field name="journal_ids"


### PR DESCRIPTION
New field `due_on` on the payment line wizard allowing to select the operator (`<=` or `=`) to apply on the due date or move date. Default operator remains `<=`.