### PR TITLE
[IMP] account_banking_pain_base: switch from @api.model to @api.multi

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -340,7 +340,6 @@ class AccountPaymentOrder(models.Model):
                 % self.company_id.name)
         return True
 
-    @api.model
     def generate_party_agent(
             self, parent_node, party_type, order, partner_bank, gen_args,
             bank_line=None):
@@ -437,7 +436,6 @@ class AccountPaymentOrder(models.Model):
 
         return True
 
-    @api.model
     def generate_party_block(
             self, parent_node, party_type, order, partner_bank, gen_args,
             bank_line=None):


### PR DESCRIPTION
The calls are the following:
`generate_payment_file()` -> `generate_party_block(...)` -> `generate_party_agent(...)`

The first was decorated with `api.multi` (with ensure_one) and the others with `api.model`.

This change allows to get the reference of the current payment order in
`generate_party_block(...)` and `generate_party_agent(...)` methods (for
instance to modulate the generation of the file depending on the related
payment method configuration).

Used by: https://github.com/OCA/l10n-switzerland/pull/558