### PR TITLE
[12.0][FIX] account_payment_order report

### DIFF
--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -91,8 +91,8 @@
                     </tbody>
                 </table>
 
-                <div class="row">
-                    <div class="col-xs-4 pull-right">
+                <div class="row pull-right">
+                    <div class="col-xs-4">
                         <table class="table table-condensed">
                             <tr class="border-black">
                                 <td><strong>Total</strong></td>

--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -21,7 +21,12 @@
                     </div>
                 </div>
 
-                <h2>Payment Order / Payment</h2>
+                <t t-if="doc.payment_type == 'inbound'">
+                    <h2>Debit Order</h2>
+                </t>
+                <t t-else="">
+                    <h2>Payment Order</h2>
+                </t>
 
                 <div class="row mt32 mb32">
                     <div t-if="doc.payment_mode_id.name" class="col-xs-2">


### PR DESCRIPTION
* Table totals was always invisible.
* Document title "Payment Order / Payment" is confusing because it's not differenced both types "Payment Order" and "Debit Order".
