### PR TITLE
[9.0][FIX] account_payment_order: do not mangle states in migration

### DIFF
--- a/account_payment_order/migrations/9.0.1.0.0/post-migration.py
+++ b/account_payment_order/migrations/9.0.1.0.0/post-migration.py
@@ -17,7 +17,7 @@ def map_payment_type(cr):
     openupgrade.map_values(
         cr,
         openupgrade.get_legacy_name('state'), 'state',
-        [('done', 'uploaded'), ('sent', 'generated')],
+        [('sent', 'uploaded')],
         table='account_payment_order', write='sql')
     # Populate these missing related fields
     openupgrade.logged_query(

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -49,6 +49,7 @@ class AccountPaymentOrder(models.Model):
         ('open', 'Confirmed'),
         ('generated', 'File Generated'),
         ('uploaded', 'File Uploaded'),
+        ('done', 'Done'),
         ('cancel', 'Cancel'),
         ], string='Status', readonly=True, copy=False, default='draft',
         track_visibility='onchange')


### PR DESCRIPTION
After a conversion from 7.0 to 12.0 of a customer we noticed that all the done payment orders had reverted to uploaded and all sent payment orders to generated.

In 9.0 for some reason the done state is missing, even though there is an button Done that sets the state to the non-existing done state,

This PR intends to rectify this problem.