### PR TITLE
[15.0][FIX] account_banking_sepa_credit_transfer: fix inactive currency error in the tests

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -29,7 +29,9 @@ class TestSCT(TransactionCase):
         cls.partner_asus = cls.env.ref("base.res_partner_1")
         cls.partner_c2c = cls.env.ref("base.res_partner_12")
         cls.eur_currency = cls.env.ref("base.EUR")
+        cls.eur_currency.active = True
         cls.usd_currency = cls.env.ref("base.USD")
+        cls.usd_currency.active = True
         cls.main_company = cls.env["res.company"].create(
             {"name": "Test EUR company", "currency_id": cls.eur_currency.id}
         )


### PR DESCRIPTION
In case the currency is not active, the test fails because an invoice cannot be validated with an inactive currency
![image](https://github.com/OCA/bank-payment/assets/118818446/2b8a5b10-b499-46df-8ad5-75d2b2cdec23)


cc @Tecnativa TT43341

@victoralmau @pedrobaeza please review