### PR TITLE
[14.0][FIX+IMP] account_payment_order: Define the value of the communication field correctly

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -27,6 +27,7 @@
         "wizard/account_payment_line_create_view.xml",
         "wizard/account_invoice_payment_line_multi_view.xml",
         "views/account_payment_mode.xml",
+        "views/account_payment_views.xml",
         "views/account_payment_order.xml",
         "views/account_payment_line.xml",
         "views/account_move_line.xml",

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -90,6 +90,19 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         with self.assertRaises(ValidationError):
             self.inbound_order.date_scheduled = date.today() - timedelta(days=1)
 
+    def test_invoice_communication_01(self):
+        self.assertEqual(
+            self.invoice.name, self.invoice._get_payment_order_communication()
+        )
+        self.invoice.ref = "R1234"
+        self.assertEqual(
+            self.invoice.name, self.invoice._get_payment_order_communication()
+        )
+
+    def test_invoice_communication_02(self):
+        self.invoice.payment_reference = "R1234"
+        self.assertEqual("R1234", self.invoice._get_payment_order_communication())
+
     def test_creation(self):
         payment_order = self.inbound_order
         self.assertEqual(len(payment_order.ids), 1)

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -126,7 +126,12 @@
                             string="Payment Transactions"
                             attrs="{'invisible': [('state', 'in', ('draft', 'cancel'))]}"
                         >
-                            <field name="payment_ids" edit="0" create="0" />
+                            <field
+                                name="payment_ids"
+                                edit="0"
+                                create="0"
+                                context="{'tree_view_ref': 'account_payment_order.view_account_payment_tree_payment_order'}"
+                            />
                         </page>
                     </notebook>
                 </sheet>

--- a/account_payment_order/views/account_payment_views.xml
+++ b/account_payment_order/views/account_payment_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_payment_tree_payment_order" model="ir.ui.view">
+        <field name="name">account.payment.tree</field>
+        <field name="model">account.payment</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="account.view_account_payment_tree" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="payment_reference" />
+            </field>
+        </field>
+    </record>
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="name">account.payment.form</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form" />
+        <field name="arch" type="xml">
+            <field name="ref" position="after">
+                <field
+                    name="payment_reference"
+                    attrs="{'invisible': [('payment_reference', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Superseed https://github.com/OCA/bank-payment/pull/1071

Changes done:
- [x] Define the value of the `communication` field correctly
- [x] Add `payment_ref` field to `account.payment` tree and form views

Example use case:
![factura](https://github.com/OCA/bank-payment/assets/4117568/c51ac5e7-0e86-4856-a6f6-f499beda02ea)
![order-pago-1](https://github.com/OCA/bank-payment/assets/4117568/f5afafcf-4118-4a5d-bd9f-901216a89af5)
![orden-pago-2](https://github.com/OCA/bank-payment/assets/4117568/81fe9d32-2b28-436b-b47d-5822587eaa30)
![orden-pago-3](https://github.com/OCA/bank-payment/assets/4117568/aceefd5e-c827-405f-9fff-463e3e1ac1f9)

@Tecnativa TT45153