### PR TITLE
[13.0][FIX] account_payment_partner: Error when salesperson tries to print invoices

### DIFF
--- a/account_payment_partner/views/report_invoice.xml
+++ b/account_payment_partner/views/report_invoice.xml
@@ -10,7 +10,7 @@
                 <span t-field="o.payment_mode_id.note" />
             </p>
             <t t-if="o.payment_mode_id and o.payment_mode_id.show_bank_account != 'no'">
-                <p t-foreach="o.partner_banks_to_show()" t-as="partner_bank">
+                <p t-foreach="o.sudo().partner_banks_to_show()" t-as="partner_bank">
                     <strong>Bank Account:</strong>
                     <t t-if="partner_bank.bank_id">
                         <t


### PR DESCRIPTION
This error is happening because the salesperson has not access to payment_method_id.

With this changes we avoid the error and the invoices are printed like normally.

cc @Tecnativa TT31296

ping @carlosdauden @pedrobaeza 