### PR TITLE
[FIX] account_banking_sepa_credit_transfer: required bank account

### DIFF
--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -174,7 +174,10 @@ class AccountPaymentOrder(models.Model):
                 instructed_amount.text = "%.2f" % line.amount_currency
                 amount_control_sum_a += line.amount_currency
                 amount_control_sum_b += line.amount_currency
-                if not line.partner_bank_id:
+                if (
+                    self.payment_method_id.bank_account_required
+                    and not line.partner_bank_id
+                ):
                     raise UserError(
                         _(
                             "Bank account is missing on the bank payment line "


### PR DESCRIPTION
Only raise UserError when the payment method requires a bank account. Before it was raising the error regardless if bank account was not required.