### PR TITLE
[IMP] Create a payment order in the past based on payment mode configuration

### DIFF
--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -80,6 +80,9 @@ class AccountPaymentMode(models.Model):
         ('line', 'One move per payment line'),
         ], string='Move Option', default='date')
     post_move = fields.Boolean(string='Post Move', default=True)
+    enable_passed_date = fields.Boolean(
+        string='Enable Passed Date',
+        help='Payment order can be created with a passed date')
 
     @api.multi
     @api.constrains(

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -134,7 +134,8 @@ class AccountPaymentOrder(models.Model):
     def check_date_scheduled(self):
         today = fields.Date.context_today(self)
         for order in self:
-            if order.date_scheduled:
+            if order.date_scheduled and not \
+                    order.payment_mode_id.enable_passed_date:
                 if order.date_scheduled < today:
                     raise ValidationError(_(
                         "On payment order %s, the Payment Execution Date "
@@ -268,7 +269,8 @@ class AccountPaymentOrder(models.Model):
                 else:
                     requested_date = today
                 # No payment date in the past
-                if requested_date < today:
+                if requested_date < today and not \
+                        order.payment_mode_id.enable_passed_date:
                     requested_date = today
                 # inbound: check option no_debit_before_maturity
                 if (

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -18,6 +18,7 @@
                     attrs="{'invisible': ['|', ('payment_type', '!=', 'inbound'), ('payment_order_ok', '!=', True)]}"/>
                 <field name="default_date_prefered"/>
                 <field name="group_lines"/>
+                <field name="enable_passed_date"/>
             </group>
             <group name="payment_order_create_defaults"
                     string="Select Move Lines to Pay - Default Values"


### PR DESCRIPTION
Add the possibility to create payment orders with passed date based on payment mode configuration