### PR TITLE
[13.0][FIX] account_payment_partner: _compute_invoice_partner_bank isn't executed

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -79,6 +79,15 @@ class AccountMove(models.Model):
                             partner.supplier_payment_mode_id.refund_payment_mode_id
                         )
 
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        """Force compute because the onchange chain doesn't call
+        ``_compute_invoice_partner_bank``.
+        """
+        res = super()._onchange_partner_id()
+        self._compute_invoice_partner_bank()
+        return res
+
     @api.depends("partner_id", "payment_mode_id")
     def _compute_invoice_partner_bank(self):
         for move in self:

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -172,7 +172,7 @@ class TestAccountPaymentPartner(SavepointCase):
         cls.journal_bank = cls.env["res.partner.bank"].create(
             {
                 "acc_number": "GB95LOYD87430237296288",
-                "partner_id": cls.env.user.company_id.id,
+                "partner_id": cls.env.user.company_id.partner_id.id,
             }
         )
         cls.journal = cls.env["account.journal"].create(
@@ -228,6 +228,16 @@ class TestAccountPaymentPartner(SavepointCase):
             ).customer_payment_mode_id,
             self.payment_mode_model,
         )
+
+    def test_partner_id_changes_compute_invoice_partner_bank(self):
+        # Test _compute_invoice_partner_bank is executed when partner_id changes
+        move_form = Form(
+            self.env["account.move"].with_context(default_type="out_invoice")
+        )
+        self.assertFalse(move_form.invoice_partner_bank_id)
+        move_form.partner_id = self.customer
+        self.assertEquals(move_form.payment_mode_id, self.customer_payment_mode)
+        self.assertFalse(move_form.invoice_partner_bank_id)
 
     def test_out_invoice_onchange(self):
         # Test the onchange methods in invoice


### PR DESCRIPTION
when partner_id changes.

Odoo sets normal M2O invoice_partner_bank_id field
https://github.com/odoo/odoo/blob/a8d3f466dfffca08214acecf08ec298e3ace6272/addons/account/models/account_move.py#L218-L220
On this onchanges:
https://github.com/odoo/odoo/blob/a8d3f466dfffca08214acecf08ec298e3ace6272/addons/account/models/account_move.py#L364
https://github.com/odoo/odoo/blob/c1e8b5ac2ef4df5851147109a510bb317a747914/addons/purchase/models/account_invoice.py#L77

The account_payment_partner module changes the field
https://github.com/OCA/bank-payment/blob/32b6b88dfdb957e87635faf44f8e8634029382e2/account_payment_partner/models/account_move.py#L29-L34
And adds this method:
https://github.com/OCA/bank-payment/blob/32b6b88dfdb957e87635faf44f8e8634029382e2/account_payment_partner/models/account_move.py#L93-L104

It is computed fine when payment_mode_id changes, but it is not executed when partner_id changes, although it is correctly defined in the depends:
https://github.com/OCA/bank-payment/blob/32b6b88dfdb957e87635faf44f8e8634029382e2/account_payment_partner/models/account_move.py#L82

As the value is set by the onchange, the ORM does not recompute the field (which is optimal in most cases).
After studying several ways, the simplest and most self-explanatory thing is to call the compute method

@Tecnativa TT30875