### PR TITLE
[FIX] account_payment_partner: Not assign bank.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ addon | version | summary
 [account_payment_mode](account_payment_mode/) | 13.0.1.2.0 | Account Payment Mode
 [account_payment_order](account_payment_order/) | 13.0.1.4.6 | Account Payment Order
 [account_payment_order_return](account_payment_order_return/) | 13.0.1.0.2 | Account Payment Order Return
-[account_payment_partner](account_payment_partner/) | 13.0.1.1.3 | Adds payment mode on partners and invoices
+[account_payment_partner](account_payment_partner/) | 13.0.1.1.4 | Adds payment mode on partners and invoices
 [account_payment_purchase](account_payment_purchase/) | 13.0.1.0.2 | Adds Bank Account and Payment Mode on Purchase Orders
 [account_payment_purchase_stock](account_payment_purchase_stock/) | 13.0.1.0.1 | Integrate Account Payment Purchase with Stock
 [account_payment_sale](account_payment_sale/) | 13.0.1.1.3 | Adds payment mode on sale orders

--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Account Payment Partner",
-    "version": "13.0.1.1.3",
+    "version": "13.0.1.1.4",
     "category": "Banking addons",
     "license": "AGPL-3",
     "summary": "Adds payment mode on partners and invoices",

--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -110,7 +110,8 @@ class AccountMove(models.Model):
                         and move.commercial_partner_id.bank_ids
                     ):
                         bank_id = get_bank_id()
-            move.invoice_partner_bank_id = bank_id
+            if bank_id:
+                move.invoice_partner_bank_id = bank_id
 
     def _reverse_move_vals(self, default_values, cancel=True):
         move_vals = super()._reverse_move_vals(default_values, cancel=cancel)


### PR DESCRIPTION
When a bank is not found, it should not be assigned, so as not to change the value that the field brings.