### PR TITLE
[10.0][ADD] account_payment_mode_auto_reconcile

### DIFF
--- a/account_payment_mode_auto_reconcile/__init__.py
+++ b/account_payment_mode_auto_reconcile/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_mode_auto_reconcile/__manifest__.py
+++ b/account_payment_mode_auto_reconcile/__manifest__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {

--- a/account_payment_mode_auto_reconcile/__manifest__.py
+++ b/account_payment_mode_auto_reconcile/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Account Payment Mode Auto Reconcile",
+    "summary": "Reconcile outstanding credits according to payment mode",
+    "version": "10.0.1.0.0",
+    "category": "Banking addons",
+    "website": "https://github.com/OCA/bank-payment",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "account_payment_partner",
+    ],
+    "data": [
+        "views/account_invoice.xml",
+        "views/account_payment_mode.xml",
+    ],
+    "demo": [
+        "demo/account_payment_mode.xml",
+    ],
+}

--- a/account_payment_mode_auto_reconcile/demo/account_payment_mode.xml
+++ b/account_payment_mode_auto_reconcile/demo/account_payment_mode.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="account_payment_mode.payment_mode_inbound_dd1" model="account.payment.mode">
+        <field name="auto_reconcile_outstanding_credits" eval="True"/>
+    </record>
+</odoo>

--- a/account_payment_mode_auto_reconcile/models/__init__.py
+++ b/account_payment_mode_auto_reconcile/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_invoice
+from . import account_payment_mode

--- a/account_payment_mode_auto_reconcile/models/__init__.py
+++ b/account_payment_mode_auto_reconcile/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_invoice
+from . import account_partial_reconcile
 from . import account_payment_mode

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -23,8 +23,8 @@ class AccountInvoice(models.Model):
     )
 
     @api.multi
-    def action_invoice_open(self):
-        res = super(AccountInvoice, self).action_invoice_open()
+    def invoice_validate(self):
+        res = super(AccountInvoice, self).invoice_validate()
         for invoice in self:
             if invoice.type != 'out_invoice':
                 continue

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -30,7 +30,7 @@ class AccountInvoice(models.Model):
                 continue
             if not invoice.payment_mode_id.auto_reconcile_outstanding_credits:
                 continue
-            partial_allowed = self.payment_mode_id.auto_reconcile_allow_partial
+            partial_allowed = invoice.payment_mode_id.auto_reconcile_allow_partial
             invoice.with_context(
                 _payment_mode_auto_reconcile=True
             ).auto_reconcile_credits(partial_allowed=partial_allowed)

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -30,10 +30,10 @@ class AccountInvoice(models.Model):
                 continue
             if not invoice.payment_mode_id.auto_reconcile_outstanding_credits:
                 continue
-            partial_allowed = invoice.payment_mode_id.auto_reconcile_allow_partial
+            partial = invoice.payment_mode_id.auto_reconcile_allow_partial
             invoice.with_context(
                 _payment_mode_auto_reconcile=True
-            ).auto_reconcile_credits(partial_allowed=partial_allowed)
+            ).auto_reconcile_credits(partial_allowed=partial)
         return res
 
     @api.multi
@@ -50,11 +50,11 @@ class AccountInvoice(models.Model):
                     payment_mode
                     and payment_mode.auto_reconcile_outstanding_credits
                 ):
-                    partial_allowed = payment_mode.auto_reconcile_allow_partial
+                    partial = payment_mode.auto_reconcile_allow_partial
                     invoice.with_context(
                         _payment_mode_auto_reconcile=True
                     ).auto_reconcile_credits(
-                        partial_allowed=partial_allowed
+                        partial_allowed=partial
                     )
                 # If the payment mode is not using auto reconcile we remove
                 #  the existing reconciliations

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import json
+
+from odoo import api, fields, models
+
+
+class AccountInvoice(models.Model):
+
+    _inherit = "account.invoice"
+
+    # Allow changing payment mode in open state
+    # TODO: Check if must be done in account_payment_partner instead
+    payment_mode_id = fields.Many2one(
+        states={'draft': [('readonly', False)], 'open': [('readonly', False)]}
+    )
+    auto_assigned_oustanding_credits = fields.Boolean(
+        compute='_compute_auto_assigned_oustanding_credits',
+    )
+
+    @api.multi
+    def action_invoice_open(self):
+        res = super(AccountInvoice, self).action_invoice_open()
+        for invoice in self:
+            if not invoice.payment_mode_id.auto_reconcile_outstanding_credits:
+                continue
+            partial_allowed = self.payment_mode_id.auto_reconcile_allow_partial
+            invoice.auto_reconcile_credits(partial_allowed=partial_allowed)
+        return res
+
+    @api.onchange('payment_mode_id')
+    def payment_mode_id_change(self):
+        super(AccountInvoice, self).payment_mode_id_change()
+        if self.state != 'open':
+            return
+        if (
+            self.payment_mode_id
+            and self.payment_mode_id.auto_reconcile_outstanding_credits
+        ):
+            partial_allowed = self.payment_mode_id.auto_reconcile_allow_partial
+            self.auto_reconcile_credits(partial_allowed=partial_allowed)
+        else:
+            self.auto_unreconcile_credits()
+
+    @api.multi
+    def auto_reconcile_credits(self, partial_allowed=True):
+        for invoice in self:
+            if not invoice.has_outstanding:
+                continue
+            credits_info = json.loads(
+                invoice.outstanding_credits_debits_widget
+            )
+            # Get outstanding credits in chronological order
+            # (using reverse because aml is sorted by date desc as default)
+            credits = credits_info.get('content')
+            credits.reverse()
+            for credit in credits:
+                if (
+                    not partial_allowed
+                    and credit.get('amount') > invoice.residual
+                ):
+                    continue
+                invoice.assign_outstanding_credit(credit.get('id'))
+
+    @api.multi
+    def auto_unreconcile_credits(self):
+        for invoice in self:
+            payments_info = json.loads(invoice.payments_widget or '{}')
+            for payment in payments_info.get('content', []):
+                aml = self.env['account.move.line'].browse(
+                    payment.get('payment_id')
+                )
+                aml.with_context(invoice_id=invoice.id).remove_move_reconcile()
+
+    @api.depends('payment_mode_id', 'payment_move_line_ids.amount_residual',
+                 'state')
+    def _compute_auto_assigned_oustanding_credits(self):
+        for invoice in self:
+            invoice.auto_assigned_oustanding_credits = (
+                invoice.state == 'open' and
+                invoice.payment_mode_id and
+                invoice.payment_mode_id.auto_reconcile_outstanding_credits and
+                invoice.payment_move_line_ids
+            )

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 import json

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -89,9 +89,9 @@ class AccountInvoice(models.Model):
         """Keep only credits on the same journal than the invoice."""
         self.ensure_one()
         line_ids = [credit['id'] for credit in credits_dict]
-        lines = self.env['account.move.line'].browse(line_ids).filtered(
-            lambda line: line.journal_id == self.journal_id
-        )
+        lines = self.env['account.move.line'].search([
+            ('id', 'in', line_ids), ('journal_id', '=', self.journal_id.id)
+        ])
         return [credit for credit in credits_dict if credit['id'] in lines.ids]
 
     @api.multi

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -26,6 +26,8 @@ class AccountInvoice(models.Model):
     def action_invoice_open(self):
         res = super(AccountInvoice, self).action_invoice_open()
         for invoice in self:
+            if invoice.type != 'out_invoice':
+                continue
             if not invoice.payment_mode_id.auto_reconcile_outstanding_credits:
                 continue
             partial_allowed = self.payment_mode_id.auto_reconcile_allow_partial
@@ -37,7 +39,7 @@ class AccountInvoice(models.Model):
         res = super(AccountInvoice, self).write(vals)
         if 'payment_mode_id' in vals:
             for invoice in self:
-                if invoice.state != 'open':
+                if invoice.state != 'open' or invoice.type != 'out_invoice':
                     continue
                 payment_mode = invoice.payment_mode_id
                 if (

--- a/account_payment_mode_auto_reconcile/models/account_invoice.py
+++ b/account_payment_mode_auto_reconcile/models/account_invoice.py
@@ -74,7 +74,9 @@ class AccountInvoice(models.Model):
             # (using reverse because aml is sorted by date desc as default)
             credits_dict = credits_info.get('content')
             if invoice.payment_mode_id.auto_reconcile_same_journal:
-                credits_dict = invoice._filter_payment_same_journal(credits_dict)
+                credits_dict = invoice._filter_payment_same_journal(
+                    credits_dict
+                )
             credits_dict.reverse()
             for credit in credits_dict:
                 if (

--- a/account_payment_mode_auto_reconcile/models/account_partial_reconcile.py
+++ b/account_payment_mode_auto_reconcile/models/account_partial_reconcile.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields, api
+
+
+class AccountPartialReconcile(models.Model):
+
+    _inherit = 'account.partial.reconcile'
+
+    payment_mode_auto_reconcile = fields.Boolean()
+
+    @api.model
+    def create(self, vals):
+        if self.env.context.get('_payment_mode_auto_reconcile'):
+            vals['payment_mode_auto_reconcile'] = True
+        return super(AccountPartialReconcile, self).create(vals)

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -9,11 +9,18 @@ class AccountPaymentMode(models.Model):
     _inherit = "account.payment.mode"
 
     auto_reconcile_outstanding_credits = fields.Boolean(
+        string="Auto reconcile",
         help="Reconcile automatically outstanding credits when an invoice "
              "using this payment mode is validated, or when this payment mode "
              "is defined on an open invoice."
     )
     auto_reconcile_allow_partial = fields.Boolean(
         default=True,
+        string="Allow partial",
         help="Allows automatic partial reconciliation of outstanding credits",
+    )
+    auto_reconcile_same_journal = fields.Boolean(
+        default=False,
+        string="Only same journal",
+        help="Only reconcile payment belonging to the same journal than the invoice",
     )

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import models, fields

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -22,5 +22,5 @@ class AccountPaymentMode(models.Model):
     auto_reconcile_same_journal = fields.Boolean(
         default=False,
         string="Only same journal",
-        help="Only reconcile payment belonging to same journal than the invoice",
+        help="Only reconcile payment in the same journal than the invoice",
     )

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -22,5 +22,5 @@ class AccountPaymentMode(models.Model):
     auto_reconcile_same_journal = fields.Boolean(
         default=False,
         string="Only same journal",
-        help="Only reconcile payment belonging to the same journal than the invoice",
+        help="Only reconcile payment belonging to same journal than the invoice",
     )

--- a/account_payment_mode_auto_reconcile/models/account_payment_mode.py
+++ b/account_payment_mode_auto_reconcile/models/account_payment_mode.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields
+
+
+class AccountPaymentMode(models.Model):
+
+    _inherit = "account.payment.mode"
+
+    auto_reconcile_outstanding_credits = fields.Boolean(
+        help="Reconcile automatically outstanding credits when an invoice "
+             "using this payment mode is validated, or when this payment mode "
+             "is defined on an open invoice."
+    )
+    auto_reconcile_allow_partial = fields.Boolean(
+        default=True,
+        help="Allows automatic partial reconciliation of outstanding credits",
+    )

--- a/account_payment_mode_auto_reconcile/readme/CONTRIBUTORS.rst
+++ b/account_payment_mode_auto_reconcile/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
+++ b/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module adds a checkbox 'auto_reconcile_outstanding_credits' on account
+payment modes to allow automatic reconciliation on account invoices if it is
+checked.
+
+Automatic reconciliation of outstanding credits will only happen on customer
+invoices at validation if the payment mode is set or when the payment mode is
+changed on an open invoice.

--- a/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
+++ b/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
@@ -5,7 +5,7 @@ checked.
 Automatic reconciliation of outstanding credits will only happen on customer
 invoices at validation if the payment mode is set or when the payment mode is
 changed on an open invoice. If a payment mode using auto-reconcile is removed
-from an open invoice, the existing payments will be removed.
+from an open invoice, the existing auto reconciled payments will be removed.
 
 Another option `auto_reconcile_allow_partial` on account payment mode defines
 if outstanding credits can be partially used for the auto reconciliation.

--- a/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
+++ b/account_payment_mode_auto_reconcile/readme/DESCRIPTION.rst
@@ -1,7 +1,11 @@
-This module adds a checkbox 'auto_reconcile_outstanding_credits' on account
+This module adds a checkbox `auto_reconcile_outstanding_credits` on account
 payment modes to allow automatic reconciliation on account invoices if it is
 checked.
 
 Automatic reconciliation of outstanding credits will only happen on customer
 invoices at validation if the payment mode is set or when the payment mode is
-changed on an open invoice.
+changed on an open invoice. If a payment mode using auto-reconcile is removed
+from an open invoice, the existing payments will be removed.
+
+Another option `auto_reconcile_allow_partial` on account payment mode defines
+if outstanding credits can be partially used for the auto reconciliation.

--- a/account_payment_mode_auto_reconcile/tests/__init__.py
+++ b/account_payment_mode_auto_reconcile/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)

--- a/account_payment_mode_auto_reconcile/tests/__init__.py
+++ b/account_payment_mode_auto_reconcile/tests/__init__.py
@@ -1,2 +1,1 @@
-# Copyright 2019 Camptocamp SA
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from . import test_partner_auto_reconcile

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -1,0 +1,157 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import date, timedelta
+
+from odoo.tests import SavepointCase
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DATE_FORMAT
+
+
+class TestPartnerAutoReconcile(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPartnerAutoReconcile, cls).setUpClass()
+        cls.acc_rec = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
+                'account.data_account_type_receivable').id
+              )], limit=1
+        )
+        cls.acc_pay = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
+                'account.data_account_type_payable').id
+              )], limit=1
+        )
+        cls.acc_rev = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
+                'account.data_account_type_revenue').id
+              )], limit=1
+        )
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Test partner',
+            'customer': True,
+            'property_account_receivable_id': cls.acc_rec.id,
+            'property_account_payable_id': cls.acc_pay.id,
+        })
+        cls.payment_mode = cls.env.ref(
+            'account_payment_mode.payment_mode_inbound_dd1'
+        )
+        # TODO check why it's not set from demo data
+        cls.payment_mode.auto_reconcile_outstanding_credits = True
+        cls.product = cls.env.ref('product.consu_delivery_02')
+        cls.invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'payment_term_id': cls.env.ref('account.account_payment_term').id,
+            'account_id': cls.acc_rec.id,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': cls.product.id,
+                'name': cls.product.name,
+                'price_unit': 1000.0,
+                'quantity': 1,
+                'account_id': cls.acc_rev.id,
+            })],
+        })
+        cls.invoice.action_invoice_open()
+        bank_journal = cls.env['account.journal'].search(
+            [('type', '=', 'bank')], limit=1
+        )
+        cls.invoice.pay_and_reconcile(bank_journal)
+        cls.refund_wiz = cls.env['account.invoice.refund'].with_context(
+            active_ids=cls.invoice.ids).create({
+                'filter_refund': 'refund',
+                'description': 'test'
+            })
+        refund_id = cls.refund_wiz.invoice_refund().get('domain')[1][2]
+        cls.refund = cls.env['account.invoice'].browse(refund_id)
+        cls.refund.action_invoice_open()
+        cls.invoice_copy = cls.invoice.copy()
+        cls.invoice_copy.write({
+            'invoice_line_ids': [(0, 0, {
+                'product_id': cls.product.id,
+                'name': cls.product.name,
+                'price_unit': 500.0,
+                'quantity': 1,
+                'account_id': cls.acc_rev.id,
+            })]
+        })
+        cls.invoice_copy.action_invoice_open()
+
+    def test_invoice_validate_auto_reconcile(self):
+        auto_rec_invoice = self.invoice.copy({
+            'payment_mode_id': self.payment_mode.id,
+        })
+        auto_rec_invoice.write({
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product.id,
+                'name': self.product.name,
+                'price_unit': 500.0,
+                'quantity': 1,
+                'account_id': self.acc_rev.id,
+            })]
+        })
+        self.assertTrue(self.payment_mode.auto_reconcile_outstanding_credits)
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        auto_rec_invoice.action_invoice_open()
+        self.assertEqual(auto_rec_invoice.residual, 500)
+
+    def test_invoice_onchange_auto_reconcile(self):
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        self.invoice_copy.payment_mode_id = self.payment_mode
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.residual, 500)
+        self.invoice_copy.payment_mode_id = False
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        # Copy the refund so there's more outstanding credit than invoice total
+        new_refund = self.refund.copy()
+        new_refund.date = (date.today() + timedelta(days=1)).strftime(
+            DATE_FORMAT
+        )
+        new_refund.invoice_line_ids.write({'price_unit': 1200})
+        new_refund.action_invoice_open()
+        # Set reconcile partial to False
+        self.payment_mode.auto_reconcile_allow_partial = False
+        self.assertFalse(self.payment_mode.auto_reconcile_allow_partial)
+        self.invoice_copy.payment_mode_id = self.payment_mode
+        self.invoice_copy.payment_mode_id_change()
+        # Only the older move is used as payment
+        self.assertEqual(self.invoice_copy.residual, 500)
+        self.invoice_copy.payment_mode_id = False
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        # Set allow partial will reconcile both moves
+        self.payment_mode.auto_reconcile_allow_partial = True
+        self.invoice_copy.payment_mode_id = self.payment_mode
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.state, 'paid')
+        self.assertEqual(self.invoice_copy.residual, 0)
+
+    def test_invoice_auto_unreconcile(self):
+        # Copy the refund so there's more outstanding credit than invoice total
+        new_refund = self.refund.copy()
+        new_refund.date = (date.today() + timedelta(days=1)).strftime(
+            DATE_FORMAT
+        )
+        new_refund.invoice_line_ids.write({'price_unit': 1200})
+        new_refund.action_invoice_open()
+
+        auto_rec_invoice = self.invoice.copy({
+            'payment_mode_id': self.payment_mode.id,
+        })
+        auto_rec_invoice.invoice_line_ids.write({'price_unit': 800})
+        auto_rec_invoice.action_invoice_open()
+        self.assertEqual(auto_rec_invoice.state, 'paid')
+        self.assertEqual(auto_rec_invoice.residual, 0)
+        # As we had 2200 of outstanding credits and 800 was assigned, there's
+        # 1400 left
+        self.assertTrue(self.payment_mode.auto_reconcile_allow_partial)
+        self.invoice_copy.payment_mode_id = self.payment_mode
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.residual, 100)
+        # Unreconcile of an invoice doesn't change the reconciliation of the
+        # other invoice
+        self.invoice_copy.payment_mode_id = False
+        self.invoice_copy.payment_mode_id_change()
+        self.assertEqual(self.invoice_copy.residual, 1500)
+        self.assertEqual(auto_rec_invoice.state, 'paid')
+        self.assertEqual(auto_rec_invoice.residual, 0)

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -94,13 +94,11 @@ class TestPartnerAutoReconcile(SavepointCase):
         auto_rec_invoice.action_invoice_open()
         self.assertEqual(auto_rec_invoice.residual, 500)
 
-    def test_invoice_onchange_auto_reconcile(self):
+    def test_invoice_change_auto_reconcile(self):
         self.assertEqual(self.invoice_copy.residual, 1500)
-        self.invoice_copy.payment_mode_id = self.payment_mode
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': self.payment_mode.id})
         self.assertEqual(self.invoice_copy.residual, 500)
-        self.invoice_copy.payment_mode_id = False
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': False})
         self.assertEqual(self.invoice_copy.residual, 1500)
         # Copy the refund so there's more outstanding credit than invoice total
         new_refund = self.refund.copy()
@@ -112,17 +110,14 @@ class TestPartnerAutoReconcile(SavepointCase):
         # Set reconcile partial to False
         self.payment_mode.auto_reconcile_allow_partial = False
         self.assertFalse(self.payment_mode.auto_reconcile_allow_partial)
-        self.invoice_copy.payment_mode_id = self.payment_mode
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': self.payment_mode.id})
         # Only the older move is used as payment
         self.assertEqual(self.invoice_copy.residual, 500)
-        self.invoice_copy.payment_mode_id = False
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': False})
         self.assertEqual(self.invoice_copy.residual, 1500)
         # Set allow partial will reconcile both moves
         self.payment_mode.auto_reconcile_allow_partial = True
-        self.invoice_copy.payment_mode_id = self.payment_mode
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': self.payment_mode.id})
         self.assertEqual(self.invoice_copy.state, 'paid')
         self.assertEqual(self.invoice_copy.residual, 0)
 
@@ -145,13 +140,11 @@ class TestPartnerAutoReconcile(SavepointCase):
         # As we had 2200 of outstanding credits and 800 was assigned, there's
         # 1400 left
         self.assertTrue(self.payment_mode.auto_reconcile_allow_partial)
-        self.invoice_copy.payment_mode_id = self.payment_mode
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': self.payment_mode.id})
         self.assertEqual(self.invoice_copy.residual, 100)
         # Unreconcile of an invoice doesn't change the reconciliation of the
         # other invoice
-        self.invoice_copy.payment_mode_id = False
-        self.invoice_copy.payment_mode_id_change()
+        self.invoice_copy.write({'payment_mode_id': False})
         self.assertEqual(self.invoice_copy.residual, 1500)
         self.assertEqual(auto_rec_invoice.state, 'paid')
         self.assertEqual(auto_rec_invoice.residual, 0)

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -13,6 +13,7 @@ class TestPartnerAutoReconcile(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestPartnerAutoReconcile, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.acc_rec = cls.env['account.account'].search(
             [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_receivable').id

--- a/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
+++ b/account_payment_mode_auto_reconcile/tests/test_partner_auto_reconcile.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from datetime import date, timedelta

--- a/account_payment_mode_auto_reconcile/views/account_invoice.xml
+++ b/account_payment_mode_auto_reconcile/views/account_invoice.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-
     <record id="invoice_form_inherit" model="ir.ui.view">
         <field name="name">account_payment_partner.invoice_form.inherit</field>
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account_payment_partner.invoice_form" />
         <field name="arch" type="xml">
             <field name="payment_mode_id" position="before">
-                <field name="auto_assigned_oustanding_credits" invisible="True"/>
+                <field name="display_payment_mode_warning" invisible="True"/>"
             </field>
             <field name="payment_mode_id" position="after">
-                <label for="onchange_payment_mode_warning" invisible="True" />
-                <div class="alert alert-warning oe_edit_only" attrs="{'invisible': [('auto_assigned_oustanding_credits', '=', False)]}">
-                    <span name="onchange_payment_mode_warning" nolabel="1">Changing the payment mode might unreconcile payments.</span>
+                <label for="payment_mode_warning" invisible="True" />
+                <div class="alert alert-warning oe_edit_only" attrs="{'invisible': [('display_payment_mode_warning', '!=', True)]}">
+                    <field name="payment_mode_warning" nolabel="1" />
                 </div>
             </field>
         </field>

--- a/account_payment_mode_auto_reconcile/views/account_invoice.xml
+++ b/account_payment_mode_auto_reconcile/views/account_invoice.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="invoice_form_inherit" model="ir.ui.view">
+        <field name="name">account_payment_partner.invoice_form.inherit</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account_payment_partner.invoice_form" />
+        <field name="arch" type="xml">
+            <field name="payment_mode_id" position="before">
+                <field name="auto_assigned_oustanding_credits" invisible="True"/>
+            </field>
+            <field name="payment_mode_id" position="after">
+                <label for="onchange_payment_mode_warning" invisible="True" />
+                <div class="alert alert-warning oe_edit_only" attrs="{'invisible': [('auto_assigned_oustanding_credits', '=', False)]}">
+                    <span name="onchange_payment_mode_warning" nolabel="1">Changing the payment mode might unreconcile payments.</span>
+                </div>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
+++ b/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="account_payment_mode_form_inherit" model="ir.ui.view">
+        <field name="name">account.payment.mode.form.inherit</field>
+        <field name="model">account.payment.mode</field>
+        <field name="inherit_id" ref="account_payment_mode.account_payment_mode_form"/>
+        <field name="arch" type="xml">
+            <group name="note" position="before">
+                <group string="Auto reconcile outstanding credits" name="auto_reconcile">
+                    <field name="auto_reconcile_outstanding_credits" />
+                    <field name="auto_reconcile_allow_partial" attrs="{'invisible': [('auto_reconcile_outstanding_credits', '=', False)]}" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
+++ b/account_payment_mode_auto_reconcile/views/account_payment_mode.xml
@@ -9,6 +9,7 @@
                 <group string="Auto reconcile outstanding credits" name="auto_reconcile">
                     <field name="auto_reconcile_outstanding_credits" />
                     <field name="auto_reconcile_allow_partial" attrs="{'invisible': [('auto_reconcile_outstanding_credits', '=', False)]}" />
+                    <field name="auto_reconcile_same_journal" attrs="{'invisible': [('auto_reconcile_outstanding_credits', '=', False)]}" />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
This module adds a checkbox 'auto_reconcile_outstanding_credits' on account
payment modes to allow automatic reconciliation on account invoices if it is
checked.

Automatic reconciliation of outstanding credits will only happen on customer
invoices at validation if the payment mode is set or when the payment mode is
changed on an open invoice.
