### PR TITLE
[13.0][IMP] account_payment_order: done status button

### DIFF
--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -49,8 +49,14 @@
                     <button
                         name="action_done_cancel"
                         type="object"
-                        states="uploaded"
+                        states="uploaded,done"
                         string="Cancel Payments"
+                    />
+                    <button
+                        name="action_done"
+                        type="object"
+                        states="uploaded"
+                        string="Set Done"
                     />
                     <field name="state" widget="statusbar" />
                 </header>


### PR DESCRIPTION
Honestly, I am just starting to use this module. However I don't see a way to set the payment order to state "Done". I really don't know why this status was included and how possibly the payment order can reach  than status without that button. This is more a "question" than a Pull request, just if someone can clarify this I will close it. Regards.