### PR TITLE
[FIX] 11.0 Account Payment Order: domain bug on create line wizard

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '11.0.1.3.0',
+    'version': '11.0.1.3.1',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/models/account_invoice.py
+++ b/account_payment_order/models/account_invoice.py
@@ -3,7 +3,7 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -1,7 +1,7 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import fields, models
 
 
 class AccountMove(models.Model):

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from lxml import etree
-from odoo import models, fields, api
+from odoo import api, fields, models
 from odoo.osv import orm
 
 

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -1,7 +1,7 @@
 # © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -4,7 +4,7 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
 

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import base64
-from odoo import models, fields, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 
 

--- a/account_payment_order/models/bank_payment_line.py
+++ b/account_payment_order/models/bank_payment_line.py
@@ -1,7 +1,7 @@
 # © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 

--- a/account_payment_order/models/res_bank.py
+++ b/account_payment_order/models/res_bank.py
@@ -1,7 +1,7 @@
 # © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, api, _
+from odoo import api, models, _
 from odoo.exceptions import ValidationError
 
 

--- a/account_payment_order/wizard/account_invoice_payment_line_multi.py
+++ b/account_payment_order/wizard/account_invoice_payment_line_multi.py
@@ -2,7 +2,7 @@
 # © 2016 Akretion (<https://www.akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, api
+from odoo import api, models
 
 
 class AccountInvoicePaymentLineMulti(models.TransientModel):

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -5,7 +5,7 @@
 # © 2015-2016 Akretion (<https://www.akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, fields, models
 
 
 class AccountPaymentLineCreate(models.TransientModel):
@@ -126,16 +126,9 @@ class AccountPaymentLineCreate(models.TransientModel):
         domain = self._prepare_move_line_domain()
         lines = self.env['account.move.line'].search(domain)
         self.move_line_ids = lines
-        action = {
-            'name': _('Select Move Lines to Create Transactions'),
-            'type': 'ir.actions.act_window',
-            'res_model': 'account.payment.line.create',
-            'view_mode': 'form',
-            'target': 'new',
-            'res_id': self.id,
-            'context': self._context,
+        return {
+            "type": "ir.actions.do_nothing",
         }
-        return action
 
     @api.onchange(
         'date_type', 'move_date', 'due_date', 'journal_ids', 'invoice',


### PR DESCRIPTION
When `populate` method was called and a the wizard action was  again to refresh the view, the dynamic domain of `move_line_ids` was lost. Updating move_line_ids field and returning `ir.actions.do_nothing` solves the issue.