### PR TITLE
[12.0] [ADD] Payment Order: only payment order option on payment methods

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -22,6 +22,7 @@
         'base_iban',  # for manual_bank_tranfer
     ],
     'data': [
+        'views/account_payment_method.xml',
         'security/payment_security.xml',
         'security/ir.model.access.csv',
         'wizard/account_payment_line_create_view.xml',

--- a/account_payment_order/models/__init__.py
+++ b/account_payment_order/models/__init__.py
@@ -6,3 +6,6 @@ from . import account_move
 from . import account_move_line
 from . import account_invoice
 from . import res_bank
+from . import account_payment_method
+from . import account_journal
+from . import account_payment

--- a/account_payment_order/models/account_journal.py
+++ b/account_payment_order/models/account_journal.py
@@ -1,0 +1,33 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    inbound_payment_order_only = fields.Boolean(
+        compute='_compute_inbound_payment_order_only',
+        readonly=True,
+        store=True,
+    )
+    outbound_payment_order_only = fields.Boolean(
+        compute='_compute_outbound_payment_order_only',
+        readonly=True,
+        store=True,
+    )
+
+    @api.multi
+    @api.depends('inbound_payment_method_ids.payment_order_only')
+    def _compute_inbound_payment_order_only(self):
+        for rec in self:
+            rec.inbound_payment_order_only = all(
+                p.payment_order_only for p in rec.inbound_payment_method_ids)
+
+    @api.multi
+    @api.depends('outbound_payment_method_ids.payment_order_only')
+    def _compute_outbound_payment_order_only(self):
+        for rec in self:
+            rec.outbound_payment_order_only = all(
+                p.payment_order_only for p in rec.outbound_payment_method_ids)

--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -1,0 +1,30 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    def _compute_journal_domain_and_types(self):
+        res = super(AccountPayment, self)._compute_journal_domain_and_types()
+        journal_domain = res.get('domain', [])
+        if self.payment_type == 'inbound':
+            journal_domain.append(('inbound_payment_order_only', '=', False))
+        else:
+            journal_domain.append(('outbound_payment_order_only', '=', False))
+        res['domain'] = journal_domain
+        return res
+
+    @api.multi
+    @api.onchange('journal_id')
+    def _onchange_journal(self):
+        res = super(AccountPayment, self)._onchange_journal()
+        domains = res.get('domain')
+        if not domains:
+            return res
+        if domains.get('payment_method_id'):
+            domains['payment_method_id'].append(
+                ('payment_order_only', '!=', True))
+        return res

--- a/account_payment_order/models/account_payment_method.py
+++ b/account_payment_order/models/account_payment_method.py
@@ -1,0 +1,15 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountPaymentMethod(models.Model):
+    _inherit = 'account.payment.method'
+
+    payment_order_only = fields.Boolean(
+        string="Only for payment orders",
+        help="This option helps enforcing the use of payment orders for "
+             "some payment methods.",
+        default=False,
+    )

--- a/account_payment_order/tests/__init__.py
+++ b/account_payment_order/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_payment_mode
 from . import test_bank
 from . import test_payment_order_inbound
 from . import test_payment_order_outbound
+from . import test_account_payment

--- a/account_payment_order/tests/test_account_payment.py
+++ b/account_payment_order/tests/test_account_payment.py
@@ -1,0 +1,112 @@
+# Copyright 2019 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestAccountPayment(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAccountPayment, cls).setUpClass()
+
+        # MODELS
+        cls.account_payment_model = cls.env['account.payment']
+        cls.account_journal_model = cls.env['account.journal']
+        cls.payment_method_model = cls.env['account.payment.method']
+
+        # INSTANCES
+        # Payment methods
+        cls.inbound_payment_method_01, cls.inbound_payment_method_02 = \
+            cls.payment_method_model.search(
+                [('payment_type', '=', 'inbound')], limit=2)
+        cls.outbound_payment_method_01 = cls.payment_method_model.search(
+            [('payment_type', '=', 'outbound')], limit=1)
+        # Journals
+        cls.bank_journal = cls.account_journal_model.search(
+            [('type', '=', 'bank')], limit=1)
+        cls.bank_journal.inbound_payment_method_ids = [
+            (6, 0, [cls.inbound_payment_method_01.id,
+                    cls.inbound_payment_method_02.id])]
+
+    def test_account_payment_01(self):
+        self.assertFalse(self.inbound_payment_method_01.payment_order_only)
+        self.assertFalse(self.inbound_payment_method_02.payment_order_only)
+        self.assertFalse(self.bank_journal.inbound_payment_order_only)
+        self.inbound_payment_method_01.payment_order_only = True
+        self.assertTrue(self.inbound_payment_method_01.payment_order_only)
+        self.assertFalse(self.inbound_payment_method_02.payment_order_only)
+        self.assertFalse(self.bank_journal.inbound_payment_order_only)
+        self.inbound_payment_method_02.payment_order_only = True
+        self.assertTrue(self.inbound_payment_method_01.payment_order_only)
+        self.assertTrue(self.inbound_payment_method_02.payment_order_only)
+        self.assertTrue(self.bank_journal.inbound_payment_order_only)
+
+    def test_account_payment_02(self):
+        self.assertFalse(self.outbound_payment_method_01.payment_order_only)
+        self.assertFalse(self.bank_journal.outbound_payment_order_only)
+        self.outbound_payment_method_01.payment_order_only = True
+        self.assertTrue(self.outbound_payment_method_01.payment_order_only)
+        self.assertTrue(self.bank_journal.outbound_payment_order_only)
+
+    def test_account_payment_03(self):
+        self.assertFalse(self.inbound_payment_method_01.payment_order_only)
+        self.assertFalse(self.inbound_payment_method_02.payment_order_only)
+        self.assertFalse(self.bank_journal.inbound_payment_order_only)
+        new_account_payment = self.account_payment_model.new({
+            'journal_id': self.bank_journal.id,
+            'payment_type': 'inbound',
+            'amount': 1,
+        })
+        # check journals
+        journal_res = new_account_payment._compute_journal_domain_and_types()
+        journal_domain = journal_res.get('domain')
+        self.assertTrue(journal_domain)
+        journals = self.account_journal_model.search(journal_domain)
+        self.assertIn(self.bank_journal, journals)
+        # check payment methods
+        payment_method_res = new_account_payment._onchange_journal()
+        payment_method_domain = payment_method_res.get('domain', {}).get(
+            'payment_method_id')
+        self.assertTrue(payment_method_domain)
+        payment_methods = self.payment_method_model.search(
+            payment_method_domain)
+        self.assertIn(self.inbound_payment_method_01, payment_methods)
+        self.assertIn(self.inbound_payment_method_02, payment_methods)
+        # Set one payment method of the bank journal 'payment order only'
+        self.inbound_payment_method_01.payment_order_only = True
+        # check journals
+        journal_res = new_account_payment._compute_journal_domain_and_types()
+        journal_domain = journal_res.get('domain')
+        self.assertTrue(journal_domain)
+        journals = self.account_journal_model.search(journal_domain)
+        self.assertIn(self.bank_journal, journals)
+        # check payment methods
+        payment_method_res = new_account_payment._onchange_journal()
+        payment_method_domain = payment_method_res.get('domain', {}).get(
+            'payment_method_id')
+        self.assertTrue(payment_method_domain)
+        payment_methods = self.payment_method_model.search(
+            payment_method_domain)
+        self.assertNotIn(self.inbound_payment_method_01, payment_methods)
+        self.assertIn(self.inbound_payment_method_02, payment_methods)
+        # Set all payment methods of the bank journal 'payment order only'
+        self.inbound_payment_method_02.payment_order_only = True
+        self.assertTrue(self.inbound_payment_method_01.payment_order_only)
+        self.assertTrue(self.inbound_payment_method_02.payment_order_only)
+        self.assertTrue(self.bank_journal.inbound_payment_order_only)
+        # check journals
+        journal_res = new_account_payment._compute_journal_domain_and_types()
+        journal_domain = journal_res.get('domain')
+        self.assertTrue(journal_domain)
+        journals = self.account_journal_model.search(journal_domain)
+        self.assertNotIn(self.bank_journal, journals)
+        # check payment methods
+        payment_method_res = new_account_payment._onchange_journal()
+        payment_method_domain = payment_method_res.get('domain', {}).get(
+            'payment_method_id')
+        self.assertTrue(payment_method_domain)
+        payment_methods = self.payment_method_model.search(
+            payment_method_domain)
+        self.assertNotIn(self.inbound_payment_method_01, payment_methods)
+        self.assertNotIn(self.inbound_payment_method_02, payment_methods)

--- a/account_payment_order/views/account_payment_method.xml
+++ b/account_payment_order/views/account_payment_method.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="account_payment_method_form_view">
+        <field name="name">account.payment.method.form (in account_payment_order)</field>
+        <field name="model">account.payment.method</field>
+        <field name="inherit_id" ref="account_payment_mode.account_payment_method_form"/>
+        <field name="arch" type="xml">
+            <field name="active" position="before">
+                <field name="payment_order_only"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
New option on payment methods: payment order only (unchecked by default) allowing to enforce the use of payment orders for some payment methods