### PR TITLE
[13.0][FIX] account_payment_order: avoid cache miss in computed field

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -42,6 +42,8 @@ class AccountMoveLine(models.Model):
                 )
             ):
                 ml.partner_bank_id = ml.move_id.invoice_partner_bank_id.id
+            else:
+                ml.partner_bank_id = ml.partner_bank_id
 
     def _prepare_payment_line_vals(self, payment_order):
         self.ensure_one()


### PR DESCRIPTION
We should always ensure to assign something in a compute method