### PR TITLE
[12.0][IMP] account_banking_mandate: bank account deletion + indexes

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -36,7 +36,9 @@ class AccountBankingMandate(models.Model):
     partner_bank_id = fields.Many2one(
         comodel_name='res.partner.bank', string='Bank Account',
         track_visibility='onchange',
-        domain=lambda self: self._get_default_partner_bank_id_domain(),)
+        domain=lambda self: self._get_default_partner_bank_id_domain(),
+        ondelete='restrict',
+    )
     partner_id = fields.Many2one(
         comodel_name='res.partner', related='partner_bank_id.partner_id',
         string='Partner', store=True)

--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -38,10 +38,11 @@ class AccountBankingMandate(models.Model):
         track_visibility='onchange',
         domain=lambda self: self._get_default_partner_bank_id_domain(),
         ondelete='restrict',
+        index=True,
     )
     partner_id = fields.Many2one(
         comodel_name='res.partner', related='partner_bank_id.partner_id',
-        string='Partner', store=True)
+        string='Partner', store=True, index=True)
     company_id = fields.Many2one(
         comodel_name='res.company', string='Company', required=True,
         default=lambda self: self.env['res.company']._company_default_get(


### PR DESCRIPTION
- Deleting a bank account linked to a valid mandate can lead to inconsistencies.
- Indexes on bank account and partner.