### PR TITLE
[12.0][IMP] account_payment_order: Print payment order in user lang if not generated

### DIFF
--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -4,7 +4,7 @@
 <odoo>
 
     <template id="print_account_payment_order_document">
-        <t t-set="doc" t-value="doc.with_context({'lang':doc.generated_user_id.lang})" />
+        <t t-set="doc" t-value="doc.with_context({'lang': doc.generated_user_id and doc.generated_user_id.lang or user.lang})" />
         <t t-call="web.external_layout">
             <div class="page">
                 <div class="oe_structure"/>


### PR DESCRIPTION
When you haven't still generated the file, `generated_user_id` is not filled, and so, you can't control the language in which the payment order is going to be printed.

Adding a condition for using the user language in that case makes this more comfortable.

@Tecnativa TT21992