### PR TITLE
[12.0][FIX] account_payment_order: wrong function name

### DIFF
--- a/account_payment_order/report/account_payment_order.py
+++ b/account_payment_order/report/account_payment_order.py
@@ -10,7 +10,7 @@ class AccountPaymentOrderReport(models.AbstractModel):
     _description = 'Technical model for printing payment order'
 
     @api.model
-    def get_report_values(self, docids, data=None):
+    def _get_report_values(self, docids, data=None):
         AccountPaymentOrderObj = self.env['account.payment.order']
         docs = AccountPaymentOrderObj.browse(docids)
 


### PR DESCRIPTION
In 12.0 the function get_report_values has been renamed to [_get_report_values](https://github.com/odoo/odoo/blob/cdc150d0a3268e9759aa3a957c6e3f7ed5ad8b54/odoo/addons/base/report/report_base_report_irmodulereference.py#L30)