### PR TITLE
[FIX] account_payment_purchase: Do not warn if no purchase

### DIFF
--- a/account_payment_purchase/models/account_invoice.py
+++ b/account_payment_purchase/models/account_invoice.py
@@ -10,9 +10,13 @@ class AccountInvoice(models.Model):
 
     @api.onchange('purchase_id')
     def purchase_order_change(self):
+        new_purchase = self.purchase_id
         new_mode = self.purchase_id.payment_mode_id.id or False
         new_bank = self.purchase_id.supplier_partner_bank_id.id or False
         res = super(AccountInvoice, self).purchase_order_change()
+        if not new_purchase:
+            # User did not add a purchase order, no need to warn
+            return res
         if self.payment_mode_id and self.payment_mode_id.id != new_mode:
             res['warning'] = {
                 'title': _('Warning'),


### PR DESCRIPTION
If the user set no purchase order on an invoice, it makes no sense
to warn them about details being different.

The onchange for the purchase_id field is not only run when the user
sets a purchase, but also when they open a new, empty form view.
Normally this causes no problems, but in some contexts the user
may want to define defaults for the payment term or bank account.
If these are defined, they will not be False on a new draft invoice,
but there will be no purchase, so the code interpreted the values
as having "changed".

We avoid this by simply not checking for changes if no purchase has
been set on the invoice.