### PR TITLE
[IMP] account_banking_mandate: sql constraints

### DIFF
--- a/account_banking_mandate/models/account_invoice.py
+++ b/account_banking_mandate/models/account_invoice.py
@@ -14,7 +14,7 @@ class AccountInvoice(models.Model):
 
     mandate_id = fields.Many2one(
         'account.banking.mandate', string='Direct Debit Mandate',
-        ondelete='restrict',
+        ondelete='restrict', index=True,
         readonly=True, states={'draft': [('readonly', False)]})
     mandate_required = fields.Boolean(
         related='payment_mode_id.payment_method_id.mandate_required',

--- a/account_banking_mandate/models/account_move_line.py
+++ b/account_banking_mandate/models/account_move_line.py
@@ -12,7 +12,7 @@ class AccountMoveLine(models.Model):
 
     mandate_id = fields.Many2one(
         'account.banking.mandate', string='Direct Debit Mandate',
-        ondelete='restrict')
+        ondelete='restrict', index=True)
 
     @api.multi
     def _prepare_payment_line_vals(self, payment_order):

--- a/account_banking_mandate/models/account_payment_line.py
+++ b/account_banking_mandate/models/account_payment_line.py
@@ -12,7 +12,7 @@ class AccountPaymentLine(models.Model):
 
     mandate_id = fields.Many2one(
         comodel_name='account.banking.mandate', string='Direct Debit Mandate',
-        domain=[('state', '=', 'valid')])
+        domain=[('state', '=', 'valid')], index=True)
     mandate_required = fields.Boolean(
         related='order_id.payment_method_id.mandate_required', readonly=True)
 

--- a/account_banking_sepa_direct_debit/demo/sepa_direct_debit_demo.xml
+++ b/account_banking_sepa_direct_debit/demo/sepa_direct_debit_demo.xml
@@ -22,6 +22,7 @@
     <field name="type">recurrent</field>
     <field name="recurrent_sequence_type">first</field>
     <field name="signature_date" eval="time.strftime('%Y-01-01')"/>
+    <field name="last_debit_date" eval="time.strftime('%Y-01-01')"/>
     <field name="state">valid</field>
 </record>
 
@@ -37,6 +38,7 @@
     <field name="type">recurrent</field>
     <field name="recurrent_sequence_type">first</field>
     <field name="signature_date" eval="time.strftime('%Y-%m-01')" />
+    <field name="last_debit_date" eval="time.strftime('%Y-%m-01')"/>
     <field name="state">valid</field>
 </record>
 


### PR DESCRIPTION
SQL constraints are faster than python equivalent, use them when 
possible. Added index on the O2M fields used in python constraints.