### PR TITLE
[12.0] [IMP] Invoice: allow modification of mandate on open invoices

### DIFF
--- a/account_banking_mandate/models/account_invoice.py
+++ b/account_banking_mandate/models/account_invoice.py
@@ -15,7 +15,8 @@ class AccountInvoice(models.Model):
     mandate_id = fields.Many2one(
         'account.banking.mandate', string='Direct Debit Mandate',
         ondelete='restrict',
-        readonly=True, states={'draft': [('readonly', False)]})
+        readonly=True, states={'draft': [('readonly', False)],
+                               'open': [('readonly', False)]})
     mandate_required = fields.Boolean(
         related='payment_mode_id.payment_method_id.mandate_required',
         readonly=True)


### PR DESCRIPTION
In case of a wrong mandate, it should be possible to re-generate the debit order with another mandate.