### PR TITLE
[FIX] account_payment_order: Fix journal domain

### DIFF
--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -35,7 +35,11 @@
                         <field name="payment_mode_id"
                             domain="[('payment_order_ok', '=', True), ('payment_type', '=', payment_type)]"
                             widget="selection"/>
-                        <field name="journal_id" widget="selection"/>
+                        <field name="allowed_journal_ids" invisible="1"/>
+                        <field name="journal_id"
+                            widget="selection"
+                            domain="[('id', 'in', allowed_journal_ids)]"
+                        />
                         <field name="bank_account_link" invisible="1"/>
                         <field name="company_partner_bank_id"/>
                         <field name="company_id" groups="base.group_multi_company"/>


### PR DESCRIPTION
Steps to reproduce
------------------

* Create a payment mode with "Link to Bank Account" = "Variable".
* Select several journals.
* Create a payment order with that payment mode.
* Save.
* Go to other menu and come back to payment order.
* Try to select a journal: the list is empty.

Fixes #544

@Tecnativa