### PR TITLE
[11.0][FIX] account_payment_mode res.partner view banks group attribute

### DIFF
--- a/account_payment_mode/views/res_partner.xml
+++ b/account_payment_mode/views/res_partner.xml
@@ -12,7 +12,7 @@ which prevents the selection of a contact -->
     <field name="inherit_id" ref="account.partner_view_buttons"/>
     <field name="arch" type="xml">
         <group name="banks" position="attributes">
-            <attribute name="attrs">{'invisible': [('parent_id', '!=', False)]}</attribute>
+            <attribute name="attrs">{'invisible': [('parent_id', '!=', False), ('is_company', '=', False)]}</attribute>
         </group>
     </field>
 </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The modules adds `{'invisible': [('parent_id', '!=', False)]}` attribute
to `banks` group on res.partner form view. The rationale for this,
according to a comment on the view itself is:
> ... there is a domain on the 'partner_id' field of res.partner.bank
(base module) which prevents the selection of a contact

However, the domain the comment refers to is
`['|', ('is_company', '=', True), ('parent_id', '=', False)]`
So, I think the domain for the group to be invisible should be
`[('parent_id', '!=', False), ('is_company', '=', False)]`. In addition,
a parent that is a company is always its own commercial partner. So we
should have access to its payment information.

Current behavior before PR:

Bank and mandates information is hidden when a partner is a company and
has a parent.

Desired behavior after PR is merged:

Banking information should be visible if a partner is a company.