### PR TITLE
[13.0][FIX] account_payment_order: fix get partner_bank_id in account move lines

### DIFF
--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -57,7 +57,6 @@
         name="Add to Payment/Debit Order"
         res_model="account.invoice.payment.line.multi"
         binding_model="account.move"
-        binding_views="form"
         view_mode="form"
         target="new"
         id="account_invoice_create_account_payment_line_action"

--- a/account_payment_order/views/ir_attachment.xml
+++ b/account_payment_order/views/ir_attachment.xml
@@ -12,12 +12,7 @@
                         <field name="name" />
                     </h1>
                     <group name="main">
-                        <field
-                            name="datas"
-                            filename="store_fname"
-                            string="Generated File"
-                        />
-                        <field name="store_fname" invisible="1" />
+                        <field name="datas" filename="name" string="Generated File" />
                         <label for="create_uid" string="Created by" />
                         <div name="creation_div">
                             <field name="create_uid" readonly="1" class="oe_inline" />


### PR DESCRIPTION
Fix get partner_bank_id in account move lines.

**Case:**
The bank account isn't set properly in the payment order lines, because the bank account is only got from account.move.line or the first bank account in the partner_id, but never from the invoice (account.move).

**Solution:**
With this fix, the bank account will be get from:

1. account.move.line
2. account.move
3. first bank account in the partner_id


This fix contain too https://github.com/OCA/bank-payment/issues/701
This fix contain too: fix the attachment file name. https://github.com/OCA/bank-payment/pull/686