### PR TITLE
[13.0][FIX] account_banking_sepa_direct_debit: Bank Account should not be required

### DIFF
--- a/account_banking_sepa_credit_transfer/data/account_payment_method.xml
+++ b/account_banking_sepa_credit_transfer/data/account_payment_method.xml
@@ -4,7 +4,7 @@
         <field name="name">SEPA Credit Transfer to suppliers</field>
         <field name="code">sepa_credit_transfer</field>
         <field name="payment_type">outbound</field>
-        <field name="bank_account_required" eval="True" />
+        <field name="bank_account_required" eval="False" />
         <field name="pain_version">pain.001.001.03</field>
     </record>
 </odoo>

--- a/account_banking_sepa_direct_debit/data/account_payment_method.xml
+++ b/account_banking_sepa_direct_debit/data/account_payment_method.xml
@@ -4,8 +4,8 @@
         <field name="name">SEPA Direct Debit for customers</field>
         <field name="code">sepa_direct_debit</field>
         <field name="payment_type">inbound</field>
-        <field name="bank_account_required" eval="True" />
-        <field name="mandate_required" eval="True" />
+        <field name="bank_account_required" eval="False" />
+        <field name="mandate_required" eval="False" />
         <field name="pain_version">pain.008.001.02</field>
     </record>
 </odoo>


### PR DESCRIPTION
The bank account is taken from the mandate. `invoice_partner_bank_id` is never used in this module, so it should not be taken as required.