### PR TITLE
[16.0][IMP] account_payment_order_grouped_output: Don't generate grouped move when 1 line

### DIFF
--- a/account_payment_order_grouped_output/models/account_payment_order.py
+++ b/account_payment_order_grouped_output/models/account_payment_order.py
@@ -44,7 +44,7 @@ class AccountPaymentOrder(models.Model):
         """Generate grouped moves if configured that way."""
         res = super().generated2uploaded()
         for order in self:
-            if order.payment_mode_id.generate_move:
+            if order.payment_mode_id.generate_move and len(order.payment_ids) > 1:
                 order.generate_move()
         return res
 

--- a/account_payment_order_grouped_output/tests/test_payment_order_inbound_grouped.py
+++ b/account_payment_order_grouped_output/tests/test_payment_order_inbound_grouped.py
@@ -17,5 +17,21 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.inbound_order.open2generated()
         self.inbound_order.generated2uploaded()
         grouped_moves = self.inbound_order.grouped_move_ids
+        self.assertFalse(grouped_moves)
+        # Add now a second line with different partner
+        self.inbound_order.action_uploaded_cancel()
+        self.inbound_order.cancel2draft()
+        old_partner = self.partner
+        self.partner = self.env["res.partner"].create({"name": "Test Partner 2"})
+        invoice2 = self._create_customer_invoice()
+        self.partner = old_partner
+        invoice2.action_post()
+        self.env["account.invoice.payment.line.multi"].with_context(
+            active_model="account.move", active_ids=invoice2.ids
+        ).create({}).run()
+        self.inbound_order.draft2open()
+        self.inbound_order.open2generated()
+        self.inbound_order.generated2uploaded()
+        grouped_moves = self.inbound_order.grouped_move_ids
         self.assertTrue(grouped_moves)
         self.assertTrue(grouped_moves.line_ids[0].reconciled)


### PR DESCRIPTION
@Tecnativa 