### PR TITLE
[13.0][FIX] account_payment_order: Fix tests

### DIFF
--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -11,6 +11,7 @@ from odoo.tests.common import TransactionCase
 class TestPaymentOrderOutbound(TransactionCase):
     def setUp(self):
         super(TestPaymentOrderOutbound, self).setUp()
+        self.env.user.company_id = self.env.ref("base.main_company").id
         self.journal = self.env["account.journal"].search(
             [("type", "=", "bank")], limit=1
         )
@@ -22,7 +23,8 @@ class TestPaymentOrderOutbound(TransactionCase):
                         "user_type_id",
                         "=",
                         self.env.ref("account.data_account_type_expenses").id,
-                    )
+                    ),
+                    ("company_id", "=", self.env.user.company_id.id),
                 ],
                 limit=1,
             )
@@ -35,10 +37,15 @@ class TestPaymentOrderOutbound(TransactionCase):
             "account_payment_mode.payment_mode_outbound_dd1"
         )
         self.bank_journal = self.env["account.journal"].search(
-            [("type", "=", "bank")], limit=1
+            [("type", "=", "bank"), ("company_id", "=", self.env.user.company_id.id)],
+            limit=1,
         )
         # Make sure no other payment orders are in the DB
-        self.domain = [("state", "=", "draft"), ("payment_type", "=", "outbound")]
+        self.domain = [
+            ("state", "=", "draft"),
+            ("payment_type", "=", "outbound"),
+            ("company_id", "=", self.env.user.company_id.id),
+        ]
         self.env["account.payment.order"].search(self.domain).unlink()
 
     def _create_supplier_invoice(self):


### PR DESCRIPTION
On multi-company settings, we need to make sure we are searching and creating objects with the correct company associated.
(Includes part of https://github.com/OCA/bank-payment/pull/786)

Create account and bank journal instead of searching.
Add proper expected taxes to that account to allow predicting the final value.

@Tecnativa
TT28423
TT28962

ping @victoralmau @pedrobaeza 