### PR TITLE
[16.0][FIX] account_payment_partner: fetchPreloadedData bug using selection…

### DIFF
--- a/account_payment_partner/views/account_move_line.xml
+++ b/account_payment_partner/views/account_move_line.xml
@@ -15,7 +15,6 @@
                     <field name="reconciled" invisible="1" />
                     <field
                         name="payment_mode_id"
-                        widget="selection"
                         force_save="1"
                         attrs="{'invisible': [('account_type', 'not in', ['asset_receivable', 'liability_payable'])], 'readonly': ['|', ('account_type', 'not in', ['asset_receivable', 'liability_payable']), ('reconciled', '=', True)]}"
                     />
@@ -34,7 +33,6 @@
                 <field
                     name="payment_mode_id"
                     optional="hide"
-                    widget="selection"
                     force_save="1"
                     attrs="{'invisible': [('account_type', 'not in', ['asset_receivable', 'liability_payable'])], 'readonly': ['|', ('account_type', 'not in', ['asset_receivable', 'liability_payable']), ('reconciled', '=', True)]}"
                 />


### PR DESCRIPTION
… widget

When clicking on `CREATE TRANSACTIONS` without a Due Date or Journal Entry Date.

![imagen](https://github.com/OCA/bank-payment/assets/95038732/76b25d9a-58f8-4cc3-8e9e-eedfe7bbff8b)

![imagen](https://github.com/OCA/bank-payment/assets/95038732/15429120-946e-4e87-89ea-03266d315afb)

![imagen](https://github.com/OCA/bank-payment/assets/95038732/15948202-7d25-4ec8-a0c1-eb5aef5d85b3)

```js
Uncaught (in promise) Error: The following error occurred in onWillStart: ""
    OwlError owl.js:87
    wrapError owl.js:2607
    onWillStart owl.js:2650
    useModel model.js:141
    setup list_controller.js:65
    ComponentNode owl.js:2359
    createComponent owl.js:5779
    slot1 owl.js:5553
    callSlot owl.js:2971
    template owl.js:5553
    _render owl.js:1725
    render owl.js:1717
    initiateRender owl.js:2381
Caused by: Error: 
    UnimplementedRouteError sample_server.js:14
    mockRpc sample_server.js:156
    fakeRPC sample_server.js:825
    call orm_service.js:109
    preloadSelection selection_field.js:89
    fetchPreloadedData relational_model.js:856
    loadPreloadedData relational_model.js:866
    _load relational_model.js:1199
```

This is caused when using a `widget` that is preloaded on data registry:

https://github.com/OCA/OCB/blob/16.0/addons/web/static/src/views/relational_model.js#L864

```js
async loadPreloadedData() {
...
            // @FIXME type should not be get like this
            const type = activeField.widget || this.fields[fieldName].type;
            if (!this.isInvisible(fieldName) && preloadedDataRegistry.contains(type)) {
                proms.push(fetchPreloadedData(preloadedDataRegistry.get(type), fieldName));
            }
...
```