### PR TITLE
[12.0][FIX] account_banking_pain_base bic constrains

### DIFF
--- a/account_banking_pain_base/models/res_bank.py
+++ b/account_banking_pain_base/models/res_bank.py
@@ -22,7 +22,7 @@ class ResBank(models.Model):
         :raise: ValidationError if the BIC doesn't respect the regex of the
         SEPA pain schemas.
         """
-        invalid_banks = self.filtered(lambda r: not BIC_REGEX.match(r.bic))
+        invalid_banks = self.filtered(lambda r: r.bic and not BIC_REGEX.match(r.bic))
         if invalid_banks:
             raise ValidationError(_(
                 "The following Bank Identifier Codes (BIC) do not respect "


### PR DESCRIPTION
The bic fields is not required, so the constraint must take that into
consideration and accept empty bic.