### PR TITLE
[11.0] Order payments with sepa and non-sepa payment lines are now working.

### DIFF
--- a/account_banking_pain_base/__manifest__.py
+++ b/account_banking_pain_base/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'Account Banking PAIN Base Module',
     'summary': 'Base module for PAIN file generation',
-    'version': '11.0.1.0.2',
+    'version': '11.0.2.0.0',
     'license': 'AGPL-3',
     'author': "Akretion, "
               "Noviat, "

--- a/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
+++ b/account_banking_pain_base/migrations/11.0.2.0.0/post-migrate.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    """Update database from previous versions, after updating module."""
+
+    if not version:
+        return
+    cr = env.cr
+
+    # update charge_bearer of account_payment_lines
+    plines = env['account.payment.line'].search([])
+    for pline in plines:
+        pline.compute_charge_bearer()
+
+    # update charge_bearer for all bank_payment_line
+    cr.execute(
+        "UPDATE bank_payment_line as l "
+        "SET charge_bearer = ("
+        "SELECT charge_bearer FROM account_payment_order as o "
+        "WHERE o.id = l.order_id)")
+    # correct charge_bearer for sepa bank_payment_line (must be 'SLEV')
+    blines = env['bank.payment.line'].search([])
+    for bline in blines:
+        if bline.sepa:
+            bline.charge_bearer = 'SLEV'

--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -234,7 +234,7 @@ class AccountPaymentOrder(models.Model):
     def generate_start_payment_info_block(
             self, parent_node, payment_info_ident,
             priority, local_instrument, category_purpose, sequence_type,
-            requested_date, eval_ctx, gen_args):
+            requested_date, sepa, eval_ctx, gen_args):
         payment_info = etree.SubElement(parent_node, 'PmtInf')
         payment_info_identification = etree.SubElement(
             payment_info, 'PmtInfId')
@@ -261,7 +261,7 @@ class AccountPaymentOrder(models.Model):
             instruction_priority = etree.SubElement(
                 payment_type_info, 'InstrPrty')
             instruction_priority.text = priority
-        if eval_ctx.get('sepa'):
+        if sepa:
             service_level = etree.SubElement(payment_type_info, 'SvcLvl')
             service_level_code = etree.SubElement(service_level, 'Cd')
             service_level_code.text = 'SEPA'

--- a/account_banking_pain_base/models/bank_payment_line.py
+++ b/account_banking_pain_base/models/bank_payment_line.py
@@ -16,10 +16,43 @@ class BankPaymentLine(models.Model):
         related='payment_line_ids.category_purpose', string='Category Purpose')
     purpose = fields.Selection(
         related='payment_line_ids.purpose')
+    sepa = fields.Boolean(
+        compute='_compute_sepa', readonly=True, string="SEPA Payment Line")
+    charge_bearer = fields.Selection([
+        ('SLEV', 'Following Service Level'),
+        ('SHAR', 'Shared'),
+        ('CRED', 'Borne by Creditor'),
+        ('DEBT', 'Borne by Debtor')], string='Charge Bearer',
+        default='SLEV', readonly=True,
+        states={'draft': [('readonly', False)], 'open': [('readonly', False)]},
+        track_visibility='onchange',
+        help="Following service level : transaction charges are to be "
+             "applied following the rules agreed in the service level "
+             "and/or scheme (SEPA Core messages must use this). "
+             "\nShared : transaction charges on the debtor side are to be "
+             "borne by the debtor, transaction charges on the creditor side "
+             "are to be borne by the creditor. \n Borne by creditor : all "
+             "transaction charges are to be borne by the creditor. \nBorne "
+             "by debtor : all transaction charges are to be borne by the "
+             "debtor.")
 
     @api.model
     def same_fields_payment_line_and_bank_payment_line(self):
         res = super(BankPaymentLine, self).\
             same_fields_payment_line_and_bank_payment_line()
-        res += ['priority', 'local_instrument', 'category_purpose', 'purpose']
+        res += ['priority', 'local_instrument', 'category_purpose', 'purpose',
+                'sepa', 'charge_bearer']
         return res
+
+    def _compute_sepa(self):
+        for bpline in self:
+            bpline._compute_sepa_line()
+
+    def _compute_sepa_line(self):
+        self.ensure_one()
+        eur = self.env.ref('base.EUR')
+        self.sepa = True
+        if self.currency_id != eur:
+            self.sepa = False
+        if self.partner_bank_id.acc_type != 'iban':
+            self.sepa = False

--- a/account_banking_pain_base/views/account_payment_line.xml
+++ b/account_banking_pain_base/views/account_payment_line.xml
@@ -6,19 +6,32 @@
 <odoo>
 
 
-<record id="account_payment_line_form" model="ir.ui.view">
-    <field name="name">pain.base.account.payment.line</field>
-    <field name="model">account.payment.line</field>
-    <field name="inherit_id" ref="account_payment_order.account_payment_line_form"/>
-    <field name="arch" type="xml">
-        <field name="communication_type" position="before">
-            <field name="priority"/>
-            <field name="local_instrument"/>
-            <field name="category_purpose"/>
-            <field name="purpose"/>
+    <record id="account_payment_line_form" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.line</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_form"/>
+        <field name="arch" type="xml">
+            <field name="communication_type" position="before">
+                <field name="priority"/>
+                <field name="local_instrument"/>
+                <field name="category_purpose"/>
+                <field name="purpose"/>
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
         </field>
-    </field>
-</record>
+    </record>
 
+    <record id="account_payment_line_tree" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.line.tree</field>
+        <field name="model">account.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
 
 </odoo>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -4,20 +4,30 @@
   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-
-
-<record id="account_payment_order_form" model="ir.ui.view">
-    <field name="name">pain.base.account.payment.order.form</field>
-    <field name="model">account.payment.order</field>
-    <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
-    <field name="arch" type="xml">
-        <field name="company_partner_bank_id" position="after">
-            <field name="sepa"/>
-            <field name="batch_booking"/>
-            <field name="charge_bearer" attrs="{'invisible': [('sepa', '=', True)]}"/>
+    <record id="account_payment_order_form" model="ir.ui.view">
+        <field name="name">pain.base.account.payment.order.form</field>
+        <field name="model">account.payment.order</field>
+        <field name="inherit_id" ref="account_payment_order.account_payment_order_form"/>
+        <field name="arch" type="xml">
+            <field name="bank_line_count" position="after">
+                <field name="batch_booking"/>
+                <field name="sepa"/>
+            </field>
+            <xpath expr="//group[@name='head']">
+                <group name="head-left-2">
+                    <field name="charge_bearer"
+                           attrs="{'readonly': ['|', ('state', '!=', 'draft')], 'invisible': [('sepa', '=', True)]}"/>
+                </group>
+                <group name="head-right-2">
+                    <button name="apply_charge_bearer"
+                            string="Apply Charge Bearer to all lines"
+                            type="object"
+                            class="oe_stat_button"
+                            attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('sepa', '=', True)]}"
+                            confirm="Warning! This will change the charge bearer value of all the payment line to the one you just selected. Do you really want to do that?"
+                    />
+                </group>
+            </xpath>
         </field>
-    </field>
-</record>
-
-
+    </record>
 </odoo>

--- a/account_banking_pain_base/views/bank_payment_line_view.xml
+++ b/account_banking_pain_base/views/bank_payment_line_view.xml
@@ -6,19 +6,29 @@
 <odoo>
 
 
-<record id="bank_payment_line_form" model="ir.ui.view">
-    <field name="name">pain.base.bank.payment.line.form</field>
-    <field name="model">bank.payment.line</field>
-    <field name="inherit_id" ref="account_payment_order.bank_payment_line_form"/>
-    <field name="arch" type="xml">
-        <field name="partner_bank_id" position="after">
-            <field name="priority"/>
-            <field name="local_instrument"/>
-            <field name="category_purpose"/>
-            <field name="purpose"/>
+    <record id="bank_payment_line_form" model="ir.ui.view">
+        <field name="name">pain.base.bank.payment.line.form</field>
+        <field name="model">bank.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.bank_payment_line_form"/>
+        <field name="arch" type="xml">
+            <field name="partner_bank_id" position="after">
+                <field name="priority"/>
+                <field name="local_instrument"/>
+                <field name="category_purpose"/>
+                <field name="purpose"/>
+            </field>
         </field>
-    </field>
-</record>
+    </record>
 
-
+    <record id="bank_payment_line_tree" model="ir.ui.view">
+        <field name="name">bank.payment.line.tree</field>
+        <field name="model">bank.payment.line</field>
+        <field name="inherit_id" ref="account_payment_order.bank_payment_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="sepa"/>
+                <field name="charge_bearer" attrs="{'readonly': [('sepa', '=', True)]}"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/account_banking_sepa_credit_transfer/__init__.py
+++ b/account_banking_sepa_credit_transfer/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from .post_install import update_bank_journals

--- a/account_banking_sepa_credit_transfer/__manifest__.py
+++ b/account_banking_sepa_credit_transfer/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2010-2016 Akretion (www.akretion.com)
 # © 2014 Tecnativa - Pedro M. Baeza
 # © 2016 Tecnativa - Antonio Espinosa

--- a/account_banking_sepa_credit_transfer/models/__init__.py
+++ b/account_banking_sepa_credit_transfer/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_method
 from . import account_payment_order
 from . import account_payment_line

--- a/account_banking_sepa_credit_transfer/models/account_payment_line.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_credit_transfer/models/account_payment_method.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2010-2016 Akretion (www.akretion.com)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -106,13 +106,12 @@ class AccountPaymentOrder(models.Model):
                     "requested_date.replace('-', '')  + '-' + priority + "
                     "'-' + local_instrument + '-' + category_purpose",
                     priority, local_instrument, categ_purpose,
-                    False, requested_date, {
+                    False, requested_date, is_sepa, {
                         'self': self,
                         'priority': priority,
                         'requested_date': requested_date,
                         'local_instrument': local_instrument or 'NOinstr',
                         'category_purpose': categ_purpose or 'NOcat',
-                        'sepa': is_sepa,
                         'loop_index': str(loop_index)
                     }, gen_args)
             self.generate_party_block(

--- a/account_banking_sepa_credit_transfer/post_install.py
+++ b/account_banking_sepa_credit_transfer/post_install.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_credit_transfer/tests/__init__.py
+++ b/account_banking_sepa_credit_transfer/tests/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import test_sct

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -140,6 +140,9 @@ class TestSCT(common.HttpCase):
         pay_lines = self.payment_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id),
             ('order_id', '=', self.payment_order.id)])
+        for pline in pay_lines:
+            self.assertEqual(pline.sepa, True)
+            self.assertEqual(pline.charge_bearer, 'SLEV')
         self.assertEqual(len(pay_lines), 3)
         agrolait_pay_line1 = pay_lines[0]
         accpre = self.env['decimal.precision'].precision_get('Account')
@@ -154,10 +157,13 @@ class TestSCT(common.HttpCase):
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
         self.assertEqual(self.payment_order.sepa, True)
+        self.assertEqual(self.payment_order.charge_bearer, 'SLEV')
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id)])
         self.assertEqual(len(bank_lines), 1)
         agrolait_bank_line = bank_lines[0]
+        self.assertEqual(bank_lines[0].sepa, True)
+        self.assertEqual(bank_lines[0].charge_bearer, 'SLEV')
         self.assertEqual(agrolait_bank_line.currency_id, self.eur_currency)
         self.assertEqual(float_compare(
             agrolait_bank_line.amount_currency, 49.0, precision_digits=accpre),
@@ -217,6 +223,9 @@ class TestSCT(common.HttpCase):
         pay_lines = self.payment_line_model.search([
             ('partner_id', '=', self.partner_asus.id),
             ('order_id', '=', self.payment_order.id)])
+        for pline in pay_lines:
+            self.assertEqual(pline.sepa, False)
+            self.assertEqual(pline.charge_bearer, 'SLEV')
         self.assertEqual(len(pay_lines), 2)
         asus_pay_line1 = pay_lines[0]
         accpre = self.env['decimal.precision'].precision_get('Account')
@@ -231,10 +240,13 @@ class TestSCT(common.HttpCase):
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, 'open')
         self.assertEqual(self.payment_order.sepa, False)
+        self.assertEqual(self.payment_order.charge_bearer, 'SLEV')
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_asus.id)])
         self.assertEqual(len(bank_lines), 1)
         asus_bank_line = bank_lines[0]
+        self.assertEqual(bank_lines[0].sepa, False)
+        self.assertEqual(bank_lines[0].charge_bearer, 'SLEV')
         self.assertEqual(asus_bank_line.currency_id, self.usd_currency)
         self.assertEqual(float_compare(
             asus_bank_line.amount_currency, 3054.0, precision_digits=accpre),
@@ -271,6 +283,36 @@ class TestSCT(common.HttpCase):
         for inv in [invoice1, invoice2]:
             self.assertEqual(inv.state, 'paid')
         return
+
+    def test_apply_charge_bearer(self):
+        invoice1 = self.create_invoice(
+            self.partner_asus.id,
+            'account_payment_mode.res_partner_2_iban', self.eur_currency.id,
+            2042.0, 'Inv9032')
+        invoice2 = self.create_invoice(
+            self.partner_asus.id,
+            'account_payment_mode.res_partner_2_iban', self.usd_currency.id,
+            1012.0, 'Inv9033')
+        for inv in [invoice1, invoice2]:
+            action = inv.create_account_payment_line()
+        self.payment_order = self.payment_order_model.browse(action['res_id'])
+        pay_lines = self.payment_line_model.search([
+            ('partner_id', '=', self.partner_asus.id),
+            ('order_id', '=', self.payment_order.id)])
+        self.assertEqual(self.payment_order.sepa, False)
+
+        self.assertEqual(pay_lines[0].sepa, True)
+        self.assertEqual(pay_lines[0].charge_bearer, 'SLEV')
+        self.assertEqual(pay_lines[1].sepa, False)
+        self.assertEqual(pay_lines[1].charge_bearer, 'SLEV')
+
+        self.payment_order.charge_bearer = 'SHAR'
+        self.payment_order.apply_charge_bearer()
+
+        self.assertEqual(pay_lines[0].sepa, True)
+        self.assertEqual(pay_lines[0].charge_bearer, 'SLEV')
+        self.assertEqual(pay_lines[1].sepa, False)
+        self.assertEqual(pay_lines[1].charge_bearer, 'SHAR')
 
     def create_invoice(
             self, partner_id, partner_bank_xmlid, currency_id,

--- a/account_banking_sepa_direct_debit/__init__.py
+++ b/account_banking_sepa_direct_debit/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from .post_install import update_bank_journals

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2013-2016 Akretion (www.akretion.com)
 # Copyright 2014-2017 Tecnativa - Pedro M. Baeza
 # Copyright 2016 Tecnativa - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/__init__.py
+++ b/account_banking_sepa_direct_debit/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import res_company
 from . import res_config
 from . import account_banking_mandate

--- a/account_banking_sepa_direct_debit/models/account_banking_mandate.py
+++ b/account_banking_sepa_direct_debit/models/account_banking_mandate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).

--- a/account_banking_sepa_direct_debit/models/account_payment_method.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_mode.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -126,13 +126,12 @@ class AccountPaymentOrder(models.Model):
                     "sequence_type + '-' + requested_date.replace('-', '')  "
                     "+ '-' + priority + '-' + category_purpose",
                     priority, scheme, categ_purpose,
-                    sequence_type, requested_date, {
+                    sequence_type, requested_date, is_sepa, {
                         'self': self,
                         'sequence_type': sequence_type,
                         'priority': priority,
                         'category_purpose': categ_purpose or 'NOcateg',
                         'requested_date': requested_date,
-                        'sepa': is_sepa,
                         'loop_index': str(loop_index)
                     }, gen_args)
 

--- a/account_banking_sepa_direct_debit/models/bank_payment_line.py
+++ b/account_banking_sepa_direct_debit/models/bank_payment_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2015-2016 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/models/common.py
+++ b/account_banking_sepa_direct_debit/models/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/res_company.py
+++ b/account_banking_sepa_direct_debit/models/res_company.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013-2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # © 2014 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # © 2016 Antiun Ingenieria S.L. - Antonio Espinosa

--- a/account_banking_sepa_direct_debit/models/res_config.py
+++ b/account_banking_sepa_direct_debit/models/res_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_banking_sepa_direct_debit/post_install.py
+++ b/account_banking_sepa_direct_debit/post_install.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/tests/__init__.py
+++ b/account_banking_sepa_direct_debit/tests/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import test_sdd
 from . import test_mandate

--- a/account_banking_sepa_direct_debit/tests/test_mandate.py
+++ b/account_banking_sepa_direct_debit/tests/test_mandate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -166,7 +166,6 @@ class TestSDD(common.HttpCase):
         self.assertEqual(agrolait_pay_line1.communication, invoice1.number)
         payment_order.draft2open()
         self.assertEqual(payment_order.state, 'open')
-        self.assertEqual(payment_order.sepa, True)
         # Check bank payment line
         bank_lines = self.bank_line_model.search([
             ('partner_id', '=', self.partner_agrolait.id)])

--- a/account_payment_mode/__init__.py
+++ b/account_payment_mode/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from . import models

--- a/account_payment_mode/__manifest__.py
+++ b/account_payment_mode/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (<https://www.akretion.com>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/migrations/11.0.1.0.1/pre-migration.py
+++ b/account_payment_mode/migrations/11.0.1.0.1/pre-migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/account_payment_mode/models/__init__.py
+++ b/account_payment_mode/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_method
 from . import account_payment_mode
 from . import account_journal

--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/account_payment_method.py
+++ b/account_payment_mode/models/account_payment_method.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/account_payment_mode.py
+++ b/account_payment_mode/models/account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/models/res_partner_bank.py
+++ b/account_payment_mode/models/res_partner_bank.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_mode/tests/__init__.py
+++ b/account_payment_mode/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_payment_mode

--- a/account_payment_mode/tests/test_account_payment_mode.py
+++ b/account_payment_mode/tests/test_account_payment_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Eficent Business and IT Consulting Services S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -221,7 +221,7 @@ class AccountPaymentOrder(models.Model):
             'order_id': paylines[0].order_id.id,
             'payment_line_ids': [(6, 0, paylines.ids)],
             'communication': '-'.join(
-                [line.communication for line in paylines]),
+                [line.communication for line in paylines])
             }
 
     @api.multi

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -25,7 +25,7 @@ class AccountPaymentOrder(models.Model):
             return [('id', 'in', jrl_ids)]
 
     name = fields.Char(
-        string='Number', readonly=True, copy=False)  # v8 field : name
+        string='Number', readonly=False, copy=False)  # v8 field : name
     payment_mode_id = fields.Many2one(
         'account.payment.mode', 'Payment Mode', required=True,
         ondelete='restrict', track_visibility='onchange',

--- a/account_payment_order/wizard/__init__.py
+++ b/account_payment_order/wizard/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_line_create
 from . import account_invoice_payment_line_multi

--- a/account_payment_order/wizard/account_invoice_payment_line_multi.py
+++ b/account_payment_order/wizard/account_invoice_payment_line_multi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (<https://www.akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<https://therp.nl>)
 # © 2014-2015 ACSONE SA/NV (<https://acsone.eu>)

--- a/account_payment_partner/migrations/11.0.1.3.0/post-migrate.py
+++ b/account_payment_partner/migrations/11.0.1.3.0/post-migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 


### PR DESCRIPTION
This is the same changes as proposed in #658, with some commits squashed and only changing the `generate_start_payment_info_block` method signature instead of adding a variable in the evaluation context, as suggested by @sbidoul .