### PR TITLE
[13.0][FIX]bank_payment: fix warning of _company_default_get

### DIFF
--- a/account_banking_mandate/models/res_partner.py
+++ b/account_banking_mandate/models/res_partner.py
@@ -34,9 +34,7 @@ class ResPartner(models.Model):
         if company_id:
             company = self.env["res.company"].browse(company_id)
         else:
-            company = self.env["res.company"]._company_default_get(
-                "account.banking.mandate"
-            )
+            company = self.env.company
 
         mandates_dic = {}
         for partner in self:


### PR DESCRIPTION
FIX the warning "The method '_company_default_get' on res.company is deprecated and shouldn't be used anymore" in version 13.
This function is used for getting the company id in computing the banking mandate id in OCA module "bank_payment/account_banking_mandate".
So the correction deployed in my commit consists of replacing this function by "self.env.company" because it's not used anymore.
(Update the site packages is necessary)   