### PR TITLE
[13.0][IMP]move payment order menus

### DIFF
--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -205,8 +205,8 @@
     </record>
     <menuitem
         id="mandate_menu"
-        parent="account_payment_order.payment_root"
+        parent="account.menu_finance_receivables"
         action="mandate_action"
-        sequence="30"
+        sequence="50"
     />
 </odoo>

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -248,6 +248,6 @@
         id="account_payment_order_inbound_menu"
         action="account_payment_order_inbound_action"
         parent="account.menu_finance_receivables"
-        sequence="2"
+        sequence="18"
     />
 </odoo>

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -239,21 +239,15 @@
         <field name="context">{'default_payment_type': 'inbound'}</field>
     </record>
     <menuitem
-        id="payment_root"
-        name="Payments"
-        parent="account.menu_finance"
-        sequence="7"
-    />
-    <menuitem
         id="account_payment_order_outbound_menu"
         action="account_payment_order_outbound_action"
-        parent="payment_root"
-        sequence="10"
+        parent="account.menu_finance_payables"
+        sequence="21"
     />
     <menuitem
         id="account_payment_order_inbound_menu"
         action="account_payment_order_inbound_action"
-        parent="payment_root"
-        sequence="20"
+        parent="account.menu_finance_receivables"
+        sequence="2"
     />
 </odoo>

--- a/account_payment_order/views/bank_payment_line.xml
+++ b/account_payment_order/views/bank_payment_line.xml
@@ -99,7 +99,7 @@
     <menuitem
         id="bank_payment_line_menu"
         action="bank_payment_line_action"
-        parent="payment_root"
+        parent="account.menu_finance_payables"
         sequence="50"
         groups="group_account_payment"
     />


### PR DESCRIPTION
In version 13 Odoo places the customer & vendor payment menus under the Customer and Vendor menus (cf. Odoo Enterprise account_batch_payment module).
I think we should stay consistent with this Odoo 13 approach.
This PR move the OCA bank-payment menus to the same place as the Odoo Enterprise equivalents.