### PR TITLE
[14.0][FIX] account_payment_order: fix account move views

### DIFF
--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -42,11 +42,10 @@
             <field name="payment_mode_id" position="after">
                 <field name="payment_order_ok" invisible="1" />
             </field>
-            <field name="ref" position="before">
+            <field name="ref" position="after">
                 <field
                     name="reference_type"
                     required="1"
-                    nolabel="1"
                     attrs="{'readonly':[('state','!=','draft')],
                                'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />


### PR DESCRIPTION
Current spec was causing weird display in account move view, both for customer invoices and vendor bills
Changing the placement and adding back the label fixes the issue

### Before

#### In customer invoices
![image](https://user-images.githubusercontent.com/38977934/118480642-6f4ff880-b70a-11eb-99f9-dde72aa089b1.png)

#### In vendor bills
![image](https://user-images.githubusercontent.com/38977934/118480708-8393f580-b70a-11eb-88e3-14a4a9ca9044.png)

### After

#### In customer invoices
![image](https://user-images.githubusercontent.com/38977934/118480871-b938de80-b70a-11eb-841b-30649a7da458.png)

#### In vendor bills
![image](https://user-images.githubusercontent.com/38977934/118480932-d1a8f900-b70a-11eb-8cfb-8f9213fd81f9.png)

@Tecnativa
TT29027

ping @pedrobaeza @CarlosRoca13 