### PR TITLE
[FIX]account_payment_order

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -89,7 +89,7 @@ class AccountMoveLine(models.Model):
         aplo = self.env["account.payment.line"]
         # default values for communication_type and communication
         communication_type = "normal"
-        communication = self.ref or self.name
+        communication = self.ref or self.name or ""
         # change these default values if move line is linked to an invoice
         if self.move_id.is_invoice():
             if (self.move_id.reference_type or "none") != "none":


### PR DESCRIPTION
**Step to Reproduce:**
1.	Invoicing > Vendors > Bills
2.     Create Vendor Bill with Partially Payment
3.	Click on the payment order

**Issue Log:**
Traceback (most recent call last):
  File "/home/workspace/U14/U14.0/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/workspace/U14/U14.0/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: unsupported operand type(s) for +=: 'bool' and 'str'