### PR TITLE
[FIX] account_payment_order: show tree view correctly when more than 1 Payment order are created

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -132,7 +132,7 @@ class AccountMove(models.Model):
             action.update(
                 {
                     "view_mode": "tree,form,pivot,graph",
-                    "domain": "[('id', 'in', %s)]" % result_payorder_ids,
+                    "domain": "[('id', 'in', %s)]" % list(result_payorder_ids),
                     "views": False,
                 }
             )


### PR DESCRIPTION
Before this commit, result_payorder_ids is a set, domain are bad evaluated by {1, 2, 3} and action is not show to user, after this commit, domain is a list of ids [1, 2, 3] and action is showed correctly
**Before this commit** 
1) Try pay invoice with various Payment Modes
2) Payments orders are created, but not show at user
![image](https://user-images.githubusercontent.com/7775116/210587902-6ca4a527-21c2-4a1f-951c-9db2ce64499f.png)
**After this commit**
Payments created are showed to user
![image](https://user-images.githubusercontent.com/7775116/210588040-4274a665-a321-4471-8ceb-6925de2c8fc0.png)
