### PR TITLE
[14.0][FIX] account_payment_order: small usability fix

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
 
     def create_account_payment_line(self):
         apoo = self.env["account.payment.order"]
-        result_payorder_ids = []
+        result_payorder_ids = set()
         action_payment_type = "debit"
         for move in self:
             if move.state != "posted":
@@ -91,7 +91,7 @@ class AccountMove(models.Model):
                         move._prepare_new_payment_order(payment_mode)
                     )
                     new_payorder = True
-                result_payorder_ids.append(payorder.id)
+                result_payorder_ids.add(payorder.id)
                 action_payment_type = payorder.payment_type
                 count = 0
                 for line in applicable_lines.filtered(


### PR DESCRIPTION
create_account_payment_line() is supposed to returned a form view for a single payment order and a tree view for multiple payment orders. Before this fix, it would return a tree view if you were paying more than 1 invoices while generating a single payment order, because the list result_payorder_ids would contain several time the same ID.