### PR TITLE
[13.0][FIX] account_payment_partner: pass invoice_partner_bank_id correctly on account move create

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -159,5 +159,5 @@ class AccountMove(models.Model):
         if self.env.context.get("active_model") == "sale.order":  # pragma: no cover
             virtual_move = self.new(vals)
             virtual_move._compute_invoice_partner_bank()
-            vals["invoice_partner_bank_id"] = virtual_move.invoice_partner_bank_id
+            vals["invoice_partner_bank_id"] = virtual_move.invoice_partner_bank_id.id
         return super().create(vals)


### PR DESCRIPTION
We need to pass the ID to the creation values to prevent the following error:

> psycopg2.ProgrammingError: can't adapt type 'res.partner.bank'

cc @pedrobaeza @carlosdauden 