### PR TITLE
[13.0] [FIX] account_payment_mode: partner view

### DIFF
--- a/account_payment_mode/views/res_partner.xml
+++ b/account_payment_mode/views/res_partner.xml
@@ -7,7 +7,7 @@ which prevents the selection of a contact -->
     <record id="partner_view_buttons" model="ir.ui.view">
         <field name="name">account_payment_mode.res_partner_form</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="account.partner_view_buttons" />
+        <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
             <group name="banks" position="attributes">
                 <attribute


### PR DESCRIPTION
The "banks" group is in the view [account.view_partner_property_form](https://github.com/odoo/odoo/blob/13.0/addons/account/views/partner_view.xml#L162) not in [account.partner_view_buttons](https://github.com/odoo/odoo/blob/13.0/addons/account/views/partner_view.xml#L111). 

This PR avoids error `Element '<group name="banks">' cannot be located in parent view`.