### PR TITLE
[IMP] account_payment_order: Set orders to done on payment reconciliation

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -199,7 +199,7 @@ class TestSCT(common.HttpCase):
             debtor_acc_xpath[0].text,
             self.payment_order.company_partner_bank_id.sanitized_acc_number)
         self.payment_order.generated2uploaded()
-        self.assertEqual(self.payment_order.state, 'uploaded')
+        self.assertEqual(self.payment_order.state, 'done')
         for inv in [invoice1, invoice2, invoice3, invoice4, invoice5]:
             self.assertEqual(inv.state, 'paid')
         return
@@ -276,7 +276,7 @@ class TestSCT(common.HttpCase):
             debtor_acc_xpath[0].text,
             self.payment_order.company_partner_bank_id.sanitized_acc_number)
         self.payment_order.generated2uploaded()
-        self.assertEqual(self.payment_order.state, 'uploaded')
+        self.assertEqual(self.payment_order.state, 'done')
         for inv in [invoice1, invoice2]:
             self.assertEqual(inv.state, 'paid')
         return

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -209,7 +209,7 @@ class TestSDD(common.HttpCase):
             debtor_acc_xpath[0].text,
             payment_order.company_partner_bank_id.sanitized_acc_number)
         payment_order.generated2uploaded()
-        self.assertEqual(payment_order.state, 'uploaded')
+        self.assertEqual(payment_order.state, 'done')
         for inv in [invoice1, invoice2]:
             self.assertEqual(inv.state, 'paid')
         self.assertEqual(self.mandate2.recurrent_sequence_type, 'recurring')

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Account Payment Order',
-    'version': '12.0.1.6.3',
+    'version': '12.0.2.0.0',
     'license': 'AGPL-3',
     'author': "ACSONE SA/NV, "
               "Therp BV, "

--- a/account_payment_order/migrations/12.0.2.0.0/post-migration.py
+++ b/account_payment_order/migrations/12.0.2.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    for order in env['account.payment.order'].search([
+            ('state', '=', 'uploaded'),
+    ]):
+        if order._all_lines_reconciled():
+            order.action_done()

--- a/account_payment_order/models/bank_payment_line.py
+++ b/account_payment_order/models/bank_payment_line.py
@@ -163,7 +163,7 @@ class BankPaymentLine(models.Model):
     def unlink(self):
         for line in self:
             order_state = line.order_id.state
-            if order_state == 'uploaded':
+            if order_state in ('uploaded', 'done'):
                 raise UserError(_(
                     'Cannot delete a payment order line whose payment order is'
                     ' in state \'%s\'. You need to cancel it first.')

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -109,7 +109,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment_order.open2generated()
         payment_order.generated2uploaded()
 
-        self.assertEqual(payment_order.state, 'uploaded')
+        self.assertEqual(payment_order.state, 'done')
         with self.assertRaises(UserError):
             payment_order.unlink()
 

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -21,8 +21,11 @@
                     string="Back to Draft" />
                 <button name="action_cancel" type="object" states="draft,open,generated"
                     string="Cancel Payments"/>
-                <button name="action_done_cancel" type="object" states="uploaded"
+                <button name="action_done_cancel" type="object" states="uploaded,done"
                     string="Cancel Payments"/>
+                <button name="action_done" type="object" states="uploaded"
+                    string="Set Done"
+                    />
                 <field name="state" widget="statusbar"/>
             </header>
             <sheet>


### PR DESCRIPTION
@luc-demeyer @pedrobaeza this is the close orders on reconciliation PR. But I don't really get what you mean in point 2 of https://github.com/OCA/bank-payment/pull/784#issuecomment-896785175 - isn't this in terms of reconciliation the same, just with a different account?

When all is ironed out here, this should be very simple to port to 13 and 14