### PR TITLE
[14.0][IMP] account_payment_order: Add existing payment references to communication

### DIFF
--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -353,6 +353,15 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
 
         self.refund.action_post()
 
+        # The user add the outstanding payment to the invoice
+        invoice_line = self.invoice.line_ids.filtered(
+            lambda line: line.account_internal_type == "payable"
+        )
+        refund_line = self.refund.line_ids.filtered(
+            lambda line: line.account_internal_type == "payable"
+        )
+        (invoice_line | refund_line).reconcile()
+
         self.env["account.invoice.payment.line.multi"].with_context(
             active_model="account.move", active_ids=self.invoice.ids
         ).create({}).run()

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -86,7 +86,31 @@ class TestPaymentOrderOutboundBase(AccountTestInvoicingCommon):
 
         return invoice
 
-    def _create_supplier_refund(self, move):
+    def _create_supplier_refund(self, move, manual=False):
+        if manual:
+            # Do the supplier refund manually
+            vals = {
+                "partner_id": self.partner.id,
+                "move_type": "in_refund",
+                "ref": move.ref,
+                "payment_mode_id": self.mode.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        None,
+                        {
+                            "product_id": self.env.ref("product.product_product_4").id,
+                            "quantity": 1.0,
+                            "price_unit": 90.0,
+                            "name": "refund of 90.0",
+                            "account_id": self.invoice_line_account.id,
+                        },
+                    )
+                ],
+            }
+            move = self.env["account.move"].create(vals)
+            return move
         wizard = (
             self.env["account.move.reversal"]
             .with_context(active_model="account.move", active_ids=move.ids)
@@ -341,3 +365,37 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
         self.assertEqual("F/1234 R1234", payment_order.payment_line_ids.communication)
+
+    def test_supplier_manual_refund(self):
+        """
+        Confirm the supplier invoice with reference
+        Create a credit note manually
+        Confirm the credit note
+        Reconcile move lines together
+        Create the payment order
+        The communication should be a combination of the invoice payment reference
+        and the credit note one
+        """
+        self.invoice.action_post()
+        self.refund = self._create_supplier_refund(self.invoice, manual=True)
+        with Form(self.refund) as refund_form:
+            refund_form.ref = "R1234"
+
+        self.refund.action_post()
+
+        (self.invoice.line_ids + self.refund.line_ids).filtered(
+            lambda line: line.account_internal_type == "payable"
+        ).reconcile()
+
+        self.env["account.invoice.payment.line.multi"].with_context(
+            active_model="account.move", active_ids=self.invoice.ids
+        ).create({}).run()
+
+        payment_order = self.env["account.payment.order"].search(self.domain)
+        self.assertEqual(len(payment_order), 1)
+
+        payment_order.write({"journal_id": self.bank_journal.id})
+
+        self.assertEqual(len(payment_order.payment_line_ids), 1)
+
+        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)


### PR DESCRIPTION
If some movements have been reconciled with the original invoice,
their references should be added in communication too.

e.g.: Manual credit notes