### PR TITLE
[14.0][IMP] account_payment_order_notification: Set format_date() to show date from template record

### DIFF
--- a/account_payment_order_notification/data/mail_template_data.xml
+++ b/account_payment_order_notification/data/mail_template_data.xml
@@ -38,7 +38,7 @@
                 % else:
                     <td>${payment_line.communication}</td>
                 % endif
-                <td>${payment_line.date}</td>
+                <td>${format_date(payment_line.date)}</td>
                 <td>${format_amount(payment_line.amount_currency, payment_line.currency_id)}</td>
             </tr>
         % endfor


### PR DESCRIPTION
Set `format_date()` to show date from template record

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT40795