### PR TITLE
[14.0][FIX] account_payment_order + account_payment_partner + account_payment_order_return: Fix tests

### DIFF
--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -4,6 +4,7 @@
 
 from datetime import date, datetime, timedelta
 
+from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import TransactionCase
 
@@ -48,6 +49,7 @@ class TestPaymentOrderOutbound(TransactionCase):
                 "payment_mode_id": self.env.ref(
                     "account_payment_mode.payment_mode_outbound_ct1"
                 ).id,
+                "invoice_date": fields.Date.today(),
                 "invoice_line_ids": [
                     (
                         0,

--- a/account_payment_order_return/tests/test_account_payment_order_return.py
+++ b/account_payment_order_return/tests/test_account_payment_order_return.py
@@ -90,7 +90,8 @@ class TestAccountPaymentOrderReturn(common.SavepointCase):
             )
         )
         self.payment = payment_register.save()._create_payments()
-        self.payment.action_post()
+        if self.payment.state != "posted":
+            self.payment.action_post()
         wizard.populate()
         # Create payment return
         payment_return_form = Form(self.env["payment.return"])

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -180,6 +180,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
         cls.supplier_invoice = cls.move_model.create(
             {
                 "partner_id": cls.supplier.id,
+                "invoice_date": fields.Date.today(),
                 "move_type": "in_invoice",
                 "journal_id": cls.journal_purchase.id,
             }
@@ -191,6 +192,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
                 "partner_id": self.supplier.id,
                 "journal_id": self.journal_purchase.id,
                 "move_type": "in_invoice",
+                "invoice_date": fields.Date.today(),
                 "company_id": self.company.id,
                 "payment_mode_id": self.env.ref(
                     "account_payment_mode.payment_mode_outbound_ct1"
@@ -257,6 +259,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
             {
                 "partner_id": self.supplier.id,
                 "move_type": "in_invoice",
+                "invoice_date": fields.Date.today(),
                 "company_id": self.company.id,
             }
         )
@@ -293,6 +296,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
                 {
                     "partner_id": self.supplier.id,
                     "move_type": "in_invoice",
+                    "invoice_date": fields.Date.today(),
                     "company_id": self.company.id,
                     "payment_mode_id": self.supplier_payment_mode_c2.id,
                 }
@@ -303,6 +307,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
             {
                 "partner_id": self.supplier.id,
                 "move_type": "in_invoice",
+                "invoice_date": fields.Date.today(),
                 "company_id": self.company.id,
             }
         )
@@ -386,7 +391,11 @@ class TestAccountPaymentPartner(common.SavepointCase):
         vals = {"partner_id": False, "move_type": "out_invoice"}
         invoice = self.move_model.new(vals)
         self.assertFalse(invoice.payment_mode_id)
-        vals = {"partner_id": False, "move_type": "in_invoice"}
+        vals = {
+            "partner_id": False,
+            "move_type": "in_invoice",
+            "invoice_date": fields.Date.today(),
+        }
         invoice = self.move_model.new(vals)
         self.assertFalse(invoice.partner_bank_id)
 
@@ -422,6 +431,7 @@ class TestAccountPaymentPartner(common.SavepointCase):
             {
                 "partner_id": self.supplier.id,
                 "move_type": "in_invoice",
+                "invoice_date": fields.Date.today(),
                 "journal_id": self.journal_purchase.id,
             }
         )


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/fcaa54939e9a4f0dd5e47cd0ccffe7aa24bd451c, we need to specify the invoice date for vendor bills to be able to post it.
Also, after https://github.com/odoo/odoo/commit/80c28189ae6b10ad17c4de2a781233a8ffe663a6 we can't post an invoice that is already posted.

@victoralmau @pedrobaeza can you review please?