### PR TITLE
[14.0][IMP]account_payment_order: payment date when adding transaction line manually

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -90,6 +90,7 @@ class AccountMoveLine(models.Model):
             "communication_type": communication_type,
             "currency_id": currency_id,
             "amount_currency": amount_currency,
+            "date": False,
             # date is set when the user confirms the payment order
         }
         return vals

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -299,7 +299,7 @@ class AccountPaymentOrder(models.Model):
                 payline.draft2open_payment_line_check()
                 # Compute requested payment date
                 if order.date_prefered == "due":
-                    requested_date = payline.ml_maturity_date or today
+                    requested_date = payline.ml_maturity_date or payline.date or today
                 elif order.date_prefered == "fixed":
                     requested_date = order.date_scheduled or today
                 else:

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -196,3 +196,82 @@ class TestPaymentOrderOutbound(TransactionCase):
         )
         with self.assertRaises(ValidationError):
             outbound_order.date_scheduled = date.today() - timedelta(days=1)
+
+
+def test_manual_line_and_manual_date(self):
+    # Create payment order
+    outbound_order = self.env["account.payment.order"].create(
+        {
+            "date_prefered": "due",
+            "payment_type": "outbound",
+            "payment_mode_id": self.mode.id,
+            "journal_id": self.journal.id,
+            "description": "order with manual line",
+        }
+    )
+    self.assertEqual(len(outbound_order.payment_line_ids), 0)
+    # Create a manual payment order line with custom date
+    vals = {
+        "order_id": outbound_order.id,
+        "partner_id": self.env.ref("base.res_partner_4").id,
+        "partner_bank_id": self.env.ref("base.res_partner_4").bank_ids[0].id,
+        "communication": "manual line and manual date",
+        "currency_id": outbound_order.payment_mode_id.company_id.currency_id.id,
+        "amount_currency": 192.38,
+        "date": date.today() + timedelta(days=8),
+    }
+    self.env["account.payment.line"].create(vals)
+
+    self.assertEqual(len(outbound_order.payment_line_ids), 1)
+    self.assertEqual(
+        outbound_order.payment_line_ids[0].date, date.today() + timedelta(days=8)
+    )
+
+    # Create a manual payment order line with normal date
+    vals = {
+        "order_id": outbound_order.id,
+        "partner_id": self.env.ref("base.res_partner_4").id,
+        "partner_bank_id": self.env.ref("base.res_partner_4").bank_ids[0].id,
+        "communication": "manual line",
+        "currency_id": outbound_order.payment_mode_id.company_id.currency_id.id,
+        "amount_currency": 200.38,
+    }
+    self.env["account.payment.line"].create(vals)
+
+    self.assertEqual(len(outbound_order.payment_line_ids), 2)
+    self.assertEqual(outbound_order.payment_line_ids[1].date, False)
+
+    # Open payment order
+    self.assertEqual(len(outbound_order.bank_line_ids), 0)
+    outbound_order.draft2open()
+    self.assertEqual(outbound_order.bank_line_count, 2)
+    self.assertEqual(
+        outbound_order.payment_line_ids[0].date,
+        outbound_order.payment_line_ids[0].bank_line_id.date,
+    )
+    self.assertEqual(outbound_order.payment_line_ids[1].date, date.today())
+    self.assertEqual(outbound_order.payment_line_ids[1].bank_line_id.date, date.today())
+    # Generate and upload
+    outbound_order.open2generated()
+    outbound_order.generated2uploaded()
+
+    self.assertEqual(outbound_order.state, "uploaded")
+    with self.assertRaises(UserError):
+        outbound_order.unlink()
+
+    bank_line = outbound_order.bank_line_ids
+
+    with self.assertRaises(UserError):
+        bank_line.unlink()
+    outbound_order.action_done_cancel()
+    self.assertEqual(outbound_order.state, "cancel")
+    outbound_order.cancel2draft()
+    outbound_order.unlink()
+    self.assertEqual(
+        len(
+            self.env["account.payment.order"].search(
+                [("description", "=", "order with manual line")]
+            )
+        ),
+        0,
+    )


### PR DESCRIPTION
A payment date can be added when a transaction line is introduced manually and it doesn't have a due date.
This imp has already been applied to v13 module (https://github.com/OCA/bank-payment/pull/801)