### PR TITLE
[14.0][FIX] account_payment_order: Fix tests

### DIFF
--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -18,16 +18,12 @@ class TestPaymentOrderInboundBase(SavepointCase):
         self.inbound_mode = self.env.ref(
             "account_payment_mode.payment_mode_inbound_dd1"
         )
-        self.invoice_line_account = self.env["account.account"].search(
-            [
-                (
-                    "user_type_id",
-                    "=",
-                    self.env.ref("account.data_account_type_revenue").id,
-                ),
-                ("company_id", "=", self.env.user.company_id.id),
-            ],
-            limit=1,
+        self.invoice_line_account = self.env["account.account"].create(
+            {
+                "name": "Test account",
+                "code": "TEST1",
+                "user_type_id": self.env.ref("account.data_account_type_revenue").id,
+            }
         )
         self.journal = self.env["account.journal"].search(
             [("type", "=", "bank"), ("company_id", "=", self.env.user.company_id.id)],
@@ -69,6 +65,7 @@ class TestPaymentOrderInboundBase(SavepointCase):
                 invoice_line_form.quantity = 1
                 invoice_line_form.price_unit = 100.0
                 invoice_line_form.account_id = self.invoice_line_account
+                invoice_line_form.tax_ids.clear()
         invoice = invoice_form.save()
         invoice_form = Form(invoice)
         invoice_form.payment_mode_id = self.inbound_mode

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -15,20 +15,12 @@ class TestPaymentOrderOutbound(TransactionCase):
         self.journal = self.env["account.journal"].search(
             [("type", "=", "bank")], limit=1
         )
-        self.invoice_line_account = (
-            self.env["account.account"]
-            .search(
-                [
-                    (
-                        "user_type_id",
-                        "=",
-                        self.env.ref("account.data_account_type_expenses").id,
-                    ),
-                    ("company_id", "=", self.env.user.company_id.id),
-                ],
-                limit=1,
-            )
-            .id
+        self.invoice_line_account = self.env["account.account"].create(
+            {
+                "name": "Test account",
+                "code": "TEST1",
+                "user_type_id": self.env.ref("account.data_account_type_expenses").id,
+            }
         )
         self.invoice = self._create_supplier_invoice()
         self.invoice_02 = self._create_supplier_invoice()
@@ -65,7 +57,7 @@ class TestPaymentOrderOutbound(TransactionCase):
                             "quantity": 1.0,
                             "price_unit": 100.0,
                             "name": "product that cost 100",
-                            "account_id": self.invoice_line_account,
+                            "account_id": self.invoice_line_account.id,
                         },
                     )
                 ],


### PR DESCRIPTION
Don't use taxes in invoices to avoid inconsistency across localization settings
Create account instead of relying on environment

FWP of https://github.com/OCA/bank-payment/pull/798, plus application of the same logic to the "outbound" tests.

@Tecnativa
TT28962

ping @victoralmau @pedrobaeza