### PR TITLE
[14.0][FIX] account_payment_order: Restore payment order number in account move line label

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -461,8 +461,10 @@ class AccountPaymentOrder(models.Model):
     ):
         vals = {}
         if self.payment_type == "outbound":
+            name = _("Payment order %s") % self.name
             account_id = self.journal_id.payment_credit_account_id.id
         else:
+            name = _("Debit order %s") % self.name
             account_id = self.journal_id.payment_debit_account_id.id
 
         partner_id = False
@@ -475,6 +477,7 @@ class AccountPaymentOrder(models.Model):
                 break
         vals.update(
             {
+                "name": name,
                 "partner_id": partner_id,
                 "account_id": account_id,
                 "credit": (


### PR DESCRIPTION
Behavior removed by https://github.com/OCA/bank-payment/commit/cbe1eed5ac2a7987a3f23db1d975b6e13abab32c 

Expected behavior :


![clipboard-202209261102-l6iy5](https://user-images.githubusercontent.com/8035793/192246787-8ac06c02-c116-4075-b477-19439f066c95.png)

Current behavior :

![clipboard-202209261102-b7gzs](https://user-images.githubusercontent.com/8035793/192246681-c50ea4f1-4578-4036-a6d9-70362a3015ca.png)

