### PR TITLE
[FIX] 12.0 refactor account_payment_order tests

### DIFF
--- a/account_payment_order/README.rst
+++ b/account_payment_order/README.rst
@@ -99,6 +99,7 @@ Contributors
 * Jose María Alzaga <jose.alzaga@aselcis.com>
 * Meyomesse Gilles <meyomesse.gilles@gmail.com>
 * Carlos Dauden
+* Pieter Paulussen <pieterpaulussen@code-source.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_payment_order/demo/payment_demo.xml
+++ b/account_payment_order/demo/payment_demo.xml
@@ -20,12 +20,12 @@
 
 <record id="account_payment_mode.payment_mode_outbound_ct1" model="account.payment.mode">
     <!-- Credit Transfer to Suppliers -->
-    <field name="default_journal_ids" search="[('type', 'in', ('purchase', 'purchase_refund'))]"/>
+    <field name="default_journal_ids" search="[('type', 'in', ('purchase', 'purchase_refund')), ('company_id', '=', ref('base.main_company'))]"/>
 </record>
 
 <record id="account_payment_mode.payment_mode_inbound_dd1" model="account.payment.mode">
     <!-- Direct Debit of customers -->
-    <field name="default_journal_ids" search="[('type', 'in', ('sale', 'sale_refund'))]"/>
+    <field name="default_journal_ids" search="[('type', 'in', ('sale', 'sale_refund')), ('company_id', '=', ref('base.main_company'))]"/>
 </record>
 
 

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -11,61 +11,61 @@ from datetime import date, timedelta
 class TestPaymentOrderInboundBase(SavepointCase):
     @classmethod
     def setUpClass(cls):
-        self = cls
-        super().setUpClass()
-        self.inbound_mode = self.env.ref(
+        super(TestPaymentOrderInboundBase, cls).setUpClass()
+        cls.inbound_mode = cls.env.ref(
             'account_payment_mode.payment_mode_inbound_dd1'
         )
-        self.invoice_line_account = self.env['account.account'].search(
-            [('user_type_id', '=', self.env.ref(
+        cls.invoice_line_account = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_revenue').id)],
             limit=1).id
-        self.journal = self.env['account.journal'].search(
+        cls.journal = cls.env['account.journal'].search(
             [('type', '=', 'bank'),
-             '|', ('company_id', '=', self.env.user.company_id.id),
+             '|', ('company_id', '=', cls.env.user.company_id.id),
              ('company_id', '=', False)], limit=1
         )
-        self.inbound_mode.variable_journal_ids = self.journal
+        cls.inbound_mode.variable_journal_ids = cls.journal
         # Make sure no others orders are present
-        self.domain = [
+        cls.domain = [
             ('state', '=', 'draft'),
             ('payment_type', '=', 'inbound'),
         ]
-        self.payment_order_obj = self.env['account.payment.order']
-        self.payment_order_obj.search(self.domain).unlink()
+        cls.payment_order_obj = cls.env['account.payment.order']
+        cls.payment_order_obj.search(cls.domain).unlink()
         # Create payment order
-        self.inbound_order = self.env['account.payment.order'].create({
+        cls.inbound_order = cls.env['account.payment.order'].create({
             'payment_type': 'inbound',
-            'payment_mode_id': self.inbound_mode.id,
-            'journal_id': self.journal.id,
+            'payment_mode_id': cls.inbound_mode.id,
+            'journal_id': cls.journal.id,
         })
         # Open invoice
-        self.invoice = self._create_customer_invoice(self)
-        self.invoice.action_invoice_open()
+        cls.invoice = cls._create_customer_invoice()
+        cls.invoice.action_invoice_open()
         # Add to payment order using the wizard
-        self.env['account.invoice.payment.line.multi'].with_context(
+        cls.env['account.invoice.payment.line.multi'].with_context(
             active_model='account.invoice',
-            active_ids=self.invoice.ids
+            active_ids=cls.invoice.ids
         ).create({}).run()
 
-    def _create_customer_invoice(self):
-        invoice_account = self.env['account.account'].search(
-            [('user_type_id', '=', self.env.ref(
+    @classmethod
+    def _create_customer_invoice(cls):
+        invoice_account = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_receivable').id)],
             limit=1).id
-        invoice = self.env['account.invoice'].create({
-            'partner_id': self.env.ref('base.res_partner_4').id,
+        invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.env.ref('base.res_partner_4').id,
             'account_id': invoice_account,
             'type': 'out_invoice',
-            'payment_mode_id': self.inbound_mode.id
+            'payment_mode_id': cls.inbound_mode.id
         })
-        self.env['account.invoice.line'].create({
-            'product_id': self.env.ref('product.product_product_4').id,
+        cls.env['account.invoice.line'].create({
+            'product_id': cls.env.ref('product.product_product_4').id,
             'quantity': 1.0,
             'price_unit': 100.0,
             'invoice_id': invoice.id,
             'name': 'product that cost 100',
-            'account_id': self.invoice_line_account,
+            'account_id': cls.invoice_line_account,
         })
         return invoice
 

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -21,7 +21,9 @@ class TestPaymentOrderInboundBase(SavepointCase):
                 'account.data_account_type_revenue').id)],
             limit=1).id
         self.journal = self.env['account.journal'].search(
-            [('type', '=', 'bank')], limit=1
+            [('type', '=', 'bank'),
+             '|', ('company_id', '=', self.env.user.company_id.id),
+             ('company_id', '=', False)], limit=1
         )
         self.inbound_mode.variable_journal_ids = self.journal
         # Make sure no others orders are present
@@ -85,13 +87,11 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
     def test_creation(self):
         payment_order = self.inbound_order
         self.assertEqual(len(payment_order.ids), 1)
-        bank_journal = self.env['account.journal'].search(
-            [('type', '=', 'bank')], limit=1)
         # Set journal to allow cancelling entries
-        bank_journal.update_posted = True
+        self.journal.update_posted = True
 
         payment_order.write({
-            'journal_id': bank_journal.id,
+            'journal_id': self.journal.id,
         })
 
         self.assertEqual(len(payment_order.payment_line_ids), 1)

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -4,63 +4,66 @@
 
 from datetime import date, datetime, timedelta
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestPaymentOrderOutbound(TransactionCase):
+class TestPaymentOrderOutbound(SavepointCase):
 
-    def setUp(self):
-        super(TestPaymentOrderOutbound, self).setUp()
-        self.invoice_line_account = self.env['account.account'].search(
-            [('user_type_id', '=', self.env.ref(
+    @classmethod
+    def setUpClass(cls):
+        super(TestPaymentOrderOutbound, cls).setUpClass()
+        cls.company = cls.env.user.company_id
+        cls.invoice_line_account = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_expenses').id)],
             limit=1).id
-        self.invoice = self._create_supplier_invoice()
-        self.invoice_02 = self._create_supplier_invoice()
-        self.mode = self.env.ref(
+        cls.invoice = cls._create_supplier_invoice()
+        cls.invoice_02 = cls._create_supplier_invoice()
+        cls.mode = cls.env.ref(
             'account_payment_mode.payment_mode_outbound_ct1')
-        self.mode.default_journal_ids = self.env['account.journal'].search([
+        cls.mode.default_journal_ids = cls.env['account.journal'].search([
             ('type', 'in', ('purchase', 'purchase_refund')),
-            ('company_id', '=', self.env.user.company_id.id)
+            ('company_id', '=', cls.env.user.company_id.id)
         ])
-        self.creation_mode = self.env.ref(
+        cls.creation_mode = cls.env.ref(
             'account_payment_mode.payment_mode_outbound_dd1')
-        self.creation_mode.default_journal_ids = (
-            self.env['account.journal'].search([
+        cls.creation_mode.default_journal_ids = (
+            cls.env['account.journal'].search([
                 ('type', 'in', ('sale', 'sale_refund')),
-                ('company_id', '=', self.env.user.company_id.id)
+                ('company_id', '=', cls.env.user.company_id.id)
             ]))
-        self.bank_journal = self.env['account.journal'].search(
+        cls.bank_journal = cls.env['account.journal'].search(
             [('type', '=', 'bank'),
-             '|', ('company_id', '=', self.env.user.company_id.id),
+             '|', ('company_id', '=', cls.env.user.company_id.id),
              ('company_id', '=', False)], limit=1)
         # Make sure no other payment orders are in the DB
-        self.domain = [
+        cls.domain = [
             ('state', '=', 'draft'),
             ('payment_type', '=', 'outbound'),
         ]
-        self.env['account.payment.order'].search(self.domain).unlink()
+        cls.env['account.payment.order'].search(cls.domain).unlink()
 
-    def _create_supplier_invoice(self):
-        invoice_account = self.env['account.account'].search(
-            [('user_type_id', '=', self.env.ref(
+    @classmethod
+    def _create_supplier_invoice(cls):
+        invoice_account = cls.env['account.account'].search(
+            [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_payable').id)],
             limit=1).id
-        invoice = self.env['account.invoice'].create({
-            'partner_id': self.env.ref('base.res_partner_4').id,
+        invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.env.ref('base.res_partner_4').id,
             'account_id': invoice_account,
             'type': 'in_invoice',
-            'payment_mode_id': self.env.ref(
+            'payment_mode_id': cls.env.ref(
                 'account_payment_mode.payment_mode_outbound_ct1').id
         })
 
-        self.env['account.invoice.line'].create({
-            'product_id': self.env.ref('product.product_product_4').id,
+        cls.env['account.invoice.line'].create({
+            'product_id': cls.env.ref('product.product_product_4').id,
             'quantity': 1.0,
             'price_unit': 100.0,
             'invoice_id': invoice.id,
             'name': 'product that cost 100',
-            'account_id': self.invoice_line_account,
+            'account_id': cls.invoice_line_account,
         })
 
         return invoice


### PR DESCRIPTION
@pedrobaeza Since you were the last person to update these tests, I would appreciate a small review.
In a multicompany setup, the search results on `account.journal` are not accurate enough because the record rules do not apply to the superuser.
I also did some cleaning in the setupclass method since there were duplicate class variables set there.