### PR TITLE
[14.0] account_payment_order: Better communication field management

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -67,15 +67,17 @@ class AccountMoveLine(models.Model):
                     self.move_id.move_type in ("in_invoice", "in_refund")
                     and self.move_id.ref
                 ):
-                    communication = self.move_id.ref
+                    communication = self.move_id.payment_reference or self.move_id.ref
                 elif "out" in self.move_id.move_type:
                     # Force to only put invoice number here
-                    communication = self.move_id.name
+                    communication = self.move_id.payment_reference or self.move_id.name
                 # If we have credit note(s) - reversal_move_id is a one2many
                 if self.move_id.reversal_move_id:
-                    references = self.move_id.reversal_move_id.filtered(
-                        lambda r: r.ref
-                    ).mapped("ref")
+                    references = [
+                        move.payment_reference or move.ref
+                        for move in self.move_id.reversal_move_id
+                        if move.payment_reference or move.ref
+                    ]
                     communication += " " + " ".join(references)
         return communication_type, communication
 

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -81,7 +81,6 @@ class AccountMoveLine(models.Model):
 
     def _prepare_payment_line_vals(self, payment_order):
         self.ensure_one()
-        assert payment_order, "Missing payment order"
         communication_type, communication = self._get_communication()
         if self.currency_id:
             currency_id = self.currency_id.id

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -71,6 +71,12 @@ class AccountMoveLine(models.Model):
                 elif "out" in self.move_id.move_type:
                     # Force to only put invoice number here
                     communication = self.move_id.name
+                # If we have credit note(s) - reversal_move_id is a one2many
+                if self.move_id.reversal_move_id:
+                    references = self.move_id.reversal_move_id.filtered(
+                        lambda r: r.ref
+                    ).mapped("ref")
+                    communication += " " + " ".join(references)
         return communication_type, communication
 
     def _prepare_payment_line_vals(self, payment_order):

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -48,9 +48,10 @@ class AccountMoveLine(models.Model):
             else:
                 ml.partner_bank_id = ml.partner_bank_id
 
-    def _prepare_payment_line_vals(self, payment_order):
-        self.ensure_one()
-        assert payment_order, "Missing payment order"
+    def _get_communication(self):
+        """
+        Retrieve the communication string for the payment order
+        """
         aplo = self.env["account.payment.line"]
         # default values for communication_type and communication
         communication_type = "normal"
@@ -70,6 +71,12 @@ class AccountMoveLine(models.Model):
                 elif "out" in self.move_id.move_type:
                     # Force to only put invoice number here
                     communication = self.move_id.name
+        return communication_type, communication
+
+    def _prepare_payment_line_vals(self, payment_order):
+        self.ensure_one()
+        assert payment_order, "Missing payment order"
+        communication_type, communication = self._get_communication()
         if self.currency_id:
             currency_id = self.currency_id.id
             amount_currency = self.amount_residual_currency

--- a/account_payment_order/readme/CONTRIBUTORS.rst
+++ b/account_payment_order/readme/CONTRIBUTORS.rst
@@ -11,6 +11,8 @@
 * Angel Moya <angel.moya@domatix.com>
 * Jose María Alzaga <jose.alzaga@aselcis.com>
 * Meyomesse Gilles <meyomesse.gilles@gmail.com>
+* Denis Roussel <denis.roussel@acsone.eu>
+
 * `DynApps <https://www.dynapps.be>`_:
 
   * Raf Ven <raf.ven@dynapps.be>

--- a/account_payment_order/tests/test_account_payment.py
+++ b/account_payment_order/tests/test_account_payment.py
@@ -1,10 +1,12 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests.common import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPayment(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -6,7 +6,7 @@
 from datetime import date, timedelta
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import Form
+from odoo.tests.common import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -77,6 +77,7 @@ class TestPaymentOrderInboundBase(AccountTestInvoicingCommon):
         return invoice_form.save()
 
 
+@tagged("post_install", "-at_install")
 class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
     def test_constrains_type(self):
         with self.assertRaises(ValidationError):

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import Form
+from odoo.tests.common import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -101,6 +101,7 @@ class TestPaymentOrderOutboundBase(AccountTestInvoicingCommon):
         return wizard.new_move_ids
 
 
+@tagged("post_install", "-at_install")
 class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
     def test_creation_due_date(self):
         self.mode.variable_journal_ids = self.bank_journal

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -307,3 +307,36 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
         self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
+
+    def test_supplier_refund_reference(self):
+        """
+        Confirm the supplier invoice
+        Set a payment referece
+        Create a credit note based on that one with an inferior amount
+        Confirm the credit note
+        Create the payment order
+        The communication should be a combination of the invoice payment reference
+        and the credit note one
+        """
+        self.invoice.payment_reference = "F/1234"
+        self.invoice.action_post()
+        self.refund = self._create_supplier_refund(self.invoice)
+        with Form(self.refund) as refund_form:
+            refund_form.ref = "R1234"
+            with refund_form.invoice_line_ids.edit(0) as line_form:
+                line_form.price_unit = 75.0
+
+        self.refund.action_post()
+
+        self.env["account.invoice.payment.line.multi"].with_context(
+            active_model="account.move", active_ids=self.invoice.ids
+        ).create({}).run()
+
+        payment_order = self.env["account.payment.order"].search(self.domain)
+        self.assertEqual(len(payment_order), 1)
+
+        payment_order.write({"journal_id": self.bank_journal.id})
+
+        self.assertEqual(len(payment_order.payment_line_ids), 1)
+
+        self.assertEqual("F/1234 R1234", payment_order.payment_line_ids.communication)

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -84,6 +85,20 @@ class TestPaymentOrderOutboundBase(AccountTestInvoicingCommon):
         )
 
         return invoice
+
+    def _create_supplier_refund(self, move):
+        wizard = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=move.ids)
+            .create(
+                {
+                    "date_mode": "custom",
+                    "refund_method": "refund",
+                }
+            )
+        )
+        wizard.reverse_moves()
+        return wizard.new_move_ids
 
 
 class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
@@ -261,3 +276,34 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(
             outbound_order.payment_line_ids[1].bank_line_id.date, date.today()
         )
+
+    def test_supplier_refund(self):
+        """
+        Confirm the supplier invoice
+        Create a credit note based on that one with an inferior amount
+        Confirm the credit note
+        Create the payment order
+        The communication should be a combination of the invoice reference
+        and the credit note one
+        """
+        self.invoice.action_post()
+        self.refund = self._create_supplier_refund(self.invoice)
+        with Form(self.refund) as refund_form:
+            refund_form.ref = "R1234"
+            with refund_form.invoice_line_ids.edit(0) as line_form:
+                line_form.price_unit = 75.0
+
+        self.refund.action_post()
+
+        self.env["account.invoice.payment.line.multi"].with_context(
+            active_model="account.move", active_ids=self.invoice.ids
+        ).create({}).run()
+
+        payment_order = self.env["account.payment.order"].search(self.domain)
+        self.assertEqual(len(payment_order), 1)
+
+        payment_order.write({"journal_id": self.bank_journal.id})
+
+        self.assertEqual(len(payment_order.payment_line_ids), 1)
+
+        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)


### PR DESCRIPTION
This improves a little bit the communication field content.

- [x] Adds a hook
- [x] Take into account refunds in normal communication
- [x] Use of 'payment_reference' field if filled in.

Other change:
- [x] Set tests as post-install since https://github.com/odoo/odoo/commit/81aac30dd2278e43a43cf8fd6cef31e1e8c60f3f