### PR TITLE
[11.0][IMP] account_banking_sepa_credit_transfer: sepa and other payments in same pain file

### DIFF
--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -12,7 +12,6 @@
     <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
     <field name="arch" type="xml">
         <field name="company_partner_bank_id" position="after">
-            <field name="sepa"/>
             <field name="batch_booking"/>
             <field name="charge_bearer"/>
         </field>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -14,7 +14,7 @@
         <field name="company_partner_bank_id" position="after">
             <field name="sepa"/>
             <field name="batch_booking"/>
-            <field name="charge_bearer" attrs="{'invisible': [('sepa', '=', True)]}"/>
+            <field name="charge_bearer"/>
         </field>
     </field>
 </record>

--- a/account_banking_sepa_credit_transfer/__manifest__.py
+++ b/account_banking_sepa_credit_transfer/__manifest__.py
@@ -18,6 +18,7 @@
     'depends': ['account_banking_pain_base'],
     'data': [
         'data/account_payment_method.xml',
+        'views/bank_payment_line.xml'
     ],
     'demo': [
         'demo/sepa_credit_transfer_demo.xml'

--- a/account_banking_sepa_credit_transfer/models/__init__.py
+++ b/account_banking_sepa_credit_transfer/models/__init__.py
@@ -3,3 +3,4 @@
 from . import account_payment_method
 from . import account_payment_order
 from . import account_payment_line
+from . import bank_payment_line

--- a/account_banking_sepa_credit_transfer/models/bank_payment_line.py
+++ b/account_banking_sepa_credit_transfer/models/bank_payment_line.py
@@ -1,0 +1,29 @@
+# © braintec-group.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api
+
+
+class BankPaymentLine(models.Model):
+    _inherit = 'bank.payment.line'
+
+    @api.multi
+    @api.depends(
+        'order_id.company_partner_bank_id.acc_type',
+        'currency_id',
+        'partner_bank_id.acc_type')
+    def _compute_sepa(self):
+        eur = self.env.ref('base.EUR')
+        for bank_payment_line in self:
+            sepa = True
+            if bank_payment_line.order_id.company_partner_bank_id.acc_type != \
+                    'iban':
+                sepa = False
+            elif bank_payment_line.currency_id != eur:
+                sepa = False
+            elif bank_payment_line.partner_bank_id.acc_type != 'iban':
+                sepa = False
+            bank_payment_line.sepa = sepa
+
+    sepa = fields.Boolean(
+        compute='_compute_sepa', readonly=True, string="SEPA Payment")

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -153,12 +153,12 @@ class TestSCT(common.HttpCase):
         self.assertEqual(agrolait_pay_line1.communication, 'F1341')
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
-        self.assertEqual(self.payment_order.sepa, True)
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id)])
         self.assertEqual(len(bank_lines), 1)
         agrolait_bank_line = bank_lines[0]
         self.assertEqual(agrolait_bank_line.currency_id, self.eur_currency)
+        self.assertEqual(agrolait_bank_line.sepa, True)
         self.assertEqual(float_compare(
             agrolait_bank_line.amount_currency, 49.0, precision_digits=accpre),
             0)
@@ -230,12 +230,12 @@ class TestSCT(common.HttpCase):
         self.assertEqual(asus_pay_line1.communication, 'Inv9032')
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
-        self.assertEqual(self.payment_order.sepa, False)
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_asus.id)])
         self.assertEqual(len(bank_lines), 1)
         asus_bank_line = bank_lines[0]
         self.assertEqual(asus_bank_line.currency_id, self.usd_currency)
+        self.assertEqual(asus_bank_line.sepa, False)
         self.assertEqual(float_compare(
             asus_bank_line.amount_currency, 3054.0, precision_digits=accpre),
             0)

--- a/account_banking_sepa_credit_transfer/views/bank_payment_line.xml
+++ b/account_banking_sepa_credit_transfer/views/bank_payment_line.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<!--
+  © braintec-group
+  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+
+<record id="bank_payment_line_form" model="ir.ui.view">
+    <field name="name">sepa.credit.transfer.bank.payment.line.form</field>
+    <field name="model">bank.payment.line</field>
+    <field name="inherit_id"
+           ref="account_payment_order.bank_payment_line_form"/>
+    <field name="arch" type="xml">
+       <field name="communication" position="before">
+            <field name="sepa"/>
+        </field>
+    </field>
+</record>
+
+<record id="bank_payment_line_tree" model="ir.ui.view">
+    <field name="name">sepa.credit.transfer.bank.payment.line.tree</field>
+    <field name="model">bank.payment.line</field>
+    <field name="inherit_id"
+           ref="account_payment_order.bank_payment_line_tree"/>
+    <field name="arch" type="xml">
+       <field name="communication" position="before">
+            <field name="sepa"/>
+        </field>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
- Moved SEPA indicator from payment order to bank-payment-line
- On generating pain.001 file the lines will be grouped by sepa too and in pain.001-file there will be Payment Information Groups (PmtInf, B-Level) for sepa payments too.

This change should allow to have sepa payments and other payments in same payment order.