### PR TITLE
[FIX] Add partner_bank_id validation in AccountMoveLine

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -26,7 +26,8 @@ class AccountMoveLine(models.Model):
     )
 
     @api.onchange('partner_id')
-    def empty_partner_bank(self):
+    def _onchange_partner_id(self):
+        """Empty partner bank for avoiding inconsistencies."""
         self.partner_bank_id = None
 
     @api.multi

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -25,6 +25,10 @@ class AccountMoveLine(models.Model):
         string="Payment lines",
     )
 
+    @api.onchange('partner_id')
+    def empty_partner_bank(self):
+        self.partner_bank_id = None
+
     @api.multi
     def _prepare_payment_line_vals(self, payment_order):
         self.ensure_one()


### PR DESCRIPTION
We found a validation mistake when we are creating AccountMove to generate the payment order. Steps to reproduce the problem:

1. Create a AccountMove with one AccountMoveLine
2. Save the AccountMove
3. Access to the AccountMoveLine tree view with the smart button `Reconcilied Entries`
4. Open the AccountMoveLine
5. Edit the AccountMoveLine adding a Bank Account (this field only show the bank accounts related with the `partner_id`) and save
6. Edit the AccountMoveLine and change the Partner. Save.

This process allow us to create AccountMoveLines with a `partner_id` and a `partner_bank_id` related to another partner. Is a hack to pass the partner_bank_id domain.

With this validation, we maintain the logic of the domain and avoid this hack.