### PR TITLE
Don't stop execution if there are no payment lines to cancel

### DIFF
--- a/account_payment_line_cancel/__manifest__.py
+++ b/account_payment_line_cancel/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Account payment line cancel',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/bank-payment',

--- a/account_payment_line_cancel/models/invoice.py
+++ b/account_payment_line_cancel/models/invoice.py
@@ -2,7 +2,10 @@
 # Copyright 2017 Compassion CH (http://www.compassion.ch)
 # @author: Marco Monzione <marco.mon@windowslive.com>, Emanuel Cino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import models, api, _, exceptions
+import logging
+from odoo import models, api
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountInvoice(models.Model):
@@ -25,7 +28,7 @@ class AccountInvoice(models.Model):
         payment_lines = pay_line_obj.search([
             ('move_line_id', 'in', move_line_ids)
         ])
-        if not payment_lines:
-            raise exceptions.UserError(_('No payment line found !'))
-
-        payment_lines.cancel_line()
+        if payment_lines:
+            payment_lines.cancel_line()
+        else:
+            _logger.warning('No payment lines to cancel.')


### PR DESCRIPTION
In current state, we cannot call the cancel_payment_lines on invoices that don't have payment lines associated to it. This should not be the case, because there is simply nothing to do in that case and we don't need to stop execution because of that.