### PR TITLE
[14.0][IMP] account_payment_order: added bill date to Create Transactions wizard

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -9,6 +9,7 @@ from odoo.fields import first
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
+    invoice_date = fields.Date(related="move_id.invoice_date")
     partner_bank_id = fields.Many2one(
         comodel_name="res.partner.bank",
         string="Partner Bank Account",

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -53,6 +53,11 @@
                     >
                         <tree>
                             <field name="date" />
+                            <field
+                                name="invoice_date"
+                                optional="hide"
+                                string="Bill Date"
+                            />
                             <field name="move_id" required="0" />
                             <field name="journal_id" />
                             <field name="partner_id" />


### PR DESCRIPTION
Some customers find useful bill date to be shown in Select Move Lines to Create Transactions wizard form, this PR simply adds it.