### PR TITLE
[12.0] [REF] Banking Mandate: move payment lines list in shortcut button

### DIFF
--- a/account_banking_mandate/tests/test_invoice_mandate.py
+++ b/account_banking_mandate/tests/test_invoice_mandate.py
@@ -31,6 +31,7 @@ class TestInvoiceMandate(TransactionCase):
         payment_order.draft2open()
         payment_order.open2generated()
         payment_order.generated2uploaded()
+        self.assertEqual(self.mandate.payment_line_ids_count, 1)
 
     def test_post_invoice_02(self):
         partner_2 = self._create_res_partner('Jane with ACME Bank')

--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -23,6 +23,7 @@
                 <field name="state" widget="statusbar"/>
             </header>
             <sheet>
+                <div class="oe_button_box" name="button_box"/>
                 <div class="oe_title">
                     <h1>
                         <field name="unique_mandate_reference"
@@ -44,15 +45,32 @@
                     <field name="scan"/>
                     <field name="last_debit_date"/>
                 </group>
-                <group name="payment_lines" string="Related Payment Lines">
-                    <field name="payment_line_ids" nolabel="1"/>
-                </group>
             </sheet>
             <div class="oe_chatter">
                 <field name="message_follower_ids" widget="mail_followers"/>
                 <field name="message_ids" widget="mail_thread"/>
             </div>
         </form>
+    </field>
+</record>
+
+<record id="views_mandate_form_buttons" model="ir.ui.view">
+    <field name="name">view.mandate.form.buttons</field>
+    <field name="model">account.banking.mandate</field>
+    <field name="inherit_id" ref="account_banking_mandate.view_mandate_form"/>
+    <field name="groups_id" eval="[(6, 0, [ref('account_payment_order.group_account_payment')])]"/>
+    <field name="arch" type="xml">
+        <div name="button_box" position="inside">
+            <button name="show_payment_lines"
+                    help="Payment lines"
+                    class="oe_stat_button"
+                    icon="fa-list"
+                    type="object">
+                <field name="payment_line_ids_count"
+                       widget="statinfo"
+                       string="Payment lines"/>
+            </button>
+        </div>
     </field>
 </record>
 


### PR DESCRIPTION
It allows a user with no access on payment lines to open mandates.

* Before: 
![Screenshot from 2019-03-12 16-14-29](https://user-images.githubusercontent.com/16916103/54211660-fd544700-44e1-11e9-9d2b-a06408b41618.png)
* After: 
![Screenshot from 2019-03-12 16-13-49](https://user-images.githubusercontent.com/16916103/54211694-0a713600-44e2-11e9-82fd-0e406edcd4bc.png)

