### PR TITLE
[FIX] account_payment_partner: payment_mode_id default not set for Refund

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -55,6 +55,7 @@ class AccountMove(models.Model):
     @api.depends("partner_id", "company_id")
     def _compute_payment_mode(self):
         for move in self:
+            move.payment_mode_id = False
             if move.partner_id:
                 if move.type == "in_invoice":
                     move.payment_mode_id = move.with_context(
@@ -64,8 +65,6 @@ class AccountMove(models.Model):
                     move.payment_mode_id = move.with_context(
                         force_company=move.company_id.id
                     ).partner_id.customer_payment_mode_id
-            else:
-                move.payment_mode_id = False
 
     @api.depends("partner_id", "payment_mode_id")
     def _compute_invoice_partner_bank(self):


### PR DESCRIPTION
When we try to create a refund for an invoice, we get an error that payment_mode_id default is not set