### PR TITLE
[12.0] [FIX] Failing test test_account_payment_02

### DIFF
--- a/account_payment_order/tests/test_account_payment.py
+++ b/account_payment_order/tests/test_account_payment.py
@@ -28,6 +28,8 @@ class TestAccountPayment(SavepointCase):
         cls.bank_journal.inbound_payment_method_ids = [
             (6, 0, [cls.inbound_payment_method_01.id,
                     cls.inbound_payment_method_02.id])]
+        cls.bank_journal.outbound_payment_method_ids = [
+            (6, 0, [cls.outbound_payment_method_01.id])]
 
     def test_account_payment_01(self):
         self.assertFalse(self.inbound_payment_method_01.payment_order_only)


### PR DESCRIPTION
The defined test `test_account_payment_02` is using outbound_payment_method_01 but this is not linked to the defined journal as outbound payment method, so the check on the journal is failing