### PR TITLE
[16.0][IMP] account_payment_order: Add a custom message if the invoice does not have a payment method.

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -57,10 +57,9 @@ class AccountMove(models.Model):
         for move in self:
             if move.state != "posted":
                 raise UserError(_("The invoice %s is not in Posted state") % move.name)
-            applicable_lines = move.line_ids.filtered(
+            pre_applicable_lines = move.line_ids.filtered(
                 lambda x: (
                     not x.reconciled
-                    and x.payment_mode_id.payment_order_ok
                     and x.account_id.account_type
                     in ("asset_receivable", "liability_payable")
                     and not any(
@@ -68,6 +67,12 @@ class AccountMove(models.Model):
                         for p_state in x.payment_line_ids.mapped("state")
                     )
                 )
+            )
+            payment_modes = pre_applicable_lines.mapped("payment_mode_id")
+            if not payment_modes:
+                raise UserError(_("No Payment Mode on invoice %s") % move.name)
+            applicable_lines = pre_applicable_lines.filtered(
+                lambda x: x.payment_mode_id.payment_order_ok
             )
             if not applicable_lines:
                 raise UserError(
@@ -78,9 +83,6 @@ class AccountMove(models.Model):
                     )
                     % move.name
                 )
-            payment_modes = applicable_lines.mapped("payment_mode_id")
-            if not payment_modes:
-                raise UserError(_("No Payment Mode on invoice %s") % move.name)
             for payment_mode in payment_modes:
                 payorder = apoo.search(
                     move.get_account_payment_domain(payment_mode), limit=1

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -209,6 +209,14 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(order.move_ids[0].date, order.payment_ids[0].date)
         self.assertEqual(order.state, "uploaded")
 
+    def test_account_payment_line_creation_without_payment_mode(self):
+        self.invoice.payment_mode_id = False
+        self.invoice.action_post()
+        with self.assertRaises(UserError):
+            self.env["account.invoice.payment.line.multi"].with_context(
+                active_model="account.move", active_ids=self.invoice.ids
+            ).create({}).run()
+
     def test_cancel_payment_order(self):
         # Open invoice
         self.invoice.action_post()


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1118

Add a custom message if the invoice does not have a payment method.

The message will be displayed when trying to create a line of a payment order to better clarify the reason.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT44551