### PR TITLE
[13.0][FIX] account_payment_order: Open the payment order created from the selected invoices.

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -50,7 +50,7 @@ class AccountMove(models.Model):
 
     def create_account_payment_line(self):
         apoo = self.env["account.payment.order"]
-        result_payorder_ids = []
+        result_payorder_ids = set()
         action_payment_type = "debit"
         for move in self:
             if move.state != "posted":
@@ -92,7 +92,7 @@ class AccountMove(models.Model):
                         move._prepare_new_payment_order(payment_mode)
                     )
                     new_payorder = True
-                result_payorder_ids.append(payorder.id)
+                result_payorder_ids.add(payorder.id)
                 action_payment_type = payorder.payment_type
                 count = 0
                 for line in applicable_lines.filtered(


### PR DESCRIPTION
Backport from 14.0: https://github.com/OCA/bank-payment/pull/948

Open the payment order created from the selected invoices.

**Before**
![antes](https://user-images.githubusercontent.com/4117568/191304942-acc5cd8e-8dbb-4c01-8a6d-6f293462c988.gif)

**After**
![despues](https://user-images.githubusercontent.com/4117568/191304962-39aa0605-0896-4266-892d-b1b522a0a4a9.gif)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT38956