### PR TITLE
[15.0][FIX] account_payment_order: Fixing newId issue

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -246,7 +246,7 @@ class AccountPaymentOrder(models.Model):
     @api.onchange("payment_mode_id")
     def payment_mode_id_change(self):
         if len(self.allowed_journal_ids) == 1:
-            self.journal_id = self.allowed_journal_ids
+            self.journal_id = self.allowed_journal_ids._origin
         if self.payment_mode_id.default_date_prefered:
             self.date_prefered = self.payment_mode_id.default_date_prefered
 

--- a/account_payment_order/tests/test_payment_mode.py
+++ b/account_payment_order/tests/test_payment_mode.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import patch
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 
@@ -96,4 +96,24 @@ class TestPaymentMode(TransactionCase):
                     for journal in self.payment_mode_c1.default_journal_ids
                 ]
             )
+        )
+
+    def test_bank_journal_apply(self):
+        inbound_mode = self.env["account.payment.mode"].create(
+            {
+                "name": "Test Direct Debit of customers",
+                "payment_method_id": self.env.ref(
+                    "account.account_payment_method_manual_in"
+                ).id,
+                "company_id": self.company.id,
+                "bank_account_link": "fixed",
+                "fixed_journal_id": self.journal_c1.id,
+            }
+        )
+        payment_order_form = Form(self.env["account.payment.order"])
+        payment_order_form.payment_mode_id = inbound_mode
+        self.assertEqual(
+            payment_order_form.journal_id,
+            self.journal_c1,
+            "Payment Order Bank Journal should be set!",
         )


### PR DESCRIPTION
This fix will make bank journal populate after payment mode on change.

fixes #950 