### PR TITLE
[11.0] FIX: Order payments with sepa and non-sepa payment lines are now working.

### DIFF
--- a/account_banking_pain_base/__manifest__.py
+++ b/account_banking_pain_base/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '11.0.1.0.2',
+    'version': '11.0.2.0.0',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "

--- a/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
+++ b/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
@@ -1,0 +1,73 @@
+# Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    """Update database from previous versions, after updating module."""
+
+    if not version:
+        return
+    cr = env.cr
+
+    # update charge_bearer of account_payment_lines
+    plines = env['account.payment.line'].search([])
+    for pline in plines:
+        pline.compute_charge_bearer()
+
+    # update charge_bearer for all bank_payment_line
+    cr.execute(
+        """
+        UPDATE bank_payment_line as l 
+        SET charge_bearer = (
+           SELECT charge_bearer FROM account_payment_order as o 
+           WHERE o.id = l.order_id
+        )
+        """
+    )
+    # correct charge_bearer for sepa bank_payment_line (must be 'SLEV')
+    blines = env['bank.payment.line'].search([])
+    for bline in blines:
+        if bline.sepa:
+            bline.charge_bearer = 'SLEV'
+
+    # update charge_bearer of account_payment_lines
+    # cr.execute(
+    #     """
+    #     UPDATE account_payment_line as l
+    #     SET charge_bearer = (
+    #        SELECT charge_bearer FROM account_payment_order as o
+    #        WHERE o.id = l.order_id
+    #     )
+    #     """
+    # )
+    #
+    # # update charge_bearer of bank_payment_line
+    # cr.execute(
+    #     """
+    #     UPDATE bank_payment_line as l
+    #     SET charge_bearer = (
+    #        SELECT charge_bearer FROM account_payment_order as o
+    #        WHERE o.id = l.order_id
+    #     )
+    #     """
+    # )
+    #
+    # cr.execute(
+    #     """
+    #     SELECT
+    #       res_partner_bank.sanitized_acc_number
+    #     FROM
+    #       public.account_payment_line,
+    #       public.account_payment_order,
+    #       public.account_journal,
+    #       public.res_partner_bank
+    #     WHERE
+    #       account_payment_line.order_id = account_payment_order.id AND
+    #       account_payment_order.journal_id = account_journal.id AND
+    #       account_journal.bank_account_id = res_partner_bank.id;
+    #     """
+    # )
+    # bank_accounts = cr.dictfetchall()
+    #

--- a/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
+++ b/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
@@ -3,6 +3,7 @@
 
 from openupgradelib import openupgrade
 
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     """Update database from previous versions, after updating module."""
@@ -18,56 +19,12 @@ def migrate(env, version):
 
     # update charge_bearer for all bank_payment_line
     cr.execute(
-        """
-        UPDATE bank_payment_line as l 
-        SET charge_bearer = (
-           SELECT charge_bearer FROM account_payment_order as o 
-           WHERE o.id = l.order_id
-        )
-        """
-    )
+        "UPDATE bank_payment_line as l "
+        "SET charge_bearer = ("
+        "SELECT charge_bearer FROM account_payment_order as o "
+        "WHERE o.id = l.order_id)")
     # correct charge_bearer for sepa bank_payment_line (must be 'SLEV')
     blines = env['bank.payment.line'].search([])
     for bline in blines:
         if bline.sepa:
             bline.charge_bearer = 'SLEV'
-
-    # update charge_bearer of account_payment_lines
-    # cr.execute(
-    #     """
-    #     UPDATE account_payment_line as l
-    #     SET charge_bearer = (
-    #        SELECT charge_bearer FROM account_payment_order as o
-    #        WHERE o.id = l.order_id
-    #     )
-    #     """
-    # )
-    #
-    # # update charge_bearer of bank_payment_line
-    # cr.execute(
-    #     """
-    #     UPDATE bank_payment_line as l
-    #     SET charge_bearer = (
-    #        SELECT charge_bearer FROM account_payment_order as o
-    #        WHERE o.id = l.order_id
-    #     )
-    #     """
-    # )
-    #
-    # cr.execute(
-    #     """
-    #     SELECT
-    #       res_partner_bank.sanitized_acc_number
-    #     FROM
-    #       public.account_payment_line,
-    #       public.account_payment_order,
-    #       public.account_journal,
-    #       public.res_partner_bank
-    #     WHERE
-    #       account_payment_line.order_id = account_payment_order.id AND
-    #       account_payment_order.journal_id = account_journal.id AND
-    #       account_journal.bank_account_id = res_partner_bank.id;
-    #     """
-    # )
-    # bank_accounts = cr.dictfetchall()
-    #

--- a/account_banking_pain_base/models/account_payment_line.py
+++ b/account_banking_pain_base/models/account_payment_line.py
@@ -185,7 +185,7 @@ class AccountPaymentLine(models.Model):
              "by debtor : all transaction charges are to be borne by the "
              "debtor.")
     sepa = fields.Boolean(
-        compute='compute_sepa', readonly=True, string="SEPA Payment Line")
+        compute='_compute_sepa', readonly=True, string="SEPA Payment Line")
 
     @api.multi
     @api.onchange('sepa')
@@ -202,7 +202,7 @@ class AccountPaymentLine(models.Model):
         'order_id.company_partner_bank_id.acc_type',
         'currency_id',
         'partner_bank_id.acc_type')
-    def compute_sepa(self):
+    def _compute_sepa(self):
         for bpline in self:
             bpline._compute_sepa_line()
 

--- a/account_banking_pain_base/models/account_payment_line.py
+++ b/account_banking_pain_base/models/account_payment_line.py
@@ -177,18 +177,29 @@ class AccountPaymentLine(models.Model):
         track_visibility='onchange',
         help="Following service level : transaction charges are to be "
              "applied following the rules agreed in the service level "
-             "and/or scheme (SEPA Core messages must use this). Shared : "
-             "transaction charges on the debtor side are to be borne by "
-             "the debtor, transaction charges on the creditor side are to "
-             "be borne by the creditor. Borne by creditor : all "
-             "transaction charges are to be borne by the creditor. Borne "
+             "and/or scheme (SEPA Core messages must use this). "
+             "\nShared : transaction charges on the debtor side are to be "
+             "borne by the debtor, transaction charges on the creditor side "
+             "are to be borne by the creditor. \n Borne by creditor : all "
+             "transaction charges are to be borne by the creditor. \nBorne "
              "by debtor : all transaction charges are to be borne by the "
              "debtor.")
     sepa = fields.Boolean(
         compute='compute_sepa', readonly=True, string="SEPA Payment Line")
 
     @api.multi
+    @api.onchange('sepa')
+    def compute_charge_bearer(self):
+        for line in self:
+            if line.sepa:
+                line.charge_bearer = 'SLEV'
+            else:
+                if line.order_id.charge_bearer:
+                    line.charge_bearer = line.order_id.charge_bearer
+
+    @api.multi
     @api.depends(
+        'order_id.company_partner_bank_id.acc_type',
         'currency_id',
         'partner_bank_id.acc_type')
     def compute_sepa(self):

--- a/account_banking_pain_base/models/account_payment_line.py
+++ b/account_banking_pain_base/models/account_payment_line.py
@@ -210,6 +210,8 @@ class AccountPaymentLine(models.Model):
         self.ensure_one()
         eur = self.env.ref('base.EUR')
         self.sepa = True
+        if self.order_id.company_partner_bank_id.acc_type != 'iban':
+            self.sepa = False
         if self.currency_id != eur:
             self.sepa = False
         if self.partner_bank_id.acc_type != 'iban':

--- a/account_banking_pain_base/models/account_payment_line.py
+++ b/account_banking_pain_base/models/account_payment_line.py
@@ -2,7 +2,7 @@
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class AccountPaymentLine(models.Model):
@@ -166,3 +166,40 @@ class AccountPaymentLine(models.Model):
     # We now use communication_type ; you should add an option
     # in communication_type with selection_add=[]
     communication_type = fields.Selection(selection_add=[('ISO', 'ISO')])
+
+    charge_bearer = fields.Selection([
+        ('SLEV', 'Following Service Level'),
+        ('SHAR', 'Shared'),
+        ('CRED', 'Borne by Creditor'),
+        ('DEBT', 'Borne by Debtor')], string='Charge Bearer',
+        default='SLEV', readonly=True,
+        states={'draft': [('readonly', False)], 'open': [('readonly', False)]},
+        track_visibility='onchange',
+        help="Following service level : transaction charges are to be "
+             "applied following the rules agreed in the service level "
+             "and/or scheme (SEPA Core messages must use this). Shared : "
+             "transaction charges on the debtor side are to be borne by "
+             "the debtor, transaction charges on the creditor side are to "
+             "be borne by the creditor. Borne by creditor : all "
+             "transaction charges are to be borne by the creditor. Borne "
+             "by debtor : all transaction charges are to be borne by the "
+             "debtor.")
+    sepa = fields.Boolean(
+        compute='compute_sepa', readonly=True, string="SEPA Payment Line")
+
+    @api.multi
+    @api.depends(
+        'currency_id',
+        'partner_bank_id.acc_type')
+    def compute_sepa(self):
+        for bpline in self:
+            bpline._compute_sepa_line()
+
+    def _compute_sepa_line(self):
+        self.ensure_one()
+        eur = self.env.ref('base.EUR')
+        self.sepa = True
+        if self.currency_id != eur:
+            self.sepa = False
+        if self.partner_bank_id.acc_type != 'iban':
+            self.sepa = False

--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -3,13 +3,14 @@
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+import logging
+from datetime import datetime
+
+from lxml import etree
+
 from odoo import models, fields, api, _, tools
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval
-from datetime import datetime
-from lxml import etree
-import logging
-
 
 try:
     from unidecode import unidecode
@@ -31,8 +32,8 @@ class AccountPaymentOrder(models.Model):
         "false, the bank statement will display one debit line per wire "
         "transfer of the SEPA XML file.")
     sepa = fields.Boolean(
-        compute='compute_sepa', readonly=True, string="SEPA", help=
-        "True only if all payment lines are SEPA payments")
+        compute='_compute_sepa', readonly=True, string="SEPA",
+        help="True only if all payment lines are SEPA payments")
     charge_bearer = fields.Selection([
         ('SLEV', 'Following Service Level'),
         ('SHAR', 'Shared'),
@@ -57,7 +58,7 @@ class AccountPaymentOrder(models.Model):
         'company_partner_bank_id.acc_type',
         'payment_line_ids.currency_id',
         'payment_line_ids.partner_bank_id.acc_type')
-    def compute_sepa(self):
+    def _compute_sepa(self):
         sepa = True
         for pline in self.payment_line_ids:
             if not pline.sepa:

--- a/account_banking_pain_base/models/bank_payment_line.py
+++ b/account_banking_pain_base/models/bank_payment_line.py
@@ -28,11 +28,11 @@ class BankPaymentLine(models.Model):
         track_visibility='onchange',
         help="Following service level : transaction charges are to be "
              "applied following the rules agreed in the service level "
-             "and/or scheme (SEPA Core messages must use this). Shared : "
-             "transaction charges on the debtor side are to be borne by "
-             "the debtor, transaction charges on the creditor side are to "
-             "be borne by the creditor. Borne by creditor : all "
-             "transaction charges are to be borne by the creditor. Borne "
+             "and/or scheme (SEPA Core messages must use this). "
+             "\nShared : transaction charges on the debtor side are to be "
+             "borne by the debtor, transaction charges on the creditor side "
+             "are to be borne by the creditor. \n Borne by creditor : all "
+             "transaction charges are to be borne by the creditor. \nBorne "
              "by debtor : all transaction charges are to be borne by the "
              "debtor.")
 

--- a/account_banking_pain_base/models/bank_payment_line.py
+++ b/account_banking_pain_base/models/bank_payment_line.py
@@ -17,7 +17,7 @@ class BankPaymentLine(models.Model):
     purpose = fields.Selection(
         related='payment_line_ids.purpose')
     sepa = fields.Boolean(
-        compute='compute_sepa', readonly=True, string="SEPA Payment Line")
+        compute='_compute_sepa', readonly=True, string="SEPA Payment Line")
     charge_bearer = fields.Selection([
         ('SLEV', 'Following Service Level'),
         ('SHAR', 'Shared'),
@@ -44,7 +44,7 @@ class BankPaymentLine(models.Model):
                 'sepa', 'charge_bearer']
         return res
 
-    def compute_sepa(self):
+    def _compute_sepa(self):
         for bpline in self:
             bpline._compute_sepa_line()
 

--- a/account_banking_pain_base/models/bank_payment_line.py
+++ b/account_banking_pain_base/models/bank_payment_line.py
@@ -16,10 +16,43 @@ class BankPaymentLine(models.Model):
         related='payment_line_ids.category_purpose', string='Category Purpose')
     purpose = fields.Selection(
         related='payment_line_ids.purpose')
+    sepa = fields.Boolean(
+        compute='compute_sepa', readonly=True, string="SEPA Payment Line")
+    charge_bearer = fields.Selection([
+        ('SLEV', 'Following Service Level'),
+        ('SHAR', 'Shared'),
+        ('CRED', 'Borne by Creditor'),
+        ('DEBT', 'Borne by Debtor')], string='Charge Bearer',
+        default='SLEV', readonly=True,
+        states={'draft': [('readonly', False)], 'open': [('readonly', False)]},
+        track_visibility='onchange',
+        help="Following service level : transaction charges are to be "
+             "applied following the rules agreed in the service level "
+             "and/or scheme (SEPA Core messages must use this). Shared : "
+             "transaction charges on the debtor side are to be borne by "
+             "the debtor, transaction charges on the creditor side are to "
+             "be borne by the creditor. Borne by creditor : all "
+             "transaction charges are to be borne by the creditor. Borne "
+             "by debtor : all transaction charges are to be borne by the "
+             "debtor.")
 
     @api.model
     def same_fields_payment_line_and_bank_payment_line(self):
         res = super(BankPaymentLine, self).\
             same_fields_payment_line_and_bank_payment_line()
-        res += ['priority', 'local_instrument', 'category_purpose', 'purpose']
+        res += ['priority', 'local_instrument', 'category_purpose', 'purpose',
+                'sepa', 'charge_bearer']
         return res
+
+    def compute_sepa(self):
+        for bpline in self:
+            bpline._compute_sepa_line()
+
+    def _compute_sepa_line(self):
+        self.ensure_one()
+        eur = self.env.ref('base.EUR')
+        self.sepa = True
+        if self.currency_id != eur:
+            self.sepa = False
+        if self.partner_bank_id.acc_type != 'iban':
+            self.sepa = False

--- a/account_banking_pain_base/views/account_payment_line.xml
+++ b/account_banking_pain_base/views/account_payment_line.xml
@@ -6,19 +6,32 @@
 <odoo>
 
 
-<record id="account_payment_line_form" model="ir.ui.view">
-    <field name="name">pain.base.account.payment.line</field>
-    <field name="model">account.payment.line</field>
-    <field name="inherit_id" ref="account_payment_order.account_payment_line_form"/>
-    <field name="arch" type="xml">
-        <field name="communication_type" position="before">
-            <field name="priority"/>
-            <field name="local_instrument"/>
-            <field name="category_purpose"/>
-            <field name="purpose"/>
+    <record id="account_payment_line_form" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.line</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_form"/>
+        <field name="arch" type="xml">
+            <field name="communication_type" position="before">
+                <field name="priority"/>
+                <field name="local_instrument"/>
+                <field name="category_purpose"/>
+                <field name="purpose"/>
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
         </field>
-    </field>
-</record>
+    </record>
 
+    <record id="account_payment_line_tree" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.line.tree</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
 
 </odoo>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -12,9 +12,7 @@
     <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
     <field name="arch" type="xml">
         <field name="company_partner_bank_id" position="after">
-            <field name="sepa"/>
             <field name="batch_booking"/>
-            <field name="charge_bearer" attrs="{'invisible': [('sepa', '=', True)]}"/>
         </field>
     </field>
 </record>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -16,7 +16,7 @@
             <xpath expr="//group[@name='head']">
                 <group name="head-left-2">
                     <field name="charge_bearer"
-                           attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('sepa', '=', True)]}"/>
+                           attrs="{'readonly': ['|', ('state', '!=', 'draft')], 'invisible': [('sepa', '=', True)]}"/>
                 </group>
                 <group name="head-right-2">
                     <button name="apply_charge_bearer"

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -4,18 +4,30 @@
   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-
-
-<record id="account_payment_order_form" model="ir.ui.view">
-    <field name="name">pain.base.account.payment.order.form</field>
-    <field name="model">account.payment.order</field>
-    <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
-    <field name="arch" type="xml">
-        <field name="company_partner_bank_id" position="after">
-            <field name="batch_booking"/>
+    <record id="account_payment_order_form" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.order.form</field>
+        <field name="model">account.payment.order</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
+        <field name="arch" type="xml">
+            <field name="bank_line_count" position="after">
+                <field name="batch_booking"/>
+                <field name="sepa"/>
+            </field>
+            <xpath expr="//group[@name='head']">
+                <group name="head-left-2">
+                    <field name="charge_bearer"
+                           attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('sepa', '=', True)]}"/>
+                </group>
+                <group name="head-right-2">
+                    <button name="apply_charge_bearer"
+                            string="Apply Charge Bearer to all lines"
+                            type="object"
+                            class="oe_stat_button"
+                            attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('sepa', '=', True)]}"
+                            confirm="Warning! This will change the charge bearer value of all the payment line to the one you just selected. Do you really want to do that?"
+                    />
+                </group>
+            </xpath>
         </field>
-    </field>
-</record>
-
-
+    </record>
 </odoo>

--- a/account_banking_pain_base/views/bank_payment_line_view.xml
+++ b/account_banking_pain_base/views/bank_payment_line_view.xml
@@ -6,19 +6,29 @@
 <odoo>
 
 
-<record id="bank_payment_line_form" model="ir.ui.view">
-    <field name="name">pain.base.bank.payment.line.form</field>
-    <field name="model">bank.payment.line</field>
-    <field name="inherit_id" ref="account_payment_order.bank_payment_line_form"/>
-    <field name="arch" type="xml">
-        <field name="partner_bank_id" position="after">
-            <field name="priority"/>
-            <field name="local_instrument"/>
-            <field name="category_purpose"/>
-            <field name="purpose"/>
+    <record id="bank_payment_line_form" model="ir.ui.view">
+        <field name="name">pain.base.bank.payment.line.form</field>
+        <field name="model">bank.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.bank_payment_line_form"/>
+        <field name="arch" type="xml">
+            <field name="partner_bank_id" position="after">
+                <field name="priority"/>
+                <field name="local_instrument"/>
+                <field name="category_purpose"/>
+                <field name="purpose"/>
+            </field>
         </field>
-    </field>
-</record>
+    </record>
 
-
+    <record id="bank_payment_line_tree" model="ir.ui.view">
+        <field name="name">bank.payment.line.tree</field>
+        <field name="model">bank.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.bank_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/account_banking_sepa_credit_transfer/__init__.py
+++ b/account_banking_sepa_credit_transfer/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from .post_install import update_bank_journals

--- a/account_banking_sepa_credit_transfer/__manifest__.py
+++ b/account_banking_sepa_credit_transfer/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2010-2016 Akretion (www.akretion.com)
 # © 2014 Tecnativa - Pedro M. Baeza
 # © 2016 Tecnativa - Antonio Espinosa

--- a/account_banking_sepa_credit_transfer/models/__init__.py
+++ b/account_banking_sepa_credit_transfer/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_method
 from . import account_payment_order
 from . import account_payment_line

--- a/account_banking_sepa_credit_transfer/models/account_payment_line.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_credit_transfer/models/account_payment_method.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2010-2016 Akretion (www.akretion.com)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -84,7 +84,6 @@ class AccountPaymentOrder(models.Model):
             priority = line.priority
             local_instrument = line.local_instrument
             categ_purpose = line.category_purpose
-            line.compute_sepa()
 
             # The field line.date is the requested payment date
             # taking into account the 'date_prefered' setting

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -85,7 +85,6 @@ class AccountPaymentOrder(models.Model):
             priority = line.priority
             local_instrument = line.local_instrument
             categ_purpose = line.category_purpose
-            line_name = line.name
             line.compute_sepa()
 
             # The field line.date is the requested payment date
@@ -93,18 +92,19 @@ class AccountPaymentOrder(models.Model):
             # cf account_banking_payment_export/models/account_payment.py
             # in the inherit of action_open()
             key = (line.date, priority, local_instrument, categ_purpose,
-                   line.sepa, line.charge_bearer, line_name)
+                   line.sepa, line.charge_bearer)
             if key in lines_per_group:
                 lines_per_group[key].append(line)
             else:
                 lines_per_group[key] = [line]
-        for (requested_date, priority, local_instrument, categ_purpose,
-             is_sepa, lines_charge_bearer, line_name), lines in list(lines_per_group.items()):
+        for loop_index, ((requested_date, priority, local_instrument,
+                          categ_purpose, is_sepa, lines_charge_bearer), lines)\
+                in enumerate(list(lines_per_group.items())):
             # B. Payment info
             payment_info, nb_of_transactions_b, control_sum_b = \
                 self.generate_start_payment_info_block(
                     pain_root,
-                    "self.name + '-' + line_name + '-' + "
+                    "self.name + '-' + loop_index + '-' + "
                     "requested_date.replace('-', '')  + '-' + priority + "
                     "'-' + local_instrument + '-' + category_purpose",
                     priority, local_instrument, categ_purpose,
@@ -113,9 +113,9 @@ class AccountPaymentOrder(models.Model):
                         'priority': priority,
                         'requested_date': requested_date,
                         'local_instrument': local_instrument or 'NOinstr',
-                        'category_purpose': categ_purpose or 'NOcateg',
+                        'category_purpose': categ_purpose or 'NOcat',
                         'sepa': is_sepa,
-                        'line_name': line_name
+                        'loop_index': str(loop_index)
                     }, gen_args)
             self.generate_party_block(
                 payment_info, 'Dbtr', 'B',

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -85,23 +85,27 @@ class AccountPaymentOrder(models.Model):
             priority = line.priority
             local_instrument = line.local_instrument
             categ_purpose = line.category_purpose
+            line_name = line.name
+            line.compute_sepa()
+
             # The field line.date is the requested payment date
             # taking into account the 'date_prefered' setting
             # cf account_banking_payment_export/models/account_payment.py
             # in the inherit of action_open()
-            key = (line.date, priority, local_instrument, categ_purpose)
+            key = (line.date, priority, local_instrument, categ_purpose,
+                   line.sepa, line.charge_bearer, line_name)
             if key in lines_per_group:
                 lines_per_group[key].append(line)
             else:
                 lines_per_group[key] = [line]
-        for (requested_date, priority, local_instrument, categ_purpose),\
-                lines in list(lines_per_group.items()):
+        for (requested_date, priority, local_instrument, categ_purpose,
+             is_sepa, lines_charge_bearer, line_name), lines in list(lines_per_group.items()):
             # B. Payment info
             payment_info, nb_of_transactions_b, control_sum_b = \
                 self.generate_start_payment_info_block(
                     pain_root,
-                    "self.name + '-' "
-                    "+ requested_date.replace('-', '')  + '-' + priority + "
+                    "self.name + '-' + line_name + '-' + "
+                    "requested_date.replace('-', '')  + '-' + priority + "
                     "'-' + local_instrument + '-' + category_purpose",
                     priority, local_instrument, categ_purpose,
                     False, requested_date, {
@@ -110,15 +114,17 @@ class AccountPaymentOrder(models.Model):
                         'requested_date': requested_date,
                         'local_instrument': local_instrument or 'NOinstr',
                         'category_purpose': categ_purpose or 'NOcateg',
+                        'sepa': is_sepa,
+                        'line_name': line_name
                     }, gen_args)
             self.generate_party_block(
                 payment_info, 'Dbtr', 'B',
                 self.company_partner_bank_id, gen_args)
             charge_bearer = etree.SubElement(payment_info, 'ChrgBr')
-            if self.sepa:
+            if is_sepa:
                 charge_bearer_text = 'SLEV'
             else:
-                charge_bearer_text = self.charge_bearer
+                charge_bearer_text = lines_charge_bearer
             charge_bearer.text = charge_bearer_text
             transactions_count_b = 0
             amount_control_sum_b = 0.0

--- a/account_banking_sepa_credit_transfer/post_install.py
+++ b/account_banking_sepa_credit_transfer/post_install.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_credit_transfer/tests/__init__.py
+++ b/account_banking_sepa_credit_transfer/tests/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import test_sct

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -153,7 +153,6 @@ class TestSCT(common.HttpCase):
         self.assertEqual(agrolait_pay_line1.communication, 'F1341')
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
-        self.assertEqual(self.payment_order.sepa, True)
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id)])
         self.assertEqual(len(bank_lines), 1)
@@ -230,7 +229,6 @@ class TestSCT(common.HttpCase):
         self.assertEqual(asus_pay_line1.communication, 'Inv9032')
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
-        self.assertEqual(self.payment_order.sepa, False)
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_asus.id)])
         self.assertEqual(len(bank_lines), 1)

--- a/account_banking_sepa_direct_debit/__init__.py
+++ b/account_banking_sepa_direct_debit/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from .post_install import update_bank_journals

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2013-2016 Akretion (www.akretion.com)
 # Copyright 2014-2017 Tecnativa - Pedro M. Baeza
 # Copyright 2016 Tecnativa - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/__init__.py
+++ b/account_banking_sepa_direct_debit/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import res_company
 from . import res_config
 from . import account_banking_mandate

--- a/account_banking_sepa_direct_debit/models/account_banking_mandate.py
+++ b/account_banking_sepa_direct_debit/models/account_banking_mandate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).

--- a/account_banking_sepa_direct_debit/models/account_payment_method.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_mode.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -69,6 +69,8 @@ class AccountPaymentOrder(models.Model):
             transactions_count_a += 1
             priority = line.priority
             categ_purpose = line.category_purpose
+            line.compute_sepa()
+
             # The field line.date is the requested payment date
             # taking into account the 'date_prefered' setting
             # cf account_banking_payment_export/models/account_payment.py
@@ -107,19 +109,22 @@ class AccountPaymentOrder(models.Model):
                     line.mandate_id.recurrent_sequence_type
                 assert seq_type_label is not False
                 seq_type = seq_type_map[seq_type_label]
-            key = (line.date, priority, categ_purpose, seq_type, scheme)
+            key = (line.date, priority, categ_purpose, seq_type, scheme,
+                   line.sepa, line.charge_bearer)
             if key in lines_per_group:
                 lines_per_group[key].append(line)
             else:
                 lines_per_group[key] = [line]
 
-        for (requested_date, priority, categ_purpose, sequence_type, scheme),\
-                lines in list(lines_per_group.items()):
+        for loop_index, ((requested_date, priority, categ_purpose,
+                          sequence_type, scheme, is_sepa,
+                          lines_charge_bearer), lines) \
+                in enumerate(list(lines_per_group.items())):
             # B. Payment info
             payment_info, nb_of_transactions_b, control_sum_b = \
                 self.generate_start_payment_info_block(
                     pain_root,
-                    "self.name + '-' + "
+                    "self.name + '-' + loop_index + '-' + "
                     "sequence_type + '-' + requested_date.replace('-', '')  "
                     "+ '-' + priority + '-' + category_purpose",
                     priority, scheme, categ_purpose,
@@ -129,16 +134,18 @@ class AccountPaymentOrder(models.Model):
                         'priority': priority,
                         'category_purpose': categ_purpose or 'NOcateg',
                         'requested_date': requested_date,
+                        'sepa': is_sepa,
+                        'loop_index': str(loop_index)
                     }, gen_args)
 
             self.generate_party_block(
                 payment_info, 'Cdtr', 'B',
                 self.company_partner_bank_id, gen_args)
             charge_bearer = etree.SubElement(payment_info, 'ChrgBr')
-            if self.sepa:
+            if is_sepa:
                 charge_bearer_text = 'SLEV'
             else:
-                charge_bearer_text = self.charge_bearer
+                charge_bearer_text = lines_charge_bearer
             charge_bearer.text = charge_bearer_text
             creditor_scheme_identification = etree.SubElement(
                 payment_info, 'CdtrSchmeId')

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -68,7 +68,6 @@ class AccountPaymentOrder(models.Model):
             transactions_count_a += 1
             priority = line.priority
             categ_purpose = line.category_purpose
-            line.compute_sepa()
 
             # The field line.date is the requested payment date
             # taking into account the 'date_prefered' setting

--- a/account_banking_sepa_direct_debit/models/bank_payment_line.py
+++ b/account_banking_sepa_direct_debit/models/bank_payment_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/common.py
+++ b/account_banking_sepa_direct_debit/models/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/res_company.py
+++ b/account_banking_sepa_direct_debit/models/res_company.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/res_config.py
+++ b/account_banking_sepa_direct_debit/models/res_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/post_install.py
+++ b/account_banking_sepa_direct_debit/post_install.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/tests/__init__.py
+++ b/account_banking_sepa_direct_debit/tests/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import test_sdd
 from . import test_mandate

--- a/account_banking_sepa_direct_debit/tests/test_mandate.py
+++ b/account_banking_sepa_direct_debit/tests/test_mandate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -166,7 +166,6 @@ class TestSDD(common.HttpCase):
         self.assertEqual(agrolait_pay_line1.communication, invoice1.number)
         payment_order.draft2open()
         self.assertEqual(payment_order.state, 'open')
-        self.assertEqual(payment_order.sepa, True)
         # Check bank payment line
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id)])

--- a/account_payment_mode/__init__.py
+++ b/account_payment_mode/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models

--- a/account_payment_mode/__manifest__.py
+++ b/account_payment_mode/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (<https://www.akretion.com>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/migrations/11.0.1.0.1/pre-migration.py
+++ b/account_payment_mode/migrations/11.0.1.0.1/pre-migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/account_payment_mode/models/__init__.py
+++ b/account_payment_mode/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_method
 from . import account_payment_mode
 from . import account_journal

--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/account_payment_method.py
+++ b/account_payment_mode/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/account_payment_mode.py
+++ b/account_payment_mode/models/account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/res_partner_bank.py
+++ b/account_payment_mode/models/res_partner_bank.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/tests/__init__.py
+++ b/account_payment_mode/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_payment_mode

--- a/account_payment_mode/tests/test_account_payment_mode.py
+++ b/account_payment_mode/tests/test_account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -25,7 +25,7 @@ class AccountPaymentOrder(models.Model):
             return [('id', 'in', jrl_ids)]
 
     name = fields.Char(
-        string='Number', readonly=False, copy=False)  # v8 field : name
+        string='Number', readonly=True, copy=False)  # v8 field : name
     payment_mode_id = fields.Many2one(
         'account.payment.mode', 'Payment Mode', required=True,
         ondelete='restrict', track_visibility='onchange',

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -25,7 +25,7 @@ class AccountPaymentOrder(models.Model):
             return [('id', 'in', jrl_ids)]
 
     name = fields.Char(
-        string='Number', readonly=True, copy=False)  # v8 field : name
+        string='Number', readonly=False, copy=False)  # v8 field : name
     payment_mode_id = fields.Many2one(
         'account.payment.mode', 'Payment Mode', required=True,
         ondelete='restrict', track_visibility='onchange',

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -222,6 +222,8 @@ class AccountPaymentOrder(models.Model):
             'payment_line_ids': [(6, 0, paylines.ids)],
             'communication': '-'.join(
                 [line.communication for line in paylines]),
+            'sepa': paylines[0].sepa,
+            'charge_bearer': paylines[0].charge_bearer
             }
 
     @api.multi

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -221,9 +221,7 @@ class AccountPaymentOrder(models.Model):
             'order_id': paylines[0].order_id.id,
             'payment_line_ids': [(6, 0, paylines.ids)],
             'communication': '-'.join(
-                [line.communication for line in paylines]),
-            'sepa': paylines[0].sepa,
-            'charge_bearer': paylines[0].charge_bearer
+                [line.communication for line in paylines])
             }
 
     @api.multi

--- a/account_payment_order/wizard/__init__.py
+++ b/account_payment_order/wizard/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_line_create
 from . import account_invoice_payment_line_multi

--- a/account_payment_order/wizard/account_invoice_payment_line_multi.py
+++ b/account_payment_order/wizard/account_invoice_payment_line_multi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (<https://www.akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<https://therp.nl>)
 # © 2014-2015 ACSONE SA/NV (<https://acsone.eu>)

--- a/account_payment_partner/migrations/11.0.1.3.0/post-migrate.py
+++ b/account_payment_partner/migrations/11.0.1.3.0/post-migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
I move the sepa and charge_bearer fields from account_payment_order to account_payment_line (and bank_payment_line).
Now, an order that contains sepa and non sepa payment lines will work correctly (which is very useful for l10n_ch).

The payments are now grouped in multiple <PmtInf> inside one same pain001.
They are grouped depending on the 4 same fields as before (requested_date, priority, local_instrument, categ_purpose) plus the boolean is_sepa (true if the line is a sepa payment), the charge_bearer of the line and an index number.

With these changes, we don't need to group sepa payment and non-sepa payment in different  payments orders.

The sepa value is now calculated for every payment line and the charge_bearer value can also be set for each payment line.