### PR TITLE
[15.0][FIX] account_banking_sepa_direct_debit: CSS styling not applied in reports.

### DIFF
--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -18,7 +18,7 @@
         ],
     },
     "assets": {
-        "web.assets_backend": [
+        "web.report_assets_common": [
             "/account_banking_sepa_direct_debit/static/src/css/report.css"
         ],
     },


### PR DESCRIPTION
cc @Tecnativa TT42403

@carlosdauden please review!

The css styling for mandate reports was not being applied.

