### PR TITLE
[14.0][FIX] account_payment_order: several minor fixes

### DIFF
--- a/account_payment_order/security/payment_security.xml
+++ b/account_payment_order/security/payment_security.xml
@@ -7,7 +7,7 @@
                 name="users"
                 eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
             />
-            <field name="category_id" ref="base.module_category_extra" />
+            <field name="category_id" ref="base.module_category_usability" />
         </record>
     </data>
     <data noupdate="1">

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -57,7 +57,10 @@
                         name="move_option"
                         attrs="{'invisible': [('generate_move', '=', False)], 'required': [('generate_move', '=', True)]}"
                     />
-                    <field name="post_move" />
+                    <field
+                        name="post_move"
+                        attrs="{'invisible': [('generate_move', '=', False)]}"
+                    />
                 </group>
             </group>
         </field>


### PR DESCRIPTION
**Change security group category**

Before this change, the group was creating a new section in each user's settings called "Other" with a field called "Other Extra Rights" that could select "Accounting / Payments" as an option
This places it in the correct location

---

**Make post move field invisible in payment modes**

When the generate_moves option is not selected, the post_move option should not be available

---

@Tecnativa
TT29182

ping @pedrobaeza @victoralmau 