### PR TITLE
[12.0][IMP] account_payment_order: show total on account.move.line tree

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -114,8 +114,9 @@ class AccountMoveLine(models.Model):
                     elem = etree.Element(
                         'field', {
                             'name': 'balance',
-                            'readonly': 'True'
-                        })
+                            'readonly': 'True',
+                            'sum': 'Total Balance',
+                    })
                     orm.setup_modifiers(elem)
                     placeholder.addprevious(elem)
             if not doc.xpath("//field[@name='amount_residual_currency']"):
@@ -124,7 +125,8 @@ class AccountMoveLine(models.Model):
                     elem = etree.Element(
                         'field', {
                             'name': 'amount_residual_currency',
-                            'readonly': 'True'
+                            'readonly': 'True',
+                            'sum': 'Total Residual Amount in Currency',
                         })
                     orm.setup_modifiers(elem)
                     placeholder.addnext(elem)
@@ -134,7 +136,8 @@ class AccountMoveLine(models.Model):
                     elem = etree.Element(
                         'field', {
                             'name': 'amount_residual',
-                            'readonly': 'True'
+                            'readonly': 'True',
+                            'sum': 'Total Residual Amount',
                         })
                     orm.setup_modifiers(elem)
                     placeholder.addnext(elem)

--- a/account_payment_order/wizard/__init__.py
+++ b/account_payment_order/wizard/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import account_payment_line_create
 from . import account_invoice_payment_line_multi

--- a/account_payment_order/wizard/account_invoice_payment_line_multi.py
+++ b/account_payment_order/wizard/account_invoice_payment_line_multi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2016 Akretion (<https://www.akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2009 EduSense BV (<http://www.edusense.nl>)
 # © 2011-2013 Therp BV (<https://therp.nl>)
 # © 2014-2015 ACSONE SA/NV (<https://acsone.eu>)


### PR DESCRIPTION
Shows total to the fields balance, amount_residual, amount_residual_currency columns in account.move.line tree view.

Before:
![account-move-line-before](https://user-images.githubusercontent.com/3082119/135997326-10d4b9ff-e52d-4065-9b11-9d2bfd2a7b06.png)

After:
![account-move-line-after](https://user-images.githubusercontent.com/3082119/135996493-389cf962-ab22-4b5b-838e-e41fee3486f4.png)

By the way, I guess there is a reason why this view is updated in the `fields_view_get` function rather than in an xml view but I don't understand it. Can someone explain ?