### PR TITLE
[14.0][IMP] account_payment_partner: Add refund_payment_mode_id to set in reverse moves

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Akretion - Alexis de Lattre <alexis.delattre@akretion.com>
 # Copyright 2014 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Tecnativa - Carlos Dauden
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -9,7 +10,7 @@
     "category": "Banking addons",
     "license": "AGPL-3",
     "summary": "Adds payment mode on partners and invoices",
-    "author": "Akretion, " "Tecnativa, " "Odoo Community Association (OCA)",
+    "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",
     "depends": ["account_payment_mode"],
     "data": [

--- a/account_payment_partner/i18n/account_payment_partner.pot
+++ b/account_payment_partner/i18n/account_payment_partner.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-25 12:38+0000\n"
+"PO-Revision-Date: 2021-05-25 12:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -163,6 +165,11 @@ msgid "Payment Modes"
 msgstr ""
 
 #. module: account_payment_partner
+#: model:ir.model.fields,field_description:account_payment_partner.field_account_payment_mode__refund_payment_mode_id
+msgid "Payment mode for refunds"
+msgstr ""
+
+#. module: account_payment_partner
 #: model_terms:ir.ui.view,arch_db:account_payment_partner.view_move_line_form
 msgid "Payments"
 msgstr ""
@@ -204,6 +211,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_payment_partner.field_res_partner__supplier_payment_mode_id
 #: model:ir.model.fields,field_description:account_payment_partner.field_res_users__supplier_payment_mode_id
 msgid "Supplier Payment Mode"
+msgstr ""
+
+#. module: account_payment_partner
+#: model:ir.model.fields,help:account_payment_partner.field_account_payment_mode__refund_payment_mode_id
+msgid ""
+"This payment mode will be used when doing refunds coming from the current "
+"payment mode."
 msgstr ""
 
 #. module: account_payment_partner

--- a/account_payment_partner/i18n/es.po
+++ b/account_payment_partner/i18n/es.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-23 03:38+0000\n"
-"PO-Revision-Date: 2021-04-18 16:46+0000\n"
+"POT-Creation-Date: 2021-05-25 12:38+0000\n"
+"PO-Revision-Date: 2021-05-25 14:40+0200\n"
 "Last-Translator: Nelson Ramírez Sánchez <info@konos.cl>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: account_payment_partner
 #: model_terms:ir.ui.view,arch_db:account_payment_partner.account_payment_mode_form
@@ -174,6 +174,11 @@ msgid "Payment Modes"
 msgstr "Modos de pago"
 
 #. module: account_payment_partner
+#: model:ir.model.fields,field_description:account_payment_partner.field_account_payment_mode__refund_payment_mode_id
+msgid "Payment mode for refunds"
+msgstr "Modo de pago para rectificaciones"
+
+#. module: account_payment_partner
 #: model_terms:ir.ui.view,arch_db:account_payment_partner.view_move_line_form
 msgid "Payments"
 msgstr "Pagos"
@@ -220,6 +225,15 @@ msgstr "Mostrar en facturas nº de cuenta bancaria parcial o completo"
 #: model:ir.model.fields,field_description:account_payment_partner.field_res_users__supplier_payment_mode_id
 msgid "Supplier Payment Mode"
 msgstr "Modo de pago de proveedor"
+
+#. module: account_payment_partner
+#: model:ir.model.fields,help:account_payment_partner.field_account_payment_mode__refund_payment_mode_id
+msgid ""
+"This payment mode will be used when doing refunds coming from the current "
+"payment mode."
+msgstr ""
+"Este modo de pago se utilizará cuando se realicen facturas rectificativas provenientes "
+"del modo de pago actual."
 
 #. module: account_payment_partner
 #: code:addons/account_payment_partner/models/account_payment_mode.py:0

--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -58,23 +58,24 @@ class AccountMove(models.Model):
         for move in self:
             move.payment_mode_id = False
             if move.partner_id:
-                partner = move.with_context(force_company=move.company_id.id).partner_id
-                if move.type == "in_invoice":
+                partner = move.with_company(move.company_id.id).partner_id
+                if move.move_type == "in_invoice":
                     move.payment_mode_id = partner.supplier_payment_mode_id
-                elif move.type == "out_invoice":
+                elif move.move_type == "out_invoice":
                     move.payment_mode_id = partner.customer_payment_mode_id
                 elif (
-                    move.type in ["out_refund", "in_refund"] and move.reversed_entry_id
+                    move.move_type in ["out_refund", "in_refund"]
+                    and move.reversed_entry_id
                 ):
                     move.payment_mode_id = (
                         move.reversed_entry_id.payment_mode_id.refund_payment_mode_id
                     )
                 elif not move.reversed_entry_id:
-                    if move.type == "out_refund":
+                    if move.move_type == "out_refund":
                         move.payment_mode_id = (
                             partner.customer_payment_mode_id.refund_payment_mode_id
                         )
-                    elif move.type == "in_refund":
+                    elif move.move_type == "in_refund":
                         move.payment_mode_id = (
                             partner.supplier_payment_mode_id.refund_payment_mode_id
                         )
@@ -106,8 +107,8 @@ class AccountMove(models.Model):
     def _reverse_move_vals(self, default_values, cancel=True):
         move_vals = super()._reverse_move_vals(default_values, cancel=cancel)
         move_vals["payment_mode_id"] = self.payment_mode_id.refund_payment_mode_id.id
-        if self.type == "in_invoice":
-            move_vals["invoice_partner_bank_id"] = self.invoice_partner_bank_id.id
+        if self.move_type == "in_invoice":
+            move_vals["partner_bank_id"] = self.partner_bank_id.id
         return move_vals
 
     def partner_banks_to_show(self):

--- a/account_payment_partner/models/account_payment_mode.py
+++ b/account_payment_partner/models/account_payment_mode.py
@@ -1,5 +1,6 @@
 # Copyright 2017 ForgeFlow S.L.
-# Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
+# Copyright 2018 Tecnativa - Carlos Dauden
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import _, api, fields, models
@@ -23,6 +24,13 @@ class AccountPaymentMode(models.Model):
     show_bank_account_from_journal = fields.Boolean(string="Bank account from journals")
     show_bank_account_chars = fields.Integer(
         string="# of digits for customer bank account"
+    )
+    refund_payment_mode_id = fields.Many2one(
+        comodel_name="account.payment.mode",
+        domain="[('payment_type', '!=', payment_type)]",
+        string="Payment mode for refunds",
+        help="This payment mode will be used when doing "
+        "refunds coming from the current payment mode.",
     )
 
     @api.constrains("company_id")

--- a/account_payment_partner/models/res_partner.py
+++ b/account_payment_partner/models/res_partner.py
@@ -9,13 +9,13 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     supplier_payment_mode_id = fields.Many2one(
-        "account.payment.mode",
+        comodel_name="account.payment.mode",
         company_dependent=True,
         domain="[('payment_type', '=', 'outbound')]",
         help="Select the default payment mode for this supplier.",
     )
     customer_payment_mode_id = fields.Many2one(
-        "account.payment.mode",
+        comodel_name="account.payment.mode",
         company_dependent=True,
         domain="[('payment_type', '=', 'inbound')]",
         help="Select the default payment mode for this customer.",

--- a/account_payment_partner/readme/CONTRIBUTORS.rst
+++ b/account_payment_partner/readme/CONTRIBUTORS.rst
@@ -7,8 +7,9 @@
 * Angel Moya <angel.moya@domatix.com>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
-  * Pedro M. Baeza <pedro.baeza@tecnativa.com>
-  * Carlos Dauden <carlos.dauden@tecnativa.com>
+  * Pedro M. Baeza
+  * Carlos Dauden
+  * Víctor Martínez
 * `DynApps <https://www.dynapps.be>`_:
 
   * Raf Ven <raf.ven@dynapps.be>

--- a/account_payment_partner/views/account_payment_mode.xml
+++ b/account_payment_partner/views/account_payment_mode.xml
@@ -6,6 +6,9 @@
         <field name="model">account.payment.mode</field>
         <field name="inherit_id" ref="account_payment_mode.account_payment_mode_form" />
         <field name="arch" type="xml">
+            <field name="variable_journal_ids" position="before">
+                <field name="refund_payment_mode_id" />
+            </field>
             <group name="note" position="before">
                 <group string="Show bank account in invoice report">
                     <group>


### PR DESCRIPTION
Add `refund_payment_mode_id` to assign any payment mode to set auto-compute in reverse moves (`in_refund` and `out_refund`).

FWP from 13.0: https://github.com/OCA/bank-payment/pull/810

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT29536