### PR TITLE
[13.0][FIX] account_payment_purchase: Do not warn if no purchase

### DIFF
--- a/account_payment_purchase/models/account_invoice.py
+++ b/account_payment_purchase/models/account_invoice.py
@@ -10,6 +10,9 @@ class AccountMove(models.Model):
 
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
     def _onchange_purchase_auto_complete(self):
+        if not self.purchase_id:
+            # User did not add a purchase order, no need to warn
+            return super()._onchange_purchase_auto_complete()
         new_mode = self.purchase_id.payment_mode_id.id or False
         new_bank = self.purchase_id.supplier_partner_bank_id.id or False
         res = super()._onchange_purchase_auto_complete() or {}


### PR DESCRIPTION
Forward port of https://github.com/OCA/bank-payment/pull/652

If the user set no purchase order on an invoice, it makes no sense
to warn them about details being different.

The onchange for the purchase_id field is not only run when the user
sets a purchase, but also when they open a new, empty form view.
Normally this causes no problems, but in some contexts the user
may want to define defaults for the payment term or bank account.
If these are defined, they will not be False on a new draft invoice,
but there will be no purchase, so the code interpreted the values
as having "changed".

We avoid this by simply not checking for changes if no purchase has
been set on the invoice.

cc @ForgeFlow @MiquelRForgeFlow 