### PR TITLE
[10.0] account_banking_pain_base: Allow override of address block

### DIFF
--- a/account_banking_pain_base/__manifest__.py
+++ b/account_banking_pain_base/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "


### PR DESCRIPTION
Move the address block generation in separate method to allow override.
This will be used in OCA/l10n-switzerland