### PR TITLE
[13.0][FIX] account_banking_mandate: only use mandate_required in invoices

### DIFF
--- a/account_banking_mandate/views/account_move_view.xml
+++ b/account_banking_mandate/views/account_move_view.xml
@@ -13,7 +13,8 @@
                 <field
                     name="mandate_id"
                     domain="[('partner_id', '=', commercial_partner_id), ('state', '=', 'valid')]"
-                    attrs="{'required': [('mandate_required', '=', True)], 'invisible': [('mandate_required', '=', False)]}"
+                    attrs="{'required': [('mandate_required', '=', True),('type', 'in', ('out_invoice', 'out_refund'))],
+                    'invisible': ['|', ('mandate_required', '=', False),('type', 'not in', ('out_invoice', 'out_refund'))]}"
                 />
                 <field name="mandate_required" invisible="1" />
             </field>


### PR DESCRIPTION
Backport of https://github.com/OCA/bank-payment/pull/908.