### PR TITLE
[OU] account_payment_order: avoid the creation of payments on some cases

### DIFF
--- a/account_payment_order/migrations/14.0.2.0.0/post-migration.py
+++ b/account_payment_order/migrations/14.0.2.0.0/post-migration.py
@@ -32,6 +32,7 @@ def _insert_account_payments(env):
         JOIN account_payment_order apo ON apo.id = bpl.order_id
         JOIN account_payment_mode apm ON apm.id = apo.payment_mode_id
         LEFT JOIN account_move_line aml ON aml.bank_payment_line_id = bpl.id
+        WHERE apo.state not in ('uploaded', 'done') or aml.move_id is not null
         """,
     )
     # As the information is asymmetric: N payment lines > 1 bank payment line, but there


### PR DESCRIPTION
It might happen when we had the `no_generate_move` marked. Not an usual case, but we want to avoid the generation of account.payment for this lines.