### PR TITLE
[15.0][FIX] account_payment_order: Set payment method line for account.payment

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -194,9 +194,22 @@ class AccountPaymentLine(models.Model):
             "journal_id": journal.id,
             "partner_bank_id": self.partner_bank_id.id,
             "payment_order_id": self.order_id.id,
-            "payment_method_id": self.order_id.payment_mode_id.payment_method_id.id,
             "payment_line_ids": [(6, 0, self.ids)],
         }
+        # Determine payment method line according payment method and journal
+        line = self.env["account.payment.method.line"].search(
+            [
+                (
+                    "payment_method_id",
+                    "=",
+                    self.order_id.payment_mode_id.payment_method_id.id,
+                ),
+                ("journal_id", "=", journal.id),
+            ],
+            limit=1,
+        )
+        if line:
+            vals["payment_method_line_id"] = line.id
         # Determine partner_type
         move_type = self[:1].move_line_id.move_id.move_type
         if move_type in {"out_invoice", "out_refund"}:


### PR DESCRIPTION
On v15+, a new model account.payment.method.line is introduced for fine-graining the outstanding account, being `payment_method_id` a related field referred to this new model, so we need to change the previous approach to select the proper method line only if found. If not found, it will be auto-selected by standard code.

@Tecnativa TT43278