### PR TITLE
[12.0][FIX]account_banking_mandate

### DIFF
--- a/account_banking_mandate/views/account_invoice_view.xml
+++ b/account_banking_mandate/views/account_invoice_view.xml
@@ -13,7 +13,7 @@
     <field name="arch" type="xml">
         <field name="partner_bank_id" position="after">
             <field name="mandate_id"
-                domain="[('partner_id', '=', commercial_partner_id), ('state', '=', 'valid')]"
+                domain="['|', ('partner_id', '=', commercial_partner_id),('partner_id', '=', partner_id), ('state', '=', 'valid')]"
                 attrs="{'required': [('mandate_required', '=', True)], 'invisible': [('mandate_required', '=', False)]}"/>
             <field name="mandate_required" invisible="1"/>
         </field>


### PR DESCRIPTION
I cannot select a mandate of the partner in a manually created invoice. I can only select mandates for his/her company.

This issue happens when the partner is not under any company and you assign a mandate to it. However, after some days, the partner is set under a company, but the mandate is still under the partner.

It is not possible to change the partner of the mandate. The only solution is to delete the mandate and create a new one but users don't want that.

This solution does not seem harmful to me, however I am not sure if it is worth it to develop something that changes the partner of the mandate when doing such changes in the partner.