### PR TITLE
[12.0] [REF] Payment Order: allow add to order from invoice if order exists

### DIFF
--- a/account_payment_order/models/account_invoice.py
+++ b/account_payment_order/models/account_invoice.py
@@ -79,7 +79,8 @@ class AccountInvoice(models.Model):
                 lambda x: (
                     not x.reconciled and x.payment_mode_id.payment_order_ok and
                     x.account_id.internal_type in ('receivable', 'payable') and
-                    not x.payment_line_ids
+                    not any(p_state in ('draft', 'open', 'generated')
+                            for p_state in x.payment_line_ids.mapped('state'))
                 )
             )
             if not applicable_lines:


### PR DESCRIPTION
This commit allows to add an invoice to an order even if it's in orders that are not in progress.
In progress orders are orders in draft, open or generated states.