### PR TITLE
[FIX] account_payment_partner: remove wrong code line

### DIFF
--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -289,7 +289,6 @@ class TestAccountPaymentPartner(common.SavepointCase):
 
     def test_invoice_refund(self):
         invoice = self._create_invoice()
-        invoice.partner_bank_id = False
         invoice.action_invoice_open()
         # Lets create a refund invoice for invoice_1.
         # I refund the invoice Using Refund Button.


### PR DESCRIPTION
I don't know why this line of code was added (https://github.com/OCA/bank-payment/blob/7c5cb9638b4139fe25e1df605f1b4f90345aab2a/account_payment_partner/tests/test_account_payment_partner.py#L292), that breaks the tests

Cc @Tecnativa