### PR TITLE
[13.0][FIX] account_payment_partner: Set the correct value of payment_mode_id instead of False

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -56,7 +56,9 @@ class AccountMove(models.Model):
     @api.depends("partner_id", "company_id")
     def _compute_payment_mode(self):
         for move in self:
-            move.payment_mode_id = False
+            move.payment_mode_id = move.payment_mode_id
+            if move.company_id and move.payment_mode_id.company_id != move.company_id:
+                move.payment_mode_id = False
             if move.partner_id:
                 partner = move.with_context(force_company=move.company_id.id).partner_id
                 if move.type == "in_invoice":

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -282,7 +282,7 @@ class TestAccountPaymentPartner(SavepointCase):
         self.assertFalse(invoice.invoice_partner_bank_id)
 
         invoice.partner_id = False
-        self.assertEquals(invoice.payment_mode_id, self.payment_mode_model)
+        self.assertEquals(invoice.payment_mode_id, self.supplier_payment_mode_c2)
         self.assertEquals(invoice.invoice_partner_bank_id, self.partner_bank_model)
 
     def test_invoice_create_in_invoice(self):
@@ -549,3 +549,19 @@ class TestAccountPaymentPartner(SavepointCase):
         self.assertEqual(
             out_invoice.partner_bank_filter_type_domain, out_invoice.bank_partner_id
         )
+
+    def test_account_move_payment_mode_id_default(self):
+        payment_mode = self.env.ref("account_payment_mode.payment_mode_inbound_dd1")
+        field = self.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", self.move_model._name),
+                ("name", "=", "payment_mode_id"),
+            ]
+        )
+        move_form = Form(self.move_model.with_context(default_type="out_invoice"))
+        self.assertFalse(move_form.payment_mode_id)
+        self.env["ir.default"].create(
+            {"field_id": field.id, "json_value": payment_mode.id}
+        )
+        move_form = Form(self.move_model.with_context(default_type="out_invoice"))
+        self.assertEqual(move_form.payment_mode_id, payment_mode)


### PR DESCRIPTION
Set the correct value of payment_mode_id instead of False.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT31904