### PR TITLE
[14.0][FIX] account_banking_pain_base: Proper condition for AdrLine

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -524,8 +524,7 @@ class AccountPaymentOrder(models.Model):
             if (
                 gen_args.get("pain_flavor").startswith("pain.001.001.")
                 or gen_args.get("pain_flavor").startswith("pain.008.001.")
-                and (partner.zip or partner.city)
-            ):
+            ) and (partner.zip or partner.city):
                 adrline2 = etree.SubElement(postal_address, "AdrLine")
                 val = []
                 if partner.zip:


### PR DESCRIPTION
Forward-port of #1005 

Steps to reproduce the problem:

- Have a partner with no zip code and no city.
- Include it in a payment order.
- Generate the SEPA XML file.

Current behavior: The file couldn't be generated because there's an empty <AdrLine> element.

We put properly parenthesis in the conditions for this to no happen.

@Tecnativa 