### PR TITLE
[14.0][FIX] - account_banking_mandate: Fix migration script

### DIFF
--- a/account_banking_mandate/migrations/14.0.1.0.0/post-migrate.py
+++ b/account_banking_mandate/migrations/14.0.1.0.0/post-migrate.py
@@ -26,5 +26,6 @@ def migrate(cr, version):
         FROM account_move_line aml
         WHERE aml.mandate_id IS NOT NULL
             AND am.mandate_id IS NULL
+            AND am.id=aml.move_id
         """
     )


### PR DESCRIPTION
the migration query is missing a where close for account_move and account_move_line join