### PR TITLE
[12.0] [REF] Account Payment Order: split generate_move method

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -380,6 +380,15 @@ class AccountPaymentOrder(models.Model):
             'payment_order_id': self.id,
             'line_ids': [],
             }
+        total_company_currency = total_payment_currency = 0
+        for bline in bank_lines:
+            total_company_currency += bline.amount_company_currency
+            total_payment_currency += bline.amount_currency
+            partner_ml_vals = self._prepare_move_line_partner_account(bline)
+            vals['line_ids'].append((0, 0, partner_ml_vals))
+        trf_ml_vals = self._prepare_move_line_offsetting_account(
+            total_company_currency, total_payment_currency, bank_lines)
+        vals['line_ids'].append((0, 0, trf_ml_vals))
         return vals
 
     @api.multi
@@ -466,16 +475,6 @@ class AccountPaymentOrder(models.Model):
         post_move = self.payment_mode_id.post_move
         am_obj = self.env['account.move']
         mvals = self._prepare_move(blines)
-        total_company_currency = total_payment_currency = 0
-        for bline in blines:
-            total_company_currency += bline.amount_company_currency
-            total_payment_currency += bline.amount_currency
-            partner_ml_vals = self._prepare_move_line_partner_account(
-                bline)
-            mvals['line_ids'].append((0, 0, partner_ml_vals))
-        trf_ml_vals = self._prepare_move_line_offsetting_account(
-            total_company_currency, total_payment_currency, blines)
-        mvals['line_ids'].append((0, 0, trf_ml_vals))
         move = am_obj.create(mvals)
         blines.reconcile_payment_lines()
         if post_move:

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -461,18 +461,35 @@ class AccountPaymentOrder(models.Model):
         return vals
 
     @api.multi
-    def generate_move(self):
+    def _create_reconcile_move(self, hashcode, blines):
+        self.ensure_one()
+        post_move = self.payment_mode_id.post_move
+        am_obj = self.env['account.move']
+        mvals = self._prepare_move(blines)
+        total_company_currency = total_payment_currency = 0
+        for bline in blines:
+            total_company_currency += bline.amount_company_currency
+            total_payment_currency += bline.amount_currency
+            partner_ml_vals = self._prepare_move_line_partner_account(
+                bline)
+            mvals['line_ids'].append((0, 0, partner_ml_vals))
+        trf_ml_vals = self._prepare_move_line_offsetting_account(
+            total_company_currency, total_payment_currency, blines)
+        mvals['line_ids'].append((0, 0, trf_ml_vals))
+        move = am_obj.create(mvals)
+        blines.reconcile_payment_lines()
+        if post_move:
+            move.post()
+
+    @api.multi
+    def _prepare_trf_moves(self):
         """
-        Create the moves that pay off the move lines from
-        the payment/debit order.
+        prepare a dict "trfmoves" that can be used when
+        self.payment_mode_id.move_option = date or line
+        key = unique identifier (date or True or line.id)
+        value = bank_pay_lines (recordset that can have several entries)
         """
         self.ensure_one()
-        am_obj = self.env['account.move']
-        post_move = self.payment_mode_id.post_move
-        # prepare a dict "trfmoves" that can be used when
-        # self.payment_mode_id.move_option = date or line
-        # key = unique identifier (date or True or line.id)
-        # value = bank_pay_lines (recordset that can have several entries)
         trfmoves = {}
         for bline in self.bank_line_ids:
             hashcode = bline.move_line_offsetting_account_hashcode()
@@ -480,20 +497,15 @@ class AccountPaymentOrder(models.Model):
                 trfmoves[hashcode] += bline
             else:
                 trfmoves[hashcode] = bline
+        return trfmoves
 
+    @api.multi
+    def generate_move(self):
+        """
+        Create the moves that pay off the move lines from
+        the payment/debit order.
+        """
+        self.ensure_one()
+        trfmoves = self._prepare_trf_moves()
         for hashcode, blines in trfmoves.items():
-            mvals = self._prepare_move(blines)
-            total_company_currency = total_payment_currency = 0
-            for bline in blines:
-                total_company_currency += bline.amount_company_currency
-                total_payment_currency += bline.amount_currency
-                partner_ml_vals = self._prepare_move_line_partner_account(
-                    bline)
-                mvals['line_ids'].append((0, 0, partner_ml_vals))
-            trf_ml_vals = self._prepare_move_line_offsetting_account(
-                total_company_currency, total_payment_currency, blines)
-            mvals['line_ids'].append((0, 0, trf_ml_vals))
-            move = am_obj.create(mvals)
-            blines.reconcile_payment_lines()
-            if post_move:
-                move.post()
+            self._create_reconcile_move(hashcode, blines)


### PR DESCRIPTION
Split the heavy `generate_move` for easier overrides. 