### PR TITLE
[FIX] [14.0] Removed external dependencies already defined in Odoo base

### DIFF
--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -11,7 +11,6 @@
     "website": "https://github.com/OCA/bank-payment",
     "category": "Banking addons",
     "depends": ["account_banking_pain_base", "account_banking_mandate"],
-    "external_dependencies": {"python": ["stdnum"]},
     "data": [
         "views/account_banking_mandate_view.xml",
         "views/res_config_settings.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
 lxml
-python-stdnum
 unidecode


### PR DESCRIPTION
Removed external dependencies already defined in Odoo base

https://github.com/odoo/odoo/blob/ae6f414ba41eee4e14235a1e82fd5ebd237dd97f/requirements.txt#L48

MT-282 @moduon