### PR TITLE
[16.0][FIX] account_banking_mandate: move's create should be overrided properly to avoid flush_recordset

### DIFF
--- a/account_banking_mandate/models/account_move.py
+++ b/account_banking_mandate/models/account_move.py
@@ -12,48 +12,20 @@ class AccountMove(models.Model):
         "account.banking.mandate",
         string="Direct Debit Mandate",
         ondelete="restrict",
-        readonly=True,
+        readonly=False,
         check_company=True,
         states={"draft": [("readonly", False)]},
+        compute="_compute_mandate_id",
+        store="True",
     )
     mandate_required = fields.Boolean(
         related="payment_mode_id.payment_method_id.mandate_required", readonly=True
     )
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        """Fill the mandate_id from the partner if none is provided on
-        creation, using same method as upstream."""
-        onchanges = {
-            "_onchange_partner_id": ["mandate_id"],
-            "_onchange_payment_mode_id": ["mandate_id"],
-        }
-        for onchange_method, changed_fields in list(onchanges.items()):
-            for vals in vals_list:
-                if any(f not in vals for f in changed_fields):
-                    move = self.new(vals)
-                    move = move.with_company(move.company_id.id)
-                    getattr(move, onchange_method)()
-                    for field in changed_fields:
-                        if field not in vals and move[field]:
-                            vals[field] = move._fields[field].convert_to_write(
-                                move[field], move
-                            )
-        return super().create(vals_list)
-
-    def set_mandate(self):
-        if self.payment_mode_id.payment_method_id.mandate_required:
-            self.mandate_id = self.partner_id.valid_mandate_id
-        else:
-            self.mandate_id = False
-
-    @api.onchange("partner_id", "company_id")
-    def _onchange_partner_id(self):
-        """Select by default the first valid mandate of the partner"""
-        res = super()._onchange_partner_id()
-        self.set_mandate()
-        return res
-
-    @api.onchange("payment_mode_id")
-    def _onchange_payment_mode_id(self):
-        self.set_mandate()
+    @api.depends("payment_mode_id", "partner_id")
+    def _compute_mandate_id(self):
+        for move in self:
+            if move.payment_mode_id.payment_method_id.mandate_required:
+                move.mandate_id = move.partner_id.valid_mandate_id
+            else:
+                move.mandate_id = False

--- a/account_banking_mandate/tests/test_invoice_mandate.py
+++ b/account_banking_mandate/tests/test_invoice_mandate.py
@@ -12,8 +12,6 @@ from odoo.addons.account.models.account_payment_method import AccountPaymentMeth
 
 class TestInvoiceMandate(TransactionCase):
     def test_post_invoice_01(self):
-        self.invoice._onchange_partner_id()
-
         self.assertEqual(self.invoice.mandate_id, self.mandate)
 
         self.invoice.action_post()
@@ -57,7 +55,6 @@ class TestInvoiceMandate(TransactionCase):
         )
         mandate_2.validate()
 
-        self.invoice._onchange_partner_id()
         self.assertEqual(self.invoice.mandate_id, self.mandate)
         self.invoice.action_post()
 
@@ -69,7 +66,6 @@ class TestInvoiceMandate(TransactionCase):
                 payable_move_lines[0].move_id.mandate_id = mandate_2
 
     def test_post_invoice_and_refund_02(self):
-        self.invoice._onchange_partner_id()
         self.invoice.action_post()
         self.assertEqual(self.invoice.mandate_id, self.mandate)
         move_reversal = (
@@ -118,7 +114,6 @@ class TestInvoiceMandate(TransactionCase):
         )
 
         invoice.partner_id = partner_2
-        invoice._onchange_partner_id()
         self.assertEqual(invoice.mandate_id, mandate_2)
 
     def test_onchange_payment_mode(self):
@@ -139,7 +134,6 @@ class TestInvoiceMandate(TransactionCase):
                 "company_id": self.company.id,
             }
         )
-        invoice._onchange_partner_id()
 
         with patch.object(
             AccountPaymentMethod,
@@ -164,7 +158,6 @@ class TestInvoiceMandate(TransactionCase):
         )
 
         invoice.payment_mode_id = mode_inbound_acme_2
-        invoice._onchange_payment_mode_id()
         self.assertEqual(invoice.mandate_id, self.env["account.banking.mandate"])
 
     def test_invoice_constrains(self):


### PR DESCRIPTION
## Context

- Install two modules: `account_banking_mandate` and `account_banking_sepa_credit_transfer`
- The test cases will be run in order: `*mandate` first, then `*transfer`
- Since [cb76725b](https://github.com/odoo/odoo/commit/cb76725b), odoo calls [flush_recordset](https://github.com/odoo/odoo/commit/cb76725b#diff-1e3bd6be3bfb83a37ec9fb800ce8b1c95afe0be90ff792874ae7299c320a2f6eR2257)() on moves before posting them
- The tests of `*transfer` will fail. Somehow the move's names are incorrectly computed and they both have the same, so flush_recordset() fails:

```
...
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "account_move_unique_name"
DETAIL:  Key (name, journal_id)=(PBNKFB/2023/00001, 10) already exists.
...
```