### PR TITLE
[14.0] account_payment_order: Add pre_init_hook to add computed columns

### DIFF
--- a/account_payment_order/__init__.py
+++ b/account_payment_order/__init__.py
@@ -1,3 +1,4 @@
+from .hooks import pre_init_hook
 from . import models
 from . import report
 from . import wizard

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -38,4 +38,5 @@
     ],
     "demo": ["demo/payment_demo.xml"],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_payment_order/hooks.py
+++ b/account_payment_order/hooks.py
@@ -1,0 +1,23 @@
+from odoo.tools import sql
+
+
+def pre_init_hook(cr):
+    """Prepare new computed fields.
+
+    Add columns to avoid MemoryError on an existing Odoo instance
+    with lots of data.
+
+    payment_order_ok on account.move is computed from payment_order_ok
+    on account.payment.mode which are both introduced by this module,
+    so nothing to compute.
+    (see AccountMove._compute_payment_order_ok() in models/account_move.py)
+
+    partner_bank_id on account.move.line requires payment_order_ok to be True
+    which it won't be as it's newly introduced - again nothing to compute.
+    (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py)
+    """
+    if not sql.column_exists(cr, "account_move", "payment_order_ok"):
+        sql.create_column(cr, "account_move", "payment_order_ok", "bool")
+
+    if not sql.column_exists(cr, "account_move_line", "partner_bank_id"):
+        sql.create_column(cr, "account_move_line", "partner_bank_id", "int4")

--- a/account_payment_order/hooks.py
+++ b/account_payment_order/hooks.py
@@ -2,22 +2,15 @@ from odoo.tools import sql
 
 
 def pre_init_hook(cr):
-    """Prepare new computed fields.
+    """Prepare new partner_bank_id computed field.
 
-    Add columns to avoid MemoryError on an existing Odoo instance
+    Add column to avoid MemoryError on an existing Odoo instance
     with lots of data.
 
-    payment_order_ok on account.move is computed from payment_order_ok
-    on account.payment.mode which are both introduced by this module,
-    so nothing to compute.
-    (see AccountMove._compute_payment_order_ok() in models/account_move.py)
-
     partner_bank_id on account.move.line requires payment_order_ok to be True
-    which it won't be as it's newly introduced - again nothing to compute.
-    (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py)
+    which it won't be as it's newly introduced - nothing to compute.
+    (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py
+    and AccountMove._compute_payment_order_ok() in models/account_move.py)
     """
-    if not sql.column_exists(cr, "account_move", "payment_order_ok"):
-        sql.create_column(cr, "account_move", "payment_order_ok", "bool")
-
     if not sql.column_exists(cr, "account_move_line", "partner_bank_id"):
         sql.create_column(cr, "account_move_line", "partner_bank_id", "int4")


### PR DESCRIPTION
Add columns to avoid MemoryError on an existing Odoo instance with lots of data.

payment_order_ok on account.move is computed from payment_order_ok on account.payment.mode which are both introduced by this module, so nothing to compute.
(see AccountMove._compute_payment_order_ok() in models/account_move.py)

partner_bank_id on account.move.line requires payment_order_ok to be True which it won't be as it's newly introduced - again nothing to compute. (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py)