### PR TITLE
[13.0][FIX] account_payment_partner: _compute_invoice_partner_bank isn't executed

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -151,3 +151,11 @@ class AccountMove(models.Model):
             )
         # Return this as empty recordset
         return self.invoice_partner_bank_id
+
+    @api.model
+    def create(self, vals):
+        """ Force compute invoice_partner_bank_id when invoice is created from SO
+         to avoid that odoo _prepare_invoice method value will be set"""
+        if self.env.context.get("active_model") == "sale.order":  # pragma: no cover
+            vals.pop("invoice_partner_bank_id", False)
+        return super().create(vals)


### PR DESCRIPTION
when value is set from SO _prepare_invoice method.

This core method set invoice_partner_bank value, so the field is not computed:
https://github.com/odoo/odoo/blob/485c7453316d268029d8b8251e62b35ce74e37b4/addons/sale/models/sale.py#L566

@Tecnativa TT30875

Similar to https://github.com/OCA/bank-payment/pull/832