### PR TITLE
[15.0][FIX] account_payment_partner: only use bank_account_required in bills

### DIFF
--- a/account_payment_partner/views/account_move_view.xml
+++ b/account_payment_partner/views/account_move_view.xml
@@ -40,8 +40,9 @@
                     '|',('company_id', '=', company_id),('company_id', '=', False)]
                 </attribute>
                 <attribute name="attrs">
-                    {'required': [('bank_account_required', '=', True)], 'readonly':
-                    [('state', '!=', 'draft')]}
+                    {'required': [('bank_account_required', '=', True),('move_type', 'in', ('in_invoice', 'in_refund'))],
+                    'readonly': [('state', '!=', 'draft')],
+                    'invisible': [('move_type', '=', 'entry')]}
                 </attribute>
                 <attribute name="context">
                     {'default_partner_id':commercial_partner_id}


### PR DESCRIPTION
Forward port of https://github.com/OCA/bank-payment/pull/905.