### PR TITLE
[13.0][FIX] account_payment_partner: only use bank_account_required in bills

### DIFF
--- a/account_payment_partner/views/account_move_view.xml
+++ b/account_payment_partner/views/account_move_view.xml
@@ -45,7 +45,8 @@
                     '|',('company_id', '=', company_id),('company_id', '=', False)]</attribute>
                 <attribute
                     name="attrs"
-                >{'required': [('bank_account_required', '=', True)], 'readonly': [('state', '!=', 'draft')]}</attribute>
+                >{'required': [('bank_account_required', '=', True),('type', 'in', ('in_invoice', 'in_refund'))],
+                    'readonly': [('state', '!=', 'draft')], 'invisible': [('type', '=', 'entry')]}</attribute>
                 <attribute
                     name="context"
                 >{'default_partner_id':commercial_partner_id}</attribute>


### PR DESCRIPTION
Backport of https://github.com/OCA/bank-payment/pull/905.