### PR TITLE
[14.0][IMP] account_payment_order - move date should be bank line date when offsetting_account is bank_account

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -420,6 +420,7 @@ class AccountPaymentOrder(models.Model):
         return True
 
     def _prepare_move(self, bank_lines=None):
+        move_date = False
         if self.payment_type == "outbound":
             ref = _("Payment order %s") % self.name
         else:
@@ -428,6 +429,8 @@ class AccountPaymentOrder(models.Model):
             ref += " - " + bank_lines.name
         if self.payment_mode_id.offsetting_account == "bank_account":
             journal_id = self.journal_id.id
+            if bank_lines:
+                move_date = bank_lines[0].date
         elif self.payment_mode_id.offsetting_account == "transfer_account":
             journal_id = self.payment_mode_id.transfer_journal_id.id
         vals = {
@@ -436,6 +439,8 @@ class AccountPaymentOrder(models.Model):
             "payment_order_id": self.id,
             "line_ids": [],
         }
+        if move_date:
+            vals.update({"date": move_date})
         total_company_currency = total_payment_currency = 0
         for bline in bank_lines:
             total_company_currency += bline.amount_company_currency

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -140,6 +140,7 @@ class TestPaymentOrderOutbound(TransactionCase):
         order.draft2open()
         order.open2generated()
         order.generated2uploaded()
+        self.assertEqual(order.move_ids[0].date, order.bank_line_ids[0].date)
         order.action_done()
         self.assertEqual(order.state, "done")
 


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/bank-payment/pull/805

Between Odoo v10.0 and Odoo v13.0, date fields on account.move and account.move.line became readonly. In both versions, date field on account.move.line is a related of the account.move one. This means that when creating our move in v10.0, date from account.move would take value of account.move.line. This is not true anymore with the readonly attributes. This is a way to return to that behavior.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT29473