### PR TITLE
[14.0][FIX] account_payment_purchase: use company context on partner lookup

### DIFF
--- a/account_payment_purchase/__manifest__.py
+++ b/account_payment_purchase/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Account Payment Purchase",
-    "version": "14.0.1.0.3",
+    "version": "14.0.1.0.4",
     "category": "Banking addons",
     "license": "AGPL-3",
     "summary": "Adds Bank Account and Payment Mode on Purchase Orders",

--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -34,7 +34,9 @@ class PurchaseOrder(models.Model):
             self.supplier_partner_bank_id = self._get_default_supplier_partner_bank(
                 self.partner_id
             )
-            self.payment_mode_id = self.partner_id.supplier_payment_mode_id
+            self.payment_mode_id = self.with_company(
+                self.company_id
+            ).partner_id.supplier_payment_mode_id
         else:
             self.supplier_partner_bank_id = False
             self.payment_mode_id = False


### PR DESCRIPTION
Use company of purchase order when checking the partner. Field supplier_payment_mode_id is company dependant.