### PR TITLE
[FIX] 10.0 - prevent partner_bank_id to stay undefined

### DIFF
--- a/account_banking_mandate/models/account_move_line.py
+++ b/account_banking_mandate/models/account_move_line.py
@@ -20,6 +20,7 @@ class AccountMoveLine(models.Model):
         if payment_order.payment_type != 'inbound':
             return vals
         mandate = self.mandate_id
+        partner_bank_id = False
         if not mandate and vals.get('mandate_id', False):
             mandate = mandate.browse(vals['mandate_id'])
         if not mandate:


### PR DESCRIPTION
In some cases, mandate can exist without a partner_bank_id. In this case, local variable 'partner_bank_id' was never initialize, causing a bug. Now, 'partner_bank_id' is initialize to False