### PR TITLE
[14.0][FIX] add company in payment_mode_id domain

### DIFF
--- a/account_payment_partner/models/res_partner.py
+++ b/account_payment_partner/models/res_partner.py
@@ -12,14 +12,16 @@ class ResPartner(models.Model):
         comodel_name="account.payment.mode",
         company_dependent=True,
         check_company=True,
-        domain="[('payment_type', '=', 'outbound')]",
+        domain="[('payment_type', '=', 'outbound'),"
+        "('company_id', '=', current_company_id)]",
         help="Select the default payment mode for this supplier.",
     )
     customer_payment_mode_id = fields.Many2one(
         comodel_name="account.payment.mode",
         company_dependent=True,
         check_company=True,
-        domain="[('payment_type', '=', 'inbound')]",
+        domain="[('payment_type', '=', 'inbound'),"
+        "('company_id', '=', current_company_id)]",
         help="Select the default payment mode for this customer.",
     )
 


### PR DESCRIPTION
A simple usability fix when many companies are selected and the fields supplier_payment_mode_id and customer_payment_mode_id show all the records of all companies. 

Despite having company verification, for the end user it can get a little confusing.

Before:
![worng paymode](https://user-images.githubusercontent.com/6812128/179362589-1584a51b-bfd8-4026-b8b8-827af3c0618b.png)

Now:
![paymode-correct](https://user-images.githubusercontent.com/6812128/179362600-7eb7335a-0f15-406c-be35-561dd5887612.png)


