### PR TITLE
[FIX] compute_payment_mode_id: recursion error

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -71,10 +71,10 @@ class AccountMove(models.Model):
                     move.payment_mode_id = partner.customer_payment_mode_id
                 elif (
                     move.move_type in ["out_refund", "in_refund"]
-                    and move.reversed_entry_id
+                    and move.reversal_move_id
                 ):
                     move.payment_mode_id = (
-                        move.reversed_entry_id.payment_mode_id.refund_payment_mode_id
+                        move.reversal_move_id.payment_mode_id.refund_payment_mode_id
                     )
                 elif not move.reversed_entry_id:
                     if move.move_type == "out_refund":


### PR DESCRIPTION
recursion error during update module (mig from v10 to v16):

```
File "/odoo/external-src/bank-payment/account_payment_partner/models/account_move.py", line 77, in _compute_payment_mode_id
    move.reversed_entry_id.payment_mode_id.refund_payment_mode_id
  File "/odoo/src/odoo/fields.py", line 2791, in __get__
    return super().__get__(records, owner)
  File "/odoo/src/odoo/fields.py", line 1136, in __get__
    self.recompute(record)
  File "/odoo/src/odoo/fields.py", line 1325, in recompute
    self.compute_value(recs)
  File "/odoo/src/odoo/fields.py", line 1347, in compute_value
    records._compute_field_value(self)
  File "/odoo/src/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/odoo/src/odoo/models.py", line 4186, in _compute_field_value
    getattr(self, field.compute)()
  File "/odoo/external-src/bank-payment/account_payment_partner/models/account_move.py", line 71, in _compute_payment_mode_id
    move.payment_mode_id = partner.customer_payment_mode_id
  File "/odoo/src/odoo/fields.py", line 2791, in __get__
    return super().__get__(records, owner)
  File "/odoo/src/odoo/fields.py", line 1188, in __get__
    self.compute_value(recs)
  File "/odoo/src/odoo/fields.py", line 1347, in compute_value
    records._compute_field_value(self)
  File "/odoo/src/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/odoo/src/odoo/models.py", line 4188, in _compute_field_value
    field.compute(self)
  File "/odoo/src/odoo/fields.py", line 732, in _compute_company_dependent
    values = Property._get_multi(self.name, self.model_name, records.ids)
  File "/odoo/src/odoo/addons/base/models/ir_property.py", line 267, in _get_multi
    field_id = self.env['ir.model.fields']._get(model, name).id
  File "/odoo/src/odoo/addons/base/models/ir_model.py", line 717, in _get
    field_id = model_name and name and self._get_ids(model_name).get(name)
  File "/usr/local/lib/python3.9/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/usr/local/lib/python3.9/dist-packages/decorator.py", line 231, in fun
    args, kw = fix(args, kw, sig)
  File "/usr/local/lib/python3.9/dist-packages/decorator.py", line 203, in fix
    ba = sig.bind(*args, **kwargs)
  File "/usr/lib/python3.9/inspect.py", line 3062, in bind
    return self._bind(args, kwargs)
  File "/usr/lib/python3.9/inspect.py", line 2931, in _bind
    parameters = iter(self.parameters.values())
RecursionError: maximum recursion depth exceeded while calling a Python object
```