### PR TITLE
[14.0] account_banking_mandate: fix inherit of partner view

### DIFF
--- a/account_banking_mandate/views/res_partner.xml
+++ b/account_banking_mandate/views/res_partner.xml
@@ -7,7 +7,7 @@
     <record id="partner_view_buttons" model="ir.ui.view">
         <field name="name">mandate.res.partner.form</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="account.partner_view_buttons" />
+        <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
             <xpath
                 expr="//button[@name='%(base.action_res_partner_bank_account_form)d']"


### PR DESCRIPTION
On the inherit of partner view: the xpath uses button[@name='%(base.action_res_partner_bank_account_form) which is located in account.view_partner_property_form and NOT in account.partner_view_buttons on v14.