### PR TITLE
[16.0][FIX] account_payment_order: Add extra form view only to avoid open move lines in edit mode

### DIFF
--- a/account_payment_order/views/account_move_line.xml
+++ b/account_payment_order/views/account_move_line.xml
@@ -18,12 +18,25 @@
             </group>
         </field>
     </record>
+    <!-- Extra form view only to avoid open the recod in edit mode !-->
+    <record id="view_move_line_form_no_edit" model="ir.ui.view">
+        <field name="name">account.move.line.form.no_edit</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_form" />
+        <field name="mode">primary</field>
+        <field name="priority">999</field>
+        <field name="arch" type="xml">
+            <form position="attributes">
+                <attribute name="edit">0</attribute>
+            </form>
+        </field>
+    </record>
     <record id="view_move_line_tree" model="ir.ui.view">
         <field name="name">account_payment_order.add.move_line_tree</field>
         <field name="model">account.move.line</field>
         <field name="inherit_id" ref="account.view_move_line_tree" />
         <field name="mode">primary</field>
-        <field name="priority">99</field>
+        <field name="priority">999</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='amount_currency']" position="after">
                 <field name="balance" readonly="1" />

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -49,7 +49,8 @@
                     <field
                         name="move_line_ids"
                         nolabel="1"
-                        context="{'tree_view_ref': 'account_payment_order.view_move_line_tree'}"
+                        force_save="1"
+                        context="{'tree_view_ref': 'account_payment_order.view_move_line_tree', 'form_view_ref':'account_payment_order.view_move_line_form_no_edit'}"
                     >
                         <tree>
                             <field name="date" />

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -40,7 +40,12 @@
                         string="Click on Add All Move Lines to auto-select the move lines matching the above criteria or click on Add an item to manually select the move lines filtered by the above criteria."
                         colspan="2"
                     />
-                    <button name="populate" type="object" string="Add All Move Lines" />
+                    <button
+                        name="populate"
+                        type="object"
+                        string="Add All Move Lines"
+                        colspan="2"
+                    />
                 </group>
                 <group
                     name="move_lines"
@@ -51,6 +56,7 @@
                         nolabel="1"
                         force_save="1"
                         context="{'tree_view_ref': 'account_payment_order.view_move_line_tree', 'form_view_ref':'account_payment_order.view_move_line_form_no_edit'}"
+                        colspan="2"
                     >
                         <tree>
                             <field name="date" />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1146

Add extra form view only to avoid open move lines in edit mode.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT45211