### PR TITLE
[9.0][OU-FIX] account_payment_mode: Rename xmlids

### DIFF
--- a/account_payment_mode/hooks.py
+++ b/account_payment_mode/hooks.py
@@ -7,6 +7,14 @@ def pre_init_hook(cr):
     migrate_from_8(cr)
 
 
+xmlid_renames = [
+    (
+        "account_payment_order.payment_mode_comp_rule",
+        "account_payment_mode.account_payment_mode_company_rule",
+    )
+]
+
+
 def migrate_from_8(cr):
     """If we're installed on a database which has the payment_mode table
     from 8.0, move its table so that we use the already existing modes"""
@@ -14,9 +22,12 @@ def migrate_from_8(cr):
     if not cr.fetchone():
         return
     try:
-        from openupgradelib.openupgrade import rename_models, rename_tables
+        from openupgradelib.openupgrade import (
+            rename_models, rename_tables, rename_xmlids
+        )
         rename_models(cr, [('payment.mode', 'account.payment.mode')])
         rename_tables(cr, [('payment_mode', 'account_payment_mode')])
+        rename_xmlids(cr, xmlid_renames)
     except ImportError:
         cr.execute('ALTER TABLE payment_mode RENAME TO account_payment_mode')
         cr.execute('ALTER SEQUENCE payment_mode_id_seq '

--- a/account_payment_mode/migrations/9.0.1.0.0/noupdate_changes.xml
+++ b/account_payment_mode/migrations/9.0.1.0.0/noupdate_changes.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="account_payment_mode_company_rule" model="ir.rule">
+        <field name="name">Payment mode multi-company rule</field>
+        <field name="model_id" ref="model_account_payment_mode"/>
+    </record>
+</odoo>

--- a/account_payment_mode/migrations/9.0.1.0.0/post-migration.py
+++ b/account_payment_mode/migrations/9.0.1.0.0/post-migration.py
@@ -22,3 +22,6 @@ def migrate(env, version):
         FROM account_payment_method pm WHERE apm.payment_method_id = pm.id
         WHERE payment_type IS NULL;
         """)
+    openupgrade.load_data(
+        env.cr, "account_payment_mode", "migrations/9.0.1.0.0/noupdate_changes.xml"
+    )


### PR DESCRIPTION
According to the renaming of the addon `account_payment` from odoo to `account_payment_order` (since https://github.com/OCA/OpenUpgrade/pull/656), the rule "payment_mode_comp_rule" (of `account_payment`) must be renamed and linked to the addon `account_payment_mode` to avoid creating a new rule.

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT33065