### PR TITLE
[FIX] account_payment_order: TypeError: a bytes-like object is required, not str

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -332,6 +332,7 @@ class AccountPaymentOrder(models.Model):
         payment_file_str, filename = self.generate_payment_file()
         action = {}
         if payment_file_str and filename:
+            payment_file_str = payment_file_str.encode()
             attachment = self.env['ir.attachment'].create({
                 'res_model': 'account.payment.order',
                 'res_id': self.id,

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -332,7 +332,8 @@ class AccountPaymentOrder(models.Model):
         payment_file_str, filename = self.generate_payment_file()
         action = {}
         if payment_file_str and filename:
-            payment_file_str = payment_file_str.encode()
+            if isinstance(payment_file_str, str):
+                payment_file_str = payment_file_str.encode()
             attachment = self.env['ir.attachment'].create({
                 'res_model': 'account.payment.order',
                 'res_id': self.id,


### PR DESCRIPTION
Account Payment Order form view, click on Generate file button and it will give you below error:
```
/oca-addons/bank-payment/account_payment_order/models/account_payment_order.py", line 339, in open2generated
    'datas': base64.b64encode(payment_file_str),
  File "/usr/lib/python3.6/base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'
```

@max3903 