### PR TITLE
[15.0] account_payment_order: Add pre_init_hook to add computed column

### DIFF
--- a/account_payment_order/__init__.py
+++ b/account_payment_order/__init__.py
@@ -1,3 +1,4 @@
+from .hooks import pre_init_hook
 from . import models
 from . import report
 from . import wizard

--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -40,4 +40,5 @@
     ],
     "demo": ["demo/payment_demo.xml"],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_payment_order/hooks.py
+++ b/account_payment_order/hooks.py
@@ -1,0 +1,16 @@
+from odoo.tools import sql
+
+
+def pre_init_hook(cr):
+    """Prepare new partner_bank_id computed field.
+
+    Add column to avoid MemoryError on an existing Odoo instance
+    with lots of data.
+
+    partner_bank_id on account.move.line requires payment_order_ok to be True
+    which it won't be as it's newly introduced - nothing to compute.
+    (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py
+    and AccountMove._compute_payment_order_ok() in models/account_move.py)
+    """
+    if not sql.column_exists(cr, "account_move_line", "partner_bank_id"):
+        sql.create_column(cr, "account_move_line", "partner_bank_id", "int4")


### PR DESCRIPTION
Add partner_bank_id column to avoid MemoryError on an existing Odoo instance with lots of data.

partner_bank_id on account.move.line requires payment_order_ok to be True which it won't be as it's newly introduced - again nothing to compute. (see AccountMoveLine._compute_partner_bank_id() in models/account_move_line.py)