### PR TITLE
[14.0][FIX] account_banking_sepa_direct_debit: Post mandate expiration message by mandate register

### DIFF
--- a/account_banking_sepa_direct_debit/models/account_banking_mandate.py
+++ b/account_banking_sepa_direct_debit/models/account_banking_mandate.py
@@ -102,16 +102,14 @@ class AccountBankingMandate(models.Model):
         )
         if expired_mandates:
             expired_mandates.write({"state": "expired"})
-            expired_mandates.message_post(
-                body=_(
-                    "Mandate automatically set to expired after %d months without use."
+            for mandate in expired_mandates:
+                mandate.message_post(
+                    body=_(
+                        "Mandate automatically set to expired after %d months without use."
+                    )
+                    % NUMBER_OF_UNUSED_MONTHS_BEFORE_EXPIRY
                 )
-                % NUMBER_OF_UNUSED_MONTHS_BEFORE_EXPIRY
-            )
-            logger.info(
-                "%d SDD Mandate set to expired: IDs %s"
-                % (len(expired_mandates), expired_mandates.ids)
-            )
+                logger.info("SDD Mandate set to expired: ID %s" % (mandate.id))
         else:
             logger.info("0 SDD Mandates had to be set to Expired")
 


### PR DESCRIPTION
When multiple mandates are set to `expired` state, it's currently calling `message_post` function, which is supposed to be called from a single register (`ensure_one`).

I created a loop so that `message_post` is called for each mandate that has been expired.

@CarlosRoca13 @alexis-via what do you think?