### PR TITLE
[14.0][FIX] account_payment_order: incorrect inbound partial reconciliations

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -8,6 +8,7 @@ import base64
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_compare
 
 
 class AccountPaymentOrder(models.Model):
@@ -433,7 +434,15 @@ class AccountPaymentOrder(models.Model):
             for line in payment.payment_line_ids:
                 if not line.move_line_id:
                     continue
-                if line.amount_currency != -line.move_line_id.amount_residual_currency:
+                sign = -1 if payment.payment_order_id.payment_type == "outbound" else 1
+                if (
+                    float_compare(
+                        line.amount_currency,
+                        (line.move_line_id.amount_residual_currency * sign),
+                        precision_rounding=line.move_line_id.currency_id.rounding,
+                    )
+                    != 0
+                ):
                     if line.move_line_id.amount_residual_currency < 0:
                         debit_move_id = payment_move_line_id.id
                         credit_move_id = line.move_line_id.id

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -111,6 +111,10 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.assertEqual(payment_order.state, "uploaded")
         with self.assertRaises(UserError):
             payment_order.unlink()
+        matching_number = (
+            payment_order.payment_ids.payment_line_ids.move_line_id.matching_number
+        )
+        self.assertTrue(matching_number and matching_number != "P")
 
         payment_order.action_uploaded_cancel()
         self.assertEqual(payment_order.state, "cancel")


### PR DESCRIPTION
- Fix a bug caused by https://github.com/OCA/bank-payment/commit/00d9e89f3d9300b4cc8b831876fc72befcea18ca changes that only partially reconciles moves that should be fully reconciled.
- Added a test that fails without the change, as the inbound reconciles to partial when it should be full
- Swapped to `float_compare` to avoid possible rounding errors