### PR TITLE
[FIX] account_payment_order filter transfer_account_id and transfer_journal_id

### DIFF
--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -35,9 +35,10 @@
                 <field name="offsetting_account" widget="radio"
                     attrs="{'required': [('generate_move', '=', True)], 'invisible': [('generate_move', '=', False)]}"/>
                 <field name="transfer_account_id"
+                    domain="[('company_id', '=', company_id)]"
                     attrs="{'invisible': [('offsetting_account', '!=', 'transfer_account')], 'required': [('offsetting_account', '=', 'transfer_account')]}"
                     context="{'default_reconcile': True, 'default_company_id': company_id}"/> <!-- We can't put a default vue to user_type_id... -->
-                <field name="transfer_journal_id"
+                <field name="transfer_journal_id" domain="[('company_id', '=', company_id)]"
                     attrs="{'invisible': [('offsetting_account', '!=', 'transfer_account')], 'required': [('offsetting_account', '=', 'transfer_account')]}"/>
                 <field name="move_option"
                     attrs="{'invisible': [('generate_move', '=', False)], 'required': [('generate_move', '=', True)]}"/>


### PR DESCRIPTION
Now transfer_account_id and transfer_journal_id are filtered by company_id in the account_payment_mode view