### PR TITLE
[14.0][FIX] account_payment_order: Add readonly=1 to prevent open move line in edit mode

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -49,6 +49,8 @@
                     <field
                         name="move_line_ids"
                         nolabel="1"
+                        readonly="1"
+                        force_save="1"
                         context="{'tree_view_ref': 'account_payment_order.view_move_line_tree'}"
                     >
                         <tree>


### PR DESCRIPTION
Add `readonly=1` to prevent open move line in edit mode.

**Before**
![antes](https://github.com/OCA/bank-payment/assets/4117568/65be52fd-b369-412c-a0b4-53ac985582a3)

**After**
![despues](https://github.com/OCA/bank-payment/assets/4117568/1314d990-90cc-4138-ade2-5b8b2746f753)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45211