### PR TITLE
[16.0][FW] account_payment_order: Fix grouped partial reconcile + incorrect inbound partial reconciliations

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -8,6 +8,7 @@ import base64
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_compare
 
 
 class AccountPaymentOrder(models.Model):
@@ -460,7 +461,15 @@ class AccountPaymentOrder(models.Model):
             for line in payment.payment_line_ids:
                 if not line.move_line_id:
                     continue
-                if line.amount_currency != -line.move_line_id.amount_residual_currency:
+                sign = -1 if payment.payment_order_id.payment_type == "outbound" else 1
+                if (
+                    float_compare(
+                        line.amount_currency,
+                        (line.move_line_id.amount_residual_currency * sign),
+                        precision_rounding=line.move_line_id.currency_id.rounding,
+                    )
+                    != 0
+                ):
                     if line.move_line_id.amount_residual_currency < 0:
                         debit_move_id = payment_move_line_id.id
                         credit_move_id = line.move_line_id.id

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -130,6 +130,10 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.assertEqual(payment_order.state, "uploaded")
         with self.assertRaises(UserError):
             payment_order.unlink()
+        matching_number = (
+            payment_order.payment_ids.payment_line_ids.move_line_id.matching_number
+        )
+        self.assertTrue(matching_number and matching_number != "P")
 
         payment_order.action_uploaded_cancel()
         self.assertEqual(payment_order.state, "cancel")

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -369,6 +369,62 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
             fields.Date.context_today(outbound_order),
         )
 
+    def test_partial_reconciliation(self):
+        """
+        Confirm both supplier invoices
+        Add invoices to payment order
+        Reduce payment amount of first invoice from 100 to 80
+        Take payment order all the way to uploaded
+        Confirm 80 reconciled with first, not second invoice
+
+        generated2uploaded() does partial reconciliation of non-matching
+        line amounts before running .reconcile() against the remaining
+        matching line amounts.
+        """
+        # Open both invoices
+        self.invoice.action_post()
+        self.invoice_02.action_post()
+
+        # Add to payment order using the wizard
+        self.env["account.invoice.payment.line.multi"].with_context(
+            active_model="account.move",
+            active_ids=self.invoice.ids + self.invoice_02.ids,
+        ).create({}).run()
+
+        payment_order = self.env["account.payment.order"].search(self.domain)
+        self.assertEqual(len(payment_order), 1)
+
+        payment_order.write({"journal_id": self.bank_journal.id})
+
+        self.assertEqual(len(payment_order.payment_line_ids), 2)
+        self.assertFalse(payment_order.payment_ids)
+
+        # Reduce payment of first invoice from 100 to 80
+        first_payment_line, second_payment_line = payment_order.payment_line_ids
+        first_payment_line.write({"amount_currency": 80.0})
+
+        # Open payment order
+        payment_order.draft2open()
+
+        # Confirm single payment (grouped - two invoices one partner)
+        self.assertEqual(payment_order.payment_count, 1)
+
+        # Generate and upload
+        payment_order.open2generated()
+        payment_order.generated2uploaded()
+
+        self.assertEqual(payment_order.state, "uploaded")
+        with self.assertRaises(UserError):
+            payment_order.unlink()
+
+        # Confirm payments were reconciled against correct invoices
+        self.assertEqual(first_payment_line.amount_currency, 80.0)
+        self.assertEqual(
+            first_payment_line.move_line_id.amount_residual_currency, -20.0
+        )
+        self.assertEqual(second_payment_line.amount_currency, 100.0)
+        self.assertEqual(second_payment_line.move_line_id.amount_residual_currency, 0.0)
+
     def test_supplier_refund(self):
         """
         Confirm the supplier invoice


### PR DESCRIPTION
Forward ports of
- https://github.com/OCA/bank-payment/pull/1049
- https://github.com/OCA/bank-payment/pull/1121