### PR TITLE
[14.0][IMP] account_payment_partner: setting to force blank partner bank

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["account_payment_mode"],
     "data": [
         "views/res_partner_view.xml",
+        "views/res_config_settings.xml",
         "views/account_move_view.xml",
         "views/account_move_line.xml",
         "views/account_payment_mode.xml",

--- a/account_payment_partner/models/__init__.py
+++ b/account_payment_partner/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move, account_move_line, account_payment_mode, res_partner
+from . import res_config_settings, res_company

--- a/account_payment_partner/models/res_company.py
+++ b/account_payment_partner/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2022 - CampToCamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    force_blank_partner_bank_id = fields.Boolean(
+        string="Force blank partner bank",
+        default=True,
+        help="No bank account assignation is done for out_invoice as this is only"
+        " needed for printing purposes and it can conflict with"
+        " SEPA direct debit payments. Current report prints it.",
+    )

--- a/account_payment_partner/models/res_config_settings.py
+++ b/account_payment_partner/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2022 - CampToCamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    force_blank_partner_bank_id = fields.Boolean(
+        related="company_id.force_blank_partner_bank_id",
+        readonly=False,
+    )

--- a/account_payment_partner/views/res_config_settings.xml
+++ b/account_payment_partner/views/res_config_settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_config_settings" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='module_account_sepa_direct_debit']/../.."
+                position="after"
+            >
+                <div
+                    class="col-xs-12 col-md-6 o_setting_box"
+                    id="force_blank_partner_bank_id"
+                    title="Force blank partner bank on invoices."
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="force_blank_partner_bank_id" class="oe_inline" />
+                    </div>
+                    <div
+                        class="o_setting_right_pane"
+                        name="force_blank_parner_bank_id_right_pane"
+                    >
+                        <label
+                            string="Force blank partner bank"
+                            for="force_blank_partner_bank_id"
+                        />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                            role="img"
+                        />
+                        <div class="text-muted">
+                            Force blank partner bank on invoices.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The l10n-switzerland/l10n_ch_isr_payment_grouping module uses partner
bank to work. This is quick fix while waiting module owners, who has
more business knowledge to resolve conflict.