### PR TITLE
[13.0][IMP] account_banking_pain_base & account_banking_sepa_credit_transfer

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -628,3 +628,10 @@ class AccountPaymentOrder(models.Model):
         csi_scheme_name_proprietary = etree.SubElement(csi_scheme_name, "Prtry")
         csi_scheme_name_proprietary.text = scheme_name_proprietary
         return True
+
+    @api.model
+    def generate_agent_block(self, parent_node, party_type, partner_bank):
+        if partner_bank.bank_id and partner_bank.bank_bic:
+            agt = etree.SubElement(parent_node, party_type)
+            fininstnid = etree.SubElement(agt, "FinInstnId")
+            etree.SubElement(fininstnid, "BIC").text = partner_bank.bank_bic

--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -182,6 +182,9 @@ class AccountPaymentOrder(models.Model):
                         )
                         % (line.partner_id.name, line.name)
                     )
+                self.generate_agent_block(
+                    credit_transfer_transaction_info, "CdtrAgt", line.partner_bank_id,
+                )
                 self.generate_party_block(
                     credit_transfer_transaction_info,
                     "Cdtr",


### PR DESCRIPTION
The agent segment must be included for creditor (\<CdtrAgt\>) in international payments. This segment contains the BIC number of the bank and should not be included if it were to be empty.