### PR TITLE
[14.0][FIX] account_payment_purchase: Don't propagate empty payment mode

### DIFF
--- a/account_payment_purchase/models/__init__.py
+++ b/account_payment_purchase/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import account_invoice, purchase_order
+from . import account_move
+from . import purchase_order

--- a/account_payment_purchase/models/account_move.py
+++ b/account_payment_purchase/models/account_move.py
@@ -1,5 +1,6 @@
 # Copyright 2016 Akretion (<http://www.akretion.com>).
-# Copyright 2017 Tecnativa - Vicent Cubells.
+# Copyright 2017 Tecnativa - Vicent Cubells
+# Copyright 2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, models
@@ -10,16 +11,8 @@ class AccountMove(models.Model):
 
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
     def _onchange_purchase_auto_complete(self):
-
-        new_mode = (
-            self.purchase_vendor_bill_id.purchase_order_id.payment_mode_id.id
-            or self.purchase_id.payment_mode_id.id
-        )
-        new_bank = (
-            self.purchase_vendor_bill_id.purchase_order_id.supplier_partner_bank_id.id
-            or self.purchase_id.supplier_partner_bank_id.id
-        )
-
+        new_mode = self.purchase_id.payment_mode_id.id or False
+        new_bank = self.purchase_id.supplier_partner_bank_id.id or False
         res = super()._onchange_purchase_auto_complete() or {}
         if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
             res["warning"] = {
@@ -27,12 +20,14 @@ class AccountMove(models.Model):
                 "message": _("Selected purchase order have different payment mode."),
             }
             return res
-        self.payment_mode_id = new_mode
+        if new_mode:
+            self.payment_mode_id = new_mode
         if self.partner_bank_id and new_bank and self.partner_bank_id.id != new_bank:
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different supplier bank."),
             }
             return res
-        self.partner_bank_id = new_bank
+        if new_bank:
+            self.partner_bank_id = new_bank
         return res

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -116,6 +116,15 @@ class TestAccountPaymentPurchase(SavepointCase):
             result and result.get("warning", {}).get("title", False), "Warning"
         )
 
+    def test_from_purchase_order_empty_mode_invoicing(self):
+        self.purchase.payment_mode_id = False
+        self.purchase.button_confirm()
+        invoice_form = Form(
+            self.env["account.move"].with_context(default_type="in_invoice")
+        )
+        invoice_form.purchase_id = self.purchase
+        self.assertEqual(invoice_form.payment_mode_id, self.payment_mode)
+
     def test_from_purchase_order_invoicing_bank(self):
         # Test partner_bank
         product = self.env["product.product"].create({"name": "Test product"})


### PR DESCRIPTION
Steps to reproduce the problem:

- Have a partner without payment mode.
- Create a PO with such partner.
- No payment mode is filled.
- Now fill the payment mode in the partner.
- Create the invoice for the PO.

Current behavior:

The invoice has empty payment mode.

Expected behavior:

The invoice has the partner payment mode. Someone may think that having no payment mode in the PO may prevail over the partner's payment mode, or even their flows may consist in empyting the payment mode in the PO for not binding it with anything yet, but that strategy has more holes than the one implemented here, as the flow presented proves.

You can then use another one like having an extra payment mode "Undetermined" or similar for doing such classification as a more resilient strategy.

It includes a regression test that fails before the change and now is correct.

Forward-port of #953 

@Tecnativa TT38608