### PR TITLE
[12.0][FIX] Fixed small bug in compute_sepa function

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -69,7 +69,7 @@ class AccountPaymentOrder(models.Model):
                     sepa = False
                     break
             sepa = order.compute_sepa_final_hook(sepa)
-            self.sepa = sepa
+            order.sepa = sepa
 
     @api.multi
     def compute_sepa_final_hook(self, sepa):


### PR DESCRIPTION
sepa flag should get set on the current order - not on self. Causes a bug when called with multiple records