### PR TITLE
[14.0][FIX] account_payment_partner - Only update partner bank if not set

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "move_type")
     def _compute_partner_bank_filter_type_domain(self):
-        for move in self:
+        for move in self.filtered(lambda m: not m.partner_bank_id):
             if move.move_type in ("out_invoice", "in_refund"):
                 move.partner_bank_filter_type_domain = move.bank_partner_id
             elif move.move_type in ("in_invoice", "out_refund"):

--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "move_type")
     def _compute_partner_bank_filter_type_domain(self):
-        for move in self.filtered(lambda m: not m.partner_bank_id):
+        for move in self:
             if move.move_type in ("out_invoice", "in_refund"):
                 move.partner_bank_filter_type_domain = move.bank_partner_id
             elif move.move_type in ("in_invoice", "out_refund"):
@@ -91,7 +91,7 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "payment_mode_id")
     def _compute_partner_bank(self):
-        for move in self:
+        for move in self.filtered(lambda m: not m.partner_bank_id):
             # No bank account assignation is done for out_invoice as this is only
             # needed for printing purposes and it can conflict with
             # SEPA direct debit payments. Current report prints it.


### PR DESCRIPTION
In some cases partner_bank_id might be set already, i.e. UBL or other imports.

In addition when no payment mode is set this method will remove the bank account, since payment mode is not mandatory this makes no sense to me.

@pedrobaeza 