### PR TITLE
[11.0][FIX] account_payment_sale: Compatibility with modules as account_banking_sepa_direct_debit…

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -14,7 +14,8 @@ class SaleOrder(models.Model):
     def _get_payment_mode_vals(self, vals):
         if self.payment_mode_id:
             vals['payment_mode_id'] = self.payment_mode_id.id
-            if self.payment_mode_id.bank_account_link == 'fixed':
+            if (self.payment_mode_id.bank_account_link == 'fixed' and
+                    self.payment_mode_id.payment_method_id.code == 'manual'):
                 vals['partner_bank_id'] =\
                     self.payment_mode_id.fixed_journal_id.bank_account_id.id
         return vals


### PR DESCRIPTION
Without this change if you have a direct debit payment mode with bank_account_link == 'fixed' the field fixed_journal_id.bank_account_id is setted in partner_bank_id field.

Payment mode: Santander Direct Debit with Fixed Journal: Santander ES11 1111 1111 1111 1111
Sale Partner bank account: ES22 2222 2222 2222 2222

Without this change invoice is created with partner bank = Santander ES11 1111 1111 1111 1111

@Tecnativa