### PR TITLE
[12.0][FIX] make tests compatible with runbot

### DIFF
--- a/account_payment_order/demo/payment_demo.xml
+++ b/account_payment_order/demo/payment_demo.xml
@@ -28,5 +28,9 @@
     <field name="default_journal_ids" search="[('type', 'in', ('sale', 'sale_refund')), ('company_id', '=', ref('base.main_company'))]"/>
 </record>
 
+<!-- without this, account tests fail /-->
+<record id="account.group_account_manager" model="res.groups">
+    <field name="implied_ids" eval="[(4, ref('group_account_payment'))]" />
+</record>
 
 </odoo>

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -132,5 +132,8 @@ class AccountMoveLine(models.Model):
                 doc.remove(elem)
             for elem in doc.xpath("//field[@name='credit']"):
                 doc.remove(elem)
-            result['arch'] = etree.tostring(doc)
+            arch, fields = self.env['ir.ui.view'].postprocess_and_fields(
+                self._name, doc, view_id,
+            )
+            result.update(arch=arch, fields=fields)
         return result

--- a/account_payment_order/tests/test_account_payment.py
+++ b/account_payment_order/tests/test_account_payment.py
@@ -1,6 +1,7 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import unittest
 from odoo.tests.common import SavepointCase
 
 
@@ -25,6 +26,8 @@ class TestAccountPayment(SavepointCase):
         # Journals
         cls.bank_journal = cls.account_journal_model.search(
             [('type', '=', 'bank')], limit=1)
+        if not cls.bank_journal:
+            raise unittest.SkipTest('No journals defined')
         cls.bank_journal.inbound_payment_method_ids = [
             (6, 0, [cls.inbound_payment_method_01.id,
                     cls.inbound_payment_method_02.id])]

--- a/account_payment_order/tests/test_payment_mode.py
+++ b/account_payment_order/tests/test_payment_mode.py
@@ -1,6 +1,7 @@
 # © 2017 Creu Blanca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import unittest
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError
 
@@ -9,6 +10,9 @@ class TestPaymentMode(TransactionCase):
 
     def setUp(self):
         super(TestPaymentMode, self).setUp()
+
+        if not self.env['account.account'].search([]):
+            raise unittest.SkipTest('No accounts defined')
 
         # Company
         self.company = self.env.ref('base.main_company')

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -3,6 +3,7 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import unittest
 from odoo.tests.common import SavepointCase
 from odoo.exceptions import ValidationError, UserError
 from datetime import date, timedelta
@@ -24,6 +25,8 @@ class TestPaymentOrderInboundBase(SavepointCase):
              '|', ('company_id', '=', cls.env.user.company_id.id),
              ('company_id', '=', False)], limit=1
         )
+        if not cls.journal:
+            raise unittest.SkipTest('No journal found')
         cls.inbound_mode.variable_journal_ids = cls.journal
         # Make sure no others orders are present
         cls.domain = [

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -1,7 +1,7 @@
 # © 2017 Camptocamp SA
 # © 2017 Creu Blanca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+import unittest
 from datetime import date, datetime, timedelta
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import SavepointCase
@@ -17,6 +17,8 @@ class TestPaymentOrderOutbound(SavepointCase):
             [('user_type_id', '=', cls.env.ref(
                 'account.data_account_type_expenses').id)],
             limit=1).id
+        if not cls.invoice_line_account:
+            raise unittest.SkipTest('No account found')
         cls.invoice = cls._create_supplier_invoice()
         cls.invoice_02 = cls._create_supplier_invoice()
         cls.mode = cls.env.ref(

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+import unittest
 from odoo import fields, _
 from odoo.tests import common
 from odoo.exceptions import ValidationError
@@ -31,8 +32,10 @@ class TestAccountPaymentPartner(common.SavepointCase):
         if charts:
             cls.chart = charts[0]
         else:
-            raise ValidationError(
+            cls.tearDownClass()
+            raise unittest.SkipTest(
                 _("No Chart of Account Template has been defined !"))
+
         old_company = cls.env.user.company_id
         cls.env.user.company_id = cls.company_2.id
         cls.chart.try_loading_for_current_company()

--- a/account_payment_sale/tests/common.py
+++ b/account_payment_sale/tests/common.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import unittest
 from odoo.tests.common import SavepointCase
 
 
@@ -9,6 +10,9 @@ class CommonTestCase(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        if not cls.env['account.account'].search([]):
+            raise unittest.SkipTest('No accounts defined')
 
         cls.bank = cls.env["res.partner.bank"].create({
             'acc_number': 'test',


### PR DESCRIPTION
the current tests rely on a chart of accounts existing when they run, which is generally not the case. On travis, this works because there we do `odoo -i account` first and only then `odoo -i ourmodules --test-enable ...`. The `account` module has all its tests post install because then whatever module is selected by the [hook](https://github.com/OCA/OCB/blob/12.0/addons/account/__init__.py#L13) has been installed and we have a COA. So I propose to do the same here, this way those tests also work on a plain runbot, or on odoo.sh.

The implied group is necessary so that https://github.com/OCA/OCB/blob/12.0/addons/account/tests/account_test_users.py#L15 can create a bank. I think this makes sense anyways, account managers should be allowed to do anything concerning accounting by default.

We need the last commit in `fields_view_get` to have a correct `fields` dictionary, as otherwise tests fail in https://github.com/OCA/OCB/blob/12.0/odoo/models.py#L5343 where core expects fields used in a view to show up in the `fields` dict.

Without the above, if you run `odoo -d empty_db -i account_payment_partner --test-enable --stop-after-init`, it actually deadlocks because the cursor from the [exception](https://github.com/OCA/bank-payment/blob/12.0/account_payment_partner/tests/test_account_payment_partner.py#L34) blocks the cursor created for the next test. This should probably be rewritten to raise `unittest.SkipTest` early in that case, or inherit from [AccountingTestCase](https://github.com/OCA/OCB/blob/12.0/addons/account/tests/account_test_classes.py#L9). The latter I started, but the diff would become huge and what I did here we'd need anyways, so I start with that.