### PR TITLE
[ENH][14.0] bank-payment Fallback to payment_ref if ref is undefined

### DIFF
--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -101,7 +101,9 @@
                                 <t
                                     t-if="line.move_line_id.move_id and 'in_' in line.move_line_id.move_id.move_type"
                                 >
-                                    <span t-field="line.move_line_id.move_id.ref" />
+                                    <span
+                                        t-esc="line.move_line_id.move_id.ref or line.move_line_id.move_id.payment_reference"
+                                    />
                                 </t>
                                 <t t-else="">
                                     <span t-esc="line.move_line_id.move_id.name" />


### PR DESCRIPTION
The payment order report in PDF format has a field "Invoice Ref", which user the move.ref. In my use case, the move.ref is always blank for a vendor bill, as I prefer not duplicating information in the vendor bill import. This pull request uses the payment_reference if the ref field is absent. A case might even be made to prefer the payment_reference over the ref if both are available but that might cause regressions.

Current report:
```
Partner                        Bank account        Invoice Ref             Value Date      Amount   Currency
Deco Addict                    NL01BANK012345                              2022-03-17      100.00   100.00
```

Desired report:
```
Partner                        Bank account        Invoice Ref             Value Date      Amount   Currency
Deco Addict                    NL01BANK012345      X/220002                2022-03-17      100.00   100.00
```