### PR TITLE
[FIX] Allow default values for payment mode in multi-company env

### DIFF
--- a/account_payment_partner/models/account_invoice.py
+++ b/account_payment_partner/models/account_invoice.py
@@ -18,6 +18,9 @@ class AccountInvoice(models.Model):
         readonly=True)
     partner_bank_id = fields.Many2one(ondelete='restrict')
 
+    def _get_refund_common_fields(self):
+        return super(AccountInvoice, self)._get_refund_common_fields() + ['company_id']
+
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
         res = super(AccountInvoice, self)._onchange_partner_id()


### PR DESCRIPTION
If using ir.default for payment mode in a multi-company environment the payment mode of a sister company could be loaded if superuser (uid 1) was active in this sister company. Resulting in the error message:
_("The company of the invoice %s does not match with that of the payment mode") % rec.name)

This PR fixes this issue.