### PR TITLE
[14.0][IMP] account_payment_order: Allow fixed date in the past

### DIFF
--- a/account_payment_order/i18n/account_payment_order.pot
+++ b/account_payment_order/i18n/account_payment_order.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-16 12:27+0000\n"
+"PO-Revision-Date: 2023-02-16 12:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -146,6 +148,11 @@ msgstr ""
 #. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_line_create__allow_blocked
 msgid "Allow Litigation Move Lines"
+msgstr ""
+
+#. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__allow_past_date
+msgid "Allow date in the past"
 msgstr ""
 
 #. module: account_payment_order
@@ -1199,6 +1206,13 @@ msgstr ""
 #. module: account_payment_order
 #: model:ir.model.fields,help:account_payment_order.field_account_payment_order__website_message_ids
 msgid "Website communication history"
+msgstr ""
+
+#. module: account_payment_order
+#: model:ir.model.fields,help:account_payment_order.field_account_payment_order__allow_past_date
+msgid ""
+"When checked, the Payment Date won't fast-forward to today and will instead "
+"remain the scheduled date"
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es.po
+++ b/account_payment_order/i18n/es.po
@@ -164,6 +164,11 @@ msgid "Allow Litigation Move Lines"
 msgstr "Permitir apuntes en litigio"
 
 #. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__allow_past_date
+msgid "Allow date in the past"
+msgstr "Permitir fecha en el pasado"
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__allowed_journal_ids
 msgid "Allowed journals"
 msgstr "Diarios permitidos"
@@ -1256,6 +1261,14 @@ msgstr "Mensajes del sitio web"
 #: model:ir.model.fields,help:account_payment_order.field_account_payment_order__website_message_ids
 msgid "Website communication history"
 msgstr "Historial de comunicaciones del sitio web"
+
+#. module: account_payment_order
+#: model:ir.model.fields,help:account_payment_order.field_account_payment_order__allow_past_date
+msgid ""
+"When checked, the Payment Date won't fast-forward to today and will instead "
+"remain the scheduled date"
+msgstr ""
+"Al marcar esta casilla, la fecha contable no se pondrá al día actual y permanecerá con la fecha de ejecución del pago"
 
 #. module: account_payment_order
 #: model:ir.model,name:account_payment_order.model_account_payment_line_create

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -144,6 +144,15 @@ class AccountPaymentOrder(models.Model):
         compute="_compute_move_count", string="Number of Journal Entries"
     )
     description = fields.Char()
+    allow_past_date = fields.Boolean(
+        string="Allow date in the past",
+        help=(
+            "When checked, the Payment Date won't fast-forward to today "
+            "and will instead remain the scheduled date"
+        ),
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
 
     @api.depends("payment_mode_id")
     def _compute_allowed_journal_ids(self):
@@ -186,7 +195,7 @@ class AccountPaymentOrder(models.Model):
         today = fields.Date.context_today(self)
         for order in self:
             if order.date_scheduled:
-                if order.date_scheduled < today:
+                if not order.allow_past_date and order.date_scheduled < today:
                     raise ValidationError(
                         _(
                             "On payment order %s, the Payment Execution Date "
@@ -303,8 +312,9 @@ class AccountPaymentOrder(models.Model):
                     requested_date = order.date_scheduled or today
                 else:
                     requested_date = today
-                # No payment date in the past
-                requested_date = max(today, requested_date)
+                # No payment date in the past unless allowed
+                if not order.allow_past_date:
+                    requested_date = max(today, requested_date)
                 # inbound: check option no_debit_before_maturity
                 if (
                     order.payment_type == "inbound"

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -89,6 +89,13 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
     def test_constrains_date(self):
         with self.assertRaises(ValidationError):
             self.inbound_order.date_scheduled = date.today() - timedelta(days=1)
+        # No raise
+        self.inbound_order.write(
+            {
+                "allow_past_date": True,
+                "date_scheduled": date.today() - timedelta(days=2),
+            }
+        )
 
     def test_creation(self):
         payment_order = self.inbound_order

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -250,6 +250,13 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         )
         with self.assertRaises(ValidationError):
             outbound_order.date_scheduled = date.today() - timedelta(days=2)
+        # No raise
+        outbound_order.write(
+            {
+                "allow_past_date": True,
+                "date_scheduled": date.today() - timedelta(days=2),
+            }
+        )
 
     def test_manual_line_and_manual_date(self):
         # Create payment order

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -108,6 +108,10 @@
                                 name="date_scheduled"
                                 attrs="{'invisible': [('date_prefered', '!=', 'fixed')], 'required': [('date_prefered', '=', 'fixed')]}"
                             />
+                            <field
+                                name="allow_past_date"
+                                attrs="{'invisible': [('date_prefered', '!=', 'fixed')]}"
+                            />
                             <field name="date_generated" />
                             <field name="generated_user_id" />
                             <field name="date_uploaded" />


### PR DESCRIPTION
- Add a checkbox to allow a past accounting date when the type is "Fixed"
- I made it checkbox reliant so it's opt-in, but IMO the accounting date should always be the scheduled date when using "Fixed" type, since that's logically what a fixed/scheduled date would be

Use case:

Payments are scheduled banking-side to be done on a specific day, you receive the info from the bank but for whatever reason, no one confirms the Payment Order in Odoo on the same day.
Next working day you confirm the payment order but the accounting date fast-forwards to the current day, which no longer reflects the schedule that was planned
