### PR TITLE
[15.0][FIX] Installation of payment provider with account_payment_mode installed

### DIFF
--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -9,18 +9,6 @@ from odoo.exceptions import ValidationError
 class AccountJournal(models.Model):
     _inherit = "account.journal"
 
-    def _default_outbound_payment_methods(self):
-        all_out = self.env["account.payment.method"].search(
-            [("payment_type", "=", "outbound")]
-        )
-        return all_out
-
-    def _default_inbound_payment_methods(self):
-        all_in = self.env["account.payment.method"].search(
-            [("payment_type", "=", "inbound")]
-        )
-        return all_in
-
     @api.constrains("company_id")
     def company_id_account_payment_mode_constrains(self):
         for journal in self:


### PR DESCRIPTION
As stated in #977 currently the order of installation matters when installing an account chart, payment method, and `account_payment_mode` causing problems on installation.

This PR tries to fix it by removing the overwrite of `_default_outbound_payment_methods` and `_default_inbound_payment_methods` causing the creation of multiple `account.payment.method.line`.