### PR TITLE
[10.0] [IMP] Account Payment Sale: journal access at invoice creation

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -29,5 +29,6 @@ class SaleOrder(models.Model):
             vals['payment_mode_id'] = self.payment_mode_id.id
             if self.payment_mode_id.bank_account_link == 'fixed':
                 vals['partner_bank_id'] =\
-                    self.payment_mode_id.fixed_journal_id.bank_account_id.id
+                    self.payment_mode_id.fixed_journal_id.sudo().\
+                    bank_account_id.id
         return vals


### PR DESCRIPTION
The creation of the invoice from a sale order should be possible with no access on the journal of the payment mode

Forward port of https://github.com/OCA/bank-payment/pull/625
Forward port to 11.0 : https://github.com/OCA/bank-payment/pull/661
Forward port to 12.0 : https://github.com/OCA/bank-payment/pull/662