### PR TITLE
[IMP] account_banking_pain_base: use account holder name in party block

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -449,7 +449,7 @@ class AccountPaymentOrder(models.Model):
             party_type_label = _("Creditor name")
         elif party_type == 'Dbtr':
             party_type_label = _("Debtor name")
-        name = 'partner_bank.partner_id.name'
+        name = 'partner_bank.acc_holder_name or partner_bank.partner_id.name'
         eval_ctx = {'partner_bank': partner_bank}
         party_name = self._prepare_field(
             party_type_label, name, eval_ctx, gen_args.get('name_maxsize'),


### PR DESCRIPTION
For some partners, the account name holder can be different than the partner name.

If that alternative name (`acc_holder_name`) is set on the bank account, use it.