### PR TITLE
[10.0][ADD] structured communication type in payment.order.line

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -54,6 +54,7 @@ class AccountPaymentLine(models.Model):
         help="Label of the payment that will be seen by the destinee")
     communication_type = fields.Selection([
         ('normal', 'Free'),
+        ('structured', 'Structured'),
         ], string='Communication Type', required=True, default='normal')
     # v8 field : state
     bank_line_id = fields.Many2one(


### PR DESCRIPTION
Structured type has been added here : 
https://github.com/OCA/bank-payment/commit/6d99bff7dfd7649fc49c24b3cde2be1f2d671666
but it hasn't been added on communication_type in payment line