### PR TITLE
[16.0] account_payment_mode: add "sequence" field on account.payment.mode

### DIFF
--- a/account_payment_mode/models/account_payment_mode.py
+++ b/account_payment_mode/models/account_payment_mode.py
@@ -13,7 +13,7 @@ class AccountPaymentMode(models.Model):
 
     _name = "account.payment.mode"
     _description = "Payment Modes"
-    _order = "name"
+    _order = "sequence, name"
     _check_company_auto = True
 
     name = fields.Char(required=True, translate=True)
@@ -68,6 +68,7 @@ class AccountPaymentMode(models.Model):
     )
     active = fields.Boolean(default=True)
     note = fields.Text(translate=True)
+    sequence = fields.Integer(default=10)
 
     @api.onchange("company_id")
     def _onchange_company_id(self):

--- a/account_payment_mode/views/account_payment_mode.xml
+++ b/account_payment_mode/views/account_payment_mode.xml
@@ -46,6 +46,7 @@
         <field name="model">account.payment.mode</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="payment_method_id" />
                 <field name="payment_type" />


### PR DESCRIPTION
Currently, payment modes are ordered by name. With the introduction of a sequence field on account.payment.mode, the user can now decide the order.