### PR TITLE
[FIX] account_payment_mode: Always set company bank account in customer

### DIFF
--- a/account_payment_mode/models/__init__.py
+++ b/account_payment_mode/models/__init__.py
@@ -1,4 +1,5 @@
 
+from . import account_invoice
 from . import account_payment_method
 from . import account_payment_mode
 from . import account_journal

--- a/account_payment_mode/models/account_invoice.py
+++ b/account_payment_mode/models/account_invoice.py
@@ -1,0 +1,19 @@
+# Copyright 2019 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+from odoo.tools import config
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    def _get_default_bank_id(self, type, company_id):
+        """When OCA payment mode is used we don't want default bank acc"""
+        context = self.env.context
+        if config['test_enable'] and not context.get(
+            'test_account_payment_mode') or context.get(
+                'force_std_default_bank_id'):
+            return super()._get_default_bank_id(type, company_id)
+        else:
+            return False


### PR DESCRIPTION
invoices

This code:
https://github.com/odoo/odoo/blob/221a1712a8c7bf4b9870d05d2fb76bef3a9f1183/addons/account/models/account_invoice.py#L549-L551
https://github.com/odoo/odoo/blob/221a1712a8c7bf4b9870d05d2fb76bef3a9f1183/addons/account/models/account_invoice.py#L592-L599

invalidates all after this code:
https://github.com/OCA/bank-payment/blob/f51b565a2b1fc5933190a9f03facd215dd110d8f/account_payment_partner/models/account_invoice.py#L131

I invalidate _get_default_bank_id function in account_payment_mode module because the above example is just one of the several that we can find.
OCA modules handle several use cases that Odoo does not cover, so it is better that nothing comes by default and each module manages its values.

@Tecnativa TT20718