### PR TITLE
[11.0][FIX]domain payline create

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -118,7 +118,7 @@ class AccountPaymentLineCreate(models.TransientModel):
             "LEFT OUTER JOIN account_move_line aml "
             "  ON aml.id = apl.move_line_id "
             "WHERE apo.state != 'cancel' "
-            "  AND COALESCE(aml.reconciled, FALSE) = FALSE)")
+            "  AND COALESCE(aml.reconciled, FALSE) = FALSE")
         res = self.env.cr.fetchall()
         if res:
             move_lines_ids = [x[0] for x in res]

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -115,7 +115,7 @@ class AccountPaymentLineCreate(models.TransientModel):
             "SELECT aml.id FROM account_payment_line apl "
             "INNER JOIN account_payment_order apo "
             "  ON apl.order_id = apo.id "
-            "LEFT OUTER JOIN account_move_line aml "
+            "INNER JOIN account_move_line aml "
             "  ON aml.id = apl.move_line_id "
             "WHERE apo.state != 'cancel' "
             "  AND COALESCE(aml.reconciled, FALSE) = FALSE")


### PR DESCRIPTION
The current domain filter does not take into account payment order that have been uploaded with a future due date. When working with a payment mode without 'transfer' account there is a risk for a double payment.

This fix correct this (I use cr.execute in stead of ORM search since we may have a large number of payment lines in large companies, as an alternative we could think about storing the account.payment.line as a M2O in the account.move.line)