### PR TITLE
[16.0][FIX] account_payment_order: create lines with same sequence name

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -192,6 +192,9 @@ class AccountPaymentLine(models.Model):
             "date": self[:1].date,
             "currency_id": self.currency_id.id,
             "ref": self.order_id.name,
+            # Put the name as the wildcard for forcing a unique name. If not, Odoo gets
+            # the sequence for all the payment at the same time
+            "name": "/",
             "payment_reference": "-".join([line.communication for line in self]),
             "journal_id": journal.id,
             "partner_bank_id": self.partner_bank_id.id,


### PR DESCRIPTION
When you are creating a debit order with various transactions you get the same sequence name in payment_lines. When you are confirming the debit order, you couldn't do it due to the fact that the payment lines have the same name.
Before
![image](https://user-images.githubusercontent.com/77978942/230134991-277ef304-c838-4843-b846-eada45ab8007.png)
![image](https://user-images.githubusercontent.com/77978942/230135600-1731f1a2-5caf-4223-88d2-f2323a26a8a4.png)
After
![image](https://user-images.githubusercontent.com/77978942/230135343-019037d3-4467-4715-a53c-26d82b53f638.png)
debit order done
![image](https://user-images.githubusercontent.com/77978942/230135751-749c7dc3-65d2-4b2f-b835-6d3893fecd26.png)
