### PR TITLE
[REM] Mandate: Remove check on on partner_bank company

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -129,13 +129,6 @@ class AccountBankingMandate(models.Model):
     @api.constrains('company_id', 'payment_line_ids', 'partner_bank_id')
     def _company_constrains(self):
         for mandate in self:
-            if mandate.partner_bank_id.company_id and \
-                    mandate.partner_bank_id.company_id != mandate.company_id:
-                raise ValidationError(
-                    _("The company of the mandate %s differs from the "
-                      "company of partner %s.") %
-                    (mandate.display_name, mandate.partner_id.name))
-
             if self.env['account.payment.line'].sudo().search(
                     [('mandate_id', '=', mandate.id),
                      ('company_id', '!=', mandate.company_id.id)], limit=1):

--- a/account_banking_mandate/tests/test_mandate.py
+++ b/account_banking_mandate/tests/test_mandate.py
@@ -86,45 +86,6 @@ class TestMandate(TransactionCase):
                 fields.Date.from_string(
                     fields.Date.context_today(mandate)) + timedelta(days=1))
 
-    def test_constrains_02(self):
-        bank_account = self.env.ref('account_payment_mode.res_partner_12_iban')
-        mandate = self.env['account.banking.mandate'].create({
-            'partner_bank_id': bank_account.id,
-            'signature_date': '2015-01-01',
-            'company_id': self.company.id,
-        })
-
-        with self.assertRaises(ValidationError):
-            mandate.company_id = self.company_2
-
-    def test_constrains_03(self):
-        bank_account = self.env.ref('account_payment_mode.res_partner_12_iban')
-        mandate = self.env['account.banking.mandate'].create({
-            'partner_bank_id': bank_account.id,
-            'signature_date': '2015-01-01',
-            'company_id': self.company.id,
-        })
-        bank_account_2 = self.env['res.partner.bank'].create({
-            'acc_number': '1234',
-            'company_id': self.company_2.id,
-            'partner_id': self.company_2.partner_id.id,
-        })
-        with self.assertRaises(ValidationError):
-            mandate.partner_bank_id = bank_account_2
-
-    def test_constrains_04(self):
-        mandate = self.env['account.banking.mandate'].create({
-            'signature_date': '2015-01-01',
-            'company_id': self.company.id,
-        })
-        bank_account = self.env['res.partner.bank'].create({
-            'acc_number': '1234',
-            'company_id': self.company_2.id,
-            'partner_id': self.company_2.partner_id.id,
-        })
-        with self.assertRaises(ValidationError):
-            bank_account.mandate_ids += mandate
-
     def test_mandate_reference_01(self):
         """
         Test case: create a mandate with no reference


### PR DESCRIPTION
Hi,
I was questioning the point of this check.
Globally, we may argue that the field company_id on a res.partner.bank serves no purpose (except for visibility) since a res.partner.bank is tightly coupled to a res.partner and must be unique among all companies anyway.
Thus, if this field makes no real sense, what's the point of checking it ?

I would appreciate reading your thoughts on that. 
Do you see any reason to have the company_id field on res.partner.bank that I'd miss ? Or to still perform this check ?

Btw, the error message is wrong here. It should say that the company of the mandate differs from the company of the bank account.

qgr