### PR TITLE
[15.0] account_payment_partner: Add pre_init_hook to add computed columns

### DIFF
--- a/account_payment_partner/__init__.py
+++ b/account_payment_partner/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from .hooks import pre_init_hook
 from . import models
 from . import reports

--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -24,4 +24,5 @@
     ],
     "demo": ["demo/partner_demo.xml"],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_payment_partner/hooks.py
+++ b/account_payment_partner/hooks.py
@@ -1,0 +1,20 @@
+import logging
+
+from odoo.tools import sql
+
+logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    """Prepare new payment_mode fields.
+    Add columns to avoid Memory error on an existing Odoo instance
+    with lots of data.
+    The payment_mode_id fields are introduced by this module and computed only
+    from each other or the also newly introduced supplier_payment_mode_id and
+    customer_payment_mode_id on res.partner, so they can stay NULL, nothing
+    to compute.
+    """
+    if not sql.column_exists(cr, "account_move", "payment_mode_id"):
+        sql.create_column(cr, "account_move", "payment_mode_id", "int4")
+    if not sql.column_exists(cr, "account_move_line", "payment_mode_id"):
+        sql.create_column(cr, "account_move_line", "payment_mode_id", "int4")


### PR DESCRIPTION
Add columns to avoid Memory error on an existing Odoo instance with lots of data.

The payment_mode_id fields are introduced by this module and computed only from each other or the also newly introduced supplier_payment_mode_id and customer_payment_mode_id on res.partner, so they can stay NULL, nothing to compute.