### PR TITLE
[14.0][IMP] account_payment_partner: Make payment mode editable

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -22,6 +22,7 @@ class AccountMove(models.Model):
         ondelete="restrict",
         readonly=False,
         check_company=True,
+        tracking=True,
     )
     bank_account_required = fields.Boolean(
         related="payment_mode_id.payment_method_id.bank_account_required", readonly=True

--- a/account_payment_partner/models/account_move_line.py
+++ b/account_payment_partner/models/account_move_line.py
@@ -13,9 +13,10 @@ class AccountMoveLine(models.Model):
         store=True,
         ondelete="restrict",
         index=True,
+        readonly=False,
     )
 
-    @api.depends("move_id.payment_mode_id")
+    @api.depends("move_id", "move_id.payment_mode_id")
     def _compute_payment_mode(self):
         for line in self:
             if line.move_id.is_invoice() and line.account_internal_type in (
@@ -25,3 +26,18 @@ class AccountMoveLine(models.Model):
                 line.payment_mode_id = line.move_id.payment_mode_id
             else:
                 line.payment_mode_id = False
+
+    def write(self, vals):
+        """Propagate up to the move the payment mode if applies."""
+        if "payment_mode_id" in vals:
+            for record in self:
+                move = (
+                    self.env["account.move"].browse(vals.get("move_id", 0))
+                    or record.move_id
+                )
+                if (
+                    move.payment_mode_id.id != vals["payment_mode_id"]
+                    and move.is_invoice()
+                ):
+                    move.payment_mode_id = vals["payment_mode_id"]
+        return super().write(vals)

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -298,6 +298,10 @@ class TestAccountPaymentPartner(SavepointCase):
         mode = self.supplier_payment_mode.copy()
         aml.payment_mode_id = mode
         self.assertEqual(invoice.payment_mode_id, mode)
+        # Test payment mode editability on account move
+        self.assertFalse(invoice.has_reconciled_items)
+        invoice.payment_mode_id = self.supplier_payment_mode
+        self.assertEqual(aml.payment_mode_id, self.supplier_payment_mode)
 
     def test_invoice_create_out_invoice(self):
         invoice = self._create_invoice(

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -294,6 +294,10 @@ class TestAccountPaymentPartner(SavepointCase):
             lambda l: l.account_id.user_type_id == self.acct_type_payable
         )
         self.assertEqual(invoice.payment_mode_id, aml[0].payment_mode_id)
+        # Test payment mode change on aml
+        mode = self.supplier_payment_mode.copy()
+        aml.payment_mode_id = mode
+        self.assertEqual(invoice.payment_mode_id, mode)
 
     def test_invoice_create_out_invoice(self):
         invoice = self._create_invoice(

--- a/account_payment_partner/views/account_move_line.xml
+++ b/account_payment_partner/views/account_move_line.xml
@@ -14,9 +14,34 @@
                 position="after"
             >
                 <group name="payments" string="Payments">
-                    <field name="payment_mode_id" widget="selection" />
+                    <field name="account_internal_type" invisible="1" />
+                    <field name="reconciled" invisible="1" />
+                    <field
+                        name="payment_mode_id"
+                        widget="selection"
+                        force_save="1"
+                        attrs="{'invisible': [('account_internal_type', 'not in', ['receivable', 'payable'])], 'readonly': ['|', ('account_internal_type', 'not in', ['receivable', 'payable']), ('reconciled', '=', True)]}"
+                    />
                 </group>
             </xpath>
+        </field>
+    </record>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">account.move.line.tree - Add payment mode</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree" />
+        <field name="arch" type="xml">
+            <field name="date_maturity" position="after">
+                <field name="account_internal_type" invisible="1" />
+                <field name="reconciled" invisible="1" />
+                <field
+                    name="payment_mode_id"
+                    optional="hide"
+                    widget="selection"
+                    force_save="1"
+                    attrs="{'invisible': [('account_internal_type', 'not in', ['receivable', 'payable'])], 'readonly': ['|', ('account_internal_type', 'not in', ['receivable', 'payable']), ('reconciled', '=', True)]}"
+                />
+            </field>
         </field>
     </record>
 </odoo>

--- a/account_payment_partner/views/account_move_view.xml
+++ b/account_payment_partner/views/account_move_view.xml
@@ -28,8 +28,9 @@
                     name="payment_mode_id"
                     domain="[('payment_type', '=', payment_mode_filter_type_domain), ('company_id', '=', company_id)]"
                     widget="selection"
-                    attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('move_type', 'not in', ('out_invoice','out_refund','in_invoice','in_refund'))]}"
+                    attrs="{'readonly': [('has_reconciled_items', '=', True)], 'invisible': [('move_type', 'not in', ('out_invoice','out_refund','in_invoice','in_refund'))]}"
                 />
+                <field name="has_reconciled_items" invisible="1" />
                 <field name="commercial_partner_id" invisible="1" />
                 <field name="bank_account_required" invisible="1" />
                 <field name="payment_mode_filter_type_domain" invisible="1" />


### PR DESCRIPTION
Forward-port of #967 to 14.0

This field was editable in previous version before invoice > move refactoring, and it's logic to allow to change payment mode once the invoice has been posted without the need of resetting it to draft.

Thus, the field has been changed to computed writable field, taking care of the consequences at model level (compute) and view level (add the field in views + proper attrs).

This commit adds tracking=True to the payment mode field as well to be aware when and who the payment mode is changed in the invoice, no matter if directly changed in draft, or through the change on the journal item.

@Tecnativa TT39850