### PR TITLE
[FIX] account_payment_order: select payable and receivable lines

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -102,7 +102,7 @@ class AccountPaymentLineCreate(models.TransientModel):
             domain += [
                 ('credit', '>', 0),
                 #  '|',
-                ('account_id.internal_type', '=', 'payable'),
+                ('account_id.internal_type', 'in', ['payable', 'receivable']),
                 #  '&',
                 #  ('account_id.internal_type', '=', 'receivable'),
                 #  ('reconcile_partial_id', '=', False),  # TODO uncomment
@@ -110,7 +110,7 @@ class AccountPaymentLineCreate(models.TransientModel):
         elif self.order_id.payment_type == 'inbound':
             domain += [
                 ('debit', '>', 0),
-                ('account_id.internal_type', '=', 'receivable'),
+                ('account_id.internal_type', 'in', ['receivable', 'payable']),
                 ]
         # Exclude lines that are already in a non-cancelled
         # and non-uploaded payment order; lines that are in a


### PR DESCRIPTION
When selecting move lines to create transactions, take into account
payable and receivable lines (to include refunds) as it is done in v11.