### PR TITLE
[FIX] account_banking_sepa_direct_debit: UserError instead of Warning

### DIFF
--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -82,7 +82,7 @@ class AccountPaymentOrder(models.Model):
                     % (line.partner_id.name, line.name))
             scheme = line.mandate_id.scheme
             if line.mandate_id.state != 'valid':
-                raise Warning(
+                raise UserError(
                     _("The SEPA Direct Debit mandate with reference '%s' "
                       "for partner '%s' has expired.")
                     % (line.mandate_id.unique_mandate_reference,
@@ -90,7 +90,7 @@ class AccountPaymentOrder(models.Model):
             if line.mandate_id.type == 'oneoff':
                 seq_type = 'OOFF'
                 if line.mandate_id.last_debit_date:
-                    raise Warning(
+                    raise UserError(
                         _("The mandate with reference '%s' for partner "
                           "'%s' has type set to 'One-Off' and it has a "
                           "last debit date set to '%s', so we can't use "


### PR DESCRIPTION
Raise UserError instead of Warning

Before:
![image](https://user-images.githubusercontent.com/36861439/67867312-7e705500-fb2a-11e9-972a-a4707e1c7e43.png)
After:
![image](https://user-images.githubusercontent.com/36861439/67867946-7cf35c80-fb2b-11e9-91fb-389c48590a47.png)

