### PR TITLE
[12.0] [FIX] Account Banking SEPA Direct Debit: creditor identifier in config

### DIFF
--- a/account_banking_sepa_direct_debit/models/res_config.py
+++ b/account_banking_sepa_direct_debit/models/res_config.py
@@ -8,4 +8,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     sepa_creditor_identifier = fields.Char(
-        related='company_id.sepa_creditor_identifier')
+        related='company_id.sepa_creditor_identifier',
+        readonly=False,
+    )


### PR DESCRIPTION
The sepa_creditor_identifier in res.config.settings is readonly by default (related) but shouldn't be.