### PR TITLE
[IMP] 10.0 bank_payment_order move invoice_ref calculation to python

### DIFF
--- a/account_payment_order/report/account_payment_order.py
+++ b/account_payment_order/report/account_payment_order.py
@@ -21,6 +21,7 @@ class AccountPaymentOrderReport(models.AbstractModel):
             'data': data,
             'env': self.env,
             'get_bank_account_name': self.get_bank_account_name,
+            'get_invoice_ref': self.get_invoice_ref,
             'formatLang': formatLang,
         }
         return self.env['report'].render(
@@ -46,3 +47,9 @@ class AccountPaymentOrderReport(models.AbstractModel):
             return name
         else:
             return False
+
+    @api.model
+    def get_invoice_ref(self, line):
+        value = (line.move_line_id.invoice_id.number or
+                 line.move_line_id.move_id.name)
+        return value or ''

--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -76,7 +76,7 @@
                                 <span t-esc="get_bank_account_name(line.partner_bank_id)"/>
                             </td>
                             <td class="text-center">
-                                <span t-raw="'%s &lt;br&gt;' % line.move_line_id.invoice_id.number or line.move_line_id.move_id.name or ''"/>
+                                <span t-esc="get_invoice_ref(line)"/>
                             </td>
                             <td class="text-center">
                                 <span t-field="line.date"/>


### PR DESCRIPTION
Moves the logic of invoice_ref calculation to python method, as well as fixes a bug when it sometimes returns False.
Lesser logic in templates - better