### PR TITLE
[16.0][FIX] account_payment_partner: bad application of attributes on the field partner_bank_id

### DIFF
--- a/account_payment_partner/views/account_move_view.xml
+++ b/account_payment_partner/views/account_move_view.xml
@@ -35,7 +35,13 @@
                 <field name="payment_mode_filter_type_domain" invisible="1" />
                 <field name="partner_bank_filter_type_domain" invisible="1" />
             </field>
-            <field name="partner_bank_id" position="attributes">
+            <xpath
+                expr="//group[@id='header_right_group']//field[@name='partner_bank_id']"
+                position="attributes"
+            >
+                <attribute name="context">
+                    {'default_partner_id':commercial_partner_id}
+                </attribute>
                 <attribute name="domain">
                     [('partner_id', '=', partner_bank_filter_type_domain),
                     '|',('company_id', '=', company_id),('company_id', '=', False)]
@@ -43,12 +49,21 @@
                 <attribute name="attrs">
                     {'required': [('bank_account_required', '=', True),('move_type', 'in', ('in_invoice', 'in_refund'))],
                     'readonly': [('state', '!=', 'draft')],
-                    'invisible': [('move_type', '=', 'entry')]}
+                    'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}
                 </attribute>
+            </xpath>
+            <xpath
+                expr="//page[@id='other_tab']//field[@name='partner_bank_id']"
+                position="attributes"
+            >
                 <attribute name="context">
                     {'default_partner_id':commercial_partner_id}
                 </attribute>
-            </field>
+                <attribute name="domain">
+                    [('partner_id', '=', partner_bank_filter_type_domain),
+                    '|',('company_id', '=', company_id),('company_id', '=', False)]
+                </attribute>
+            </xpath>
         </field>
     </record>
     <record id="view_invoice_tree" model="ir.ui.view">


### PR DESCRIPTION
This commit fixes showing the same field twice in customer invoices.

Without change:

- Customer Invoice:
![Selección_320](https://user-images.githubusercontent.com/6359121/231785901-4b17e0a0-5804-4fca-a567-990ff41247d5.jpg)

With change:

- Customer Invoice:
![Selección_321](https://user-images.githubusercontent.com/6359121/231791080-77051216-bc53-400a-8d1a-70de47360ed7.jpg)

- Vendor Bills:
![Selección_323](https://user-images.githubusercontent.com/6359121/231791381-e8abb7af-f11f-4d97-85f8-19aaf096da32.jpg)