### PR TITLE
[12.0] Add indexes on account payment models

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -15,7 +15,9 @@ class AccountMoveLine(models.Model):
         help='Bank account on which we should pay the supplier')
     bank_payment_line_id = fields.Many2one(
         'bank.payment.line', string='Bank Payment Line',
-        readonly=True)
+        readonly=True,
+        index=True,
+    )
     payment_line_ids = fields.One2many(
         comodel_name='account.payment.line',
         inverse_name='move_line_id',

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -56,7 +56,9 @@ class AccountPaymentLine(models.Model):
         ], string='Communication Type', required=True, default='normal')
     # v8 field : state
     bank_line_id = fields.Many2one(
-        'bank.payment.line', string='Bank Payment Line', readonly=True)
+        'bank.payment.line', string='Bank Payment Line', readonly=True,
+        index=True,
+    )
 
     _sql_constraints = [(
         'name_company_unique',

--- a/account_payment_partner/models/account_move_line.py
+++ b/account_payment_partner/models/account_move_line.py
@@ -11,5 +11,6 @@ class AccountMoveLine(models.Model):
         'account.payment.mode',
         string='Payment Mode',
         domain="[('company_id', '=', company_id)]",
-        ondelete='restrict'
+        ondelete='restrict',
+        index=True,
     )


### PR DESCRIPTION
The fields where the indexes are added are used in searches in
account_payment_order, which becomes really slow when a database have
many lines.

Port from https://github.com/OCA/bank-payment/pull/590