### PR TITLE
[13.0] [account_payment_purchase][fix] Only issue a warning message if the PO had a non-blank payment mode or bank.

### DIFF
--- a/account_payment_purchase/models/account_invoice.py
+++ b/account_payment_purchase/models/account_invoice.py
@@ -16,14 +16,18 @@ class AccountMove(models.Model):
         new_mode = self.purchase_id.payment_mode_id.id or False
         new_bank = self.purchase_id.supplier_partner_bank_id.id or False
         res = super()._onchange_purchase_auto_complete() or {}
-        if self.payment_mode_id and self.payment_mode_id.id != new_mode:
+        if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different payment mode."),
             }
             return res
         self.payment_mode_id = new_mode
-        if self.invoice_partner_bank_id and self.invoice_partner_bank_id.id != new_bank:
+        if (
+            self.invoice_partner_bank_id
+            and new_bank
+            and self.invoice_partner_bank_id.id != new_bank
+        ):
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different supplier bank."),

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -13,14 +13,20 @@ class TestAccountPaymentPurchase(SavepointCase):
         cls.journal = cls.env["account.journal"].create(
             {"name": "Test journal", "code": "TEST", "type": "general"}
         )
+        cls.payment_method_out = cls.env["account.payment.method"].create(
+            {
+                "name": "Test payment method",
+                "code": "test",
+                "payment_type": "outbound",
+                "bank_account_required": True,
+            }
+        )
         cls.payment_mode = cls.env["account.payment.mode"].create(
             {
                 "name": "Test payment mode",
                 "fixed_journal_id": cls.journal.id,
                 "bank_account_link": "variable",
-                "payment_method_id": cls.env.ref(
-                    "account.account_payment_method_manual_in"
-                ).id,
+                "payment_method_id": cls.payment_method_out.id,
             }
         )
         cls.partner = cls.env["res.partner"].create(
@@ -75,6 +81,7 @@ class TestAccountPaymentPurchase(SavepointCase):
         self.assertEqual(self.purchase.payment_mode_id, self.payment_mode)
 
     def test_purchase_order_invoicing(self):
+        self.purchase.onchange_partner_id()
         self.purchase.button_confirm()
 
         invoice = self.env["account.move"].create(
@@ -113,10 +120,8 @@ class TestAccountPaymentPurchase(SavepointCase):
         # Test partner_bank
         product = self.env["product.product"].create({"name": "Test product"})
         self.purchase.order_line[0].product_id = product
-        self.purchase.payment_mode_id = False
         self.purchase.supplier_partner_bank_id = self.bank
         self.purchase.button_confirm()
-
         invoice = self.env["account.move"].create(
             {"partner_id": self.partner.id, "type": "in_invoice"}
         )

--- a/account_payment_purchase_stock/tests/test_account_payment_purchase_stock.py
+++ b/account_payment_purchase_stock/tests/test_account_payment_purchase_stock.py
@@ -12,6 +12,7 @@ from odoo.addons.account_payment_purchase.tests.test_account_payment_purchase im
 
 class TestAccountPaymentPurchaseStock(TestAccountPaymentPurchase):
     def test_purchase_stock_order_invoicing(self):
+        self.purchase.onchange_partner_id()
         self.purchase.button_confirm()
         picking = self.purchase.picking_ids[0]
         picking.action_confirm()
@@ -65,7 +66,6 @@ class TestAccountPaymentPurchaseStock(TestAccountPaymentPurchase):
             {"name": "Test stockable product", "type": "product"}
         )
         self.purchase.order_line[0].product_id = stockable_product
-        self.purchase.payment_mode_id = False
         self.purchase.supplier_partner_bank_id = self.bank
         self.purchase.button_confirm()
         picking = self.purchase.picking_ids[0]


### PR DESCRIPTION
cc @AaronHForgeFlow @JordiMForgeFlow 