### PR TITLE
[14.0][FIX] account_payment_order + account_banking_mandate: Fix tests

### DIFF
--- a/account_banking_mandate/tests/test_invoice_mandate.py
+++ b/account_banking_mandate/tests/test_invoice_mandate.py
@@ -18,7 +18,7 @@ class TestInvoiceMandate(TransactionCase):
             lambda s: s.account_id == self.invoice_account
         )
         if payable_move_lines:
-            self.assertEqual(payable_move_lines[0].mandate_id, self.mandate)
+            self.assertEqual(payable_move_lines[0].move_id.mandate_id, self.mandate)
 
         self.env["account.invoice.payment.line.multi"].with_context(
             active_model="account.move", active_ids=self.invoice.ids
@@ -62,7 +62,7 @@ class TestInvoiceMandate(TransactionCase):
         )
         if payable_move_lines:
             with self.assertRaises(UserError):
-                payable_move_lines[0].mandate_id = mandate_2
+                payable_move_lines[0].move_id.mandate_id = mandate_2
 
     def test_post_invoice_and_refund_02(self):
         self.invoice._onchange_partner_id()

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -14,6 +14,7 @@ class TestPaymentOrderInboundBase(SavepointCase):
     def setUpClass(cls):
         self = cls
         super().setUpClass()
+        self.env.user.company_id = self.env.ref("base.main_company").id
         self.inbound_mode = self.env.ref(
             "account_payment_mode.payment_mode_inbound_dd1"
         )
@@ -23,16 +24,22 @@ class TestPaymentOrderInboundBase(SavepointCase):
                     "user_type_id",
                     "=",
                     self.env.ref("account.data_account_type_revenue").id,
-                )
+                ),
+                ("company_id", "=", self.env.user.company_id.id),
             ],
             limit=1,
         )
         self.journal = self.env["account.journal"].search(
-            [("type", "=", "bank")], limit=1
+            [("type", "=", "bank"), ("company_id", "=", self.env.user.company_id.id)],
+            limit=1,
         )
         self.inbound_mode.variable_journal_ids = self.journal
         # Make sure no others orders are present
-        self.domain = [("state", "=", "draft"), ("payment_type", "=", "inbound")]
+        self.domain = [
+            ("state", "=", "draft"),
+            ("payment_type", "=", "inbound"),
+            ("company_id", "=", self.env.user.company_id.id),
+        ]
         self.payment_order_obj = self.env["account.payment.order"]
         self.payment_order_obj.search(self.domain).unlink()
         # Create payment order

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -11,6 +11,7 @@ from odoo.tests.common import TransactionCase
 class TestPaymentOrderOutbound(TransactionCase):
     def setUp(self):
         super(TestPaymentOrderOutbound, self).setUp()
+        self.env.user.company_id = self.env.ref("base.main_company").id
         self.journal = self.env["account.journal"].search(
             [("type", "=", "bank")], limit=1
         )
@@ -22,7 +23,8 @@ class TestPaymentOrderOutbound(TransactionCase):
                         "user_type_id",
                         "=",
                         self.env.ref("account.data_account_type_expenses").id,
-                    )
+                    ),
+                    ("company_id", "=", self.env.user.company_id.id),
                 ],
                 limit=1,
             )
@@ -35,10 +37,15 @@ class TestPaymentOrderOutbound(TransactionCase):
             "account_payment_mode.payment_mode_outbound_dd1"
         )
         self.bank_journal = self.env["account.journal"].search(
-            [("type", "=", "bank")], limit=1
+            [("type", "=", "bank"), ("company_id", "=", self.env.user.company_id.id)],
+            limit=1,
         )
         # Make sure no other payment orders are in the DB
-        self.domain = [("state", "=", "draft"), ("payment_type", "=", "outbound")]
+        self.domain = [
+            ("state", "=", "draft"),
+            ("payment_type", "=", "outbound"),
+            ("company_id", "=", self.env.user.company_id.id),
+        ]
         self.env["account.payment.order"].search(self.domain).unlink()
 
     def _create_supplier_invoice(self):


### PR DESCRIPTION
`account_payment_order`: On multi-company settings, we need to make sure we are searching and creating objects with the correct company associated.
`account_banking_mandate`: Tests were trying to write/access a field that does not exist in account.move.line, but in account.move

@Tecnativa
TT28423