### PR TITLE
[11.0] Set account number partner_id (supplier)

### DIFF
--- a/account_payment_purchase/views/purchase_order_view.xml
+++ b/account_payment_purchase/views/purchase_order_view.xml
@@ -13,7 +13,7 @@
                 <field name="payment_mode_id"
                     domain="[('payment_type', '=', 'outbound')]"
                     widget="selection"/>
-                <field name="supplier_partner_bank_id" context="{'default_partner_id':partner_id}"/>/>
+                <field name="supplier_partner_bank_id" context="{'default_partner_id':partner_id}"/>
             </field>
         </field>
     </record>

--- a/account_payment_purchase/views/purchase_order_view.xml
+++ b/account_payment_purchase/views/purchase_order_view.xml
@@ -13,7 +13,7 @@
                 <field name="payment_mode_id"
                     domain="[('payment_type', '=', 'outbound')]"
                     widget="selection"/>
-                <field name="supplier_partner_bank_id"/>
+                <field name="supplier_partner_bank_id" context="{'default_partner_id':partner_id}"/>/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Set a context to the bank account created from the purchase order, if not set then is assigned to the main company as the account owner.