### PR TITLE
[12.0] [IMP] Account Payment Sale: journal access at invoice creation

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -16,7 +16,8 @@ class SaleOrder(models.Model):
             vals['payment_mode_id'] = self.payment_mode_id.id
             if self.payment_mode_id.bank_account_link == 'fixed':
                 vals['partner_bank_id'] =\
-                    self.payment_mode_id.fixed_journal_id.bank_account_id.id
+                    self.payment_mode_id.fixed_journal_id.sudo().\
+                    bank_account_id.id
         return vals
 
     @api.onchange('partner_id')


### PR DESCRIPTION
The creation of the invoice from a sale order should be possible with no access on the journal of the payment mode

Forward port of https://github.com/OCA/bank-payment/pull/625
Forward port to 10.0 : https://github.com/OCA/bank-payment/pull/660
Forward port to 11.0 : https://github.com/OCA/bank-payment/pull/661