### PR TITLE
[16.0] Add warning when payment order is not SEPA

### DIFF
--- a/account_banking_pain_base/models/account_payment_method.py
+++ b/account_banking_pain_base/models/account_payment_method.py
@@ -16,6 +16,7 @@ class AccountPaymentMethod(models.Model):
         "the corresponding unaccented character, so that only ASCII "
         "characters are used in the generated PAIN file.",
     )
+    warn_not_sepa = fields.Boolean(string="Warn If Not SEPA")
 
     def get_xsd_file_path(self):
         """This method is designed to be inherited in the SEPA modules"""

--- a/account_banking_pain_base/views/account_payment_method.xml
+++ b/account_banking_pain_base/views/account_payment_method.xml
@@ -10,8 +10,13 @@
         <field name="arch" type="xml">
             <field name="payment_type" position="after">
                 <field name="pain_version" />
+
                 <field
                     name="convert_to_ascii"
+                    attrs="{'invisible': [('pain_version', '=', False)]}"
+                />
+                <field
+                    name="warn_not_sepa"
                     attrs="{'invisible': [('pain_version', '=', False)]}"
                 />
             </field>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -13,26 +13,31 @@
         />
         <field name="arch" type="xml">
             <field name="company_partner_bank_id" position="after">
-                <field name="sepa" />
+                <field
+                    name="sepa"
+                    attrs="{'invisible': [('sepa_payment_method', '=', False)]}"
+                />
+                <field name="sepa_payment_method" invisible="1" />
+                <field name="show_warning_not_sepa" invisible="1" />
                 <field name="batch_booking" />
                 <field
                     name="charge_bearer"
                     attrs="{'invisible': [('sepa', '=', True)]}"
                 />
             </field>
-        </field>
-</record>
-    <record id="account_payment_order_tree" model="ir.ui.view">
-        <field name="name">pain.base.account.payment.order.tree</field>
-        <field name="model">account.payment.order</field>
-        <field
-            name="inherit_id"
-            ref="account_payment_order.account_payment_order_tree"
-        />
-        <field name="arch" type="xml">
-                <field name="description" position="after">
-                        <field name="sepa" optional="hide" />
-            </field>
+            <header position="after">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('show_warning_not_sepa', '=', False)]}"
+                >
+                        This payment order is <b
+                    >not SEPA</b>. If it is not intented, check that all payment lines are in € and that all bank accounts are valid IBANs with a country prefix in the <a
+                        href="https://en.wikipedia.org/wiki/Single_Euro_Payments_Area"
+                        target="_blank"
+                    >SEPA zone</a>.
+                </div>
+            </header>
         </field>
 </record>
 

--- a/account_banking_sepa_credit_transfer/__manifest__.py
+++ b/account_banking_sepa_credit_transfer/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account Banking SEPA Credit Transfer",
     "summary": "Create SEPA XML files for Credit Transfers",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "license": "AGPL-3",
     "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",

--- a/account_banking_sepa_credit_transfer/data/account_payment_method.xml
+++ b/account_banking_sepa_credit_transfer/data/account_payment_method.xml
@@ -6,5 +6,6 @@
         <field name="payment_type">outbound</field>
         <field name="bank_account_required" eval="True" />
         <field name="pain_version">pain.001.001.03</field>
+        <field name="warn_not_sepa" eval="True" />
     </record>
 </odoo>

--- a/account_banking_sepa_credit_transfer/migrations/16.0.1.0.1/post-migration.py
+++ b/account_banking_sepa_credit_transfer/migrations/16.0.1.0.1/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    sct_method = env.ref("account_banking_sepa_credit_transfer.sepa_credit_transfer")
+    sct_method.write({"warn_not_sepa": True})

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -206,7 +206,10 @@ class TestSCT(TransactionCase):
         self.assertEqual(agrolait_pay_line1.communication, "F1341")
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, "open")
-        self.assertEqual(self.payment_order.sepa, True)
+        if self.payment_mode.payment_method_id.pain_version:
+            self.assertTrue(self.payment_order.sepa)
+        else:
+            self.assertFalse(self.payment_order.sepa)
         self.assertTrue(self.payment_order.payment_ids)
         agrolait_bank_line = self.payment_order.payment_ids[0]
         self.assertEqual(agrolait_bank_line.currency_id, self.eur_currency)

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account Banking SEPA Direct Debit",
     "summary": "Create SEPA files for Direct Debit",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "license": "AGPL-3",
     "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",

--- a/account_banking_sepa_direct_debit/data/account_payment_method.xml
+++ b/account_banking_sepa_direct_debit/data/account_payment_method.xml
@@ -7,5 +7,6 @@
         <field name="bank_account_required" eval="False" />
         <field name="mandate_required" eval="True" />
         <field name="pain_version">pain.008.001.02</field>
+        <field name="warn_not_sepa" eval="True" />
     </record>
 </odoo>

--- a/account_banking_sepa_direct_debit/migrations/16.0.1.0.2/post-migration.py
+++ b/account_banking_sepa_direct_debit/migrations/16.0.1.0.2/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    sct_method = env.ref("account_banking_sepa_direct_debit.sepa_direct_debit")
+    sct_method.write({"warn_not_sepa": True})

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -66,6 +66,9 @@ class AccountPaymentLine(models.Model):
         ondelete="restrict",
         check_company=True,
     )
+    partner_bank_acc_type = fields.Selection(
+        related="partner_bank_id.acc_type", string="Bank Account Type"
+    )
     date = fields.Date(string="Payment Date")
     # communication field is required=False because we don't want to block
     # the creation of lines from move/invoices when communication is empty

--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -62,6 +62,7 @@
                 <field name="partner_id" />
                 <field name="communication" />
                 <field name="partner_bank_id" />
+                <field name="partner_bank_acc_type" optional="hide" />
                 <field name="move_line_id" optional="hide" />
                 <field name="ml_maturity_date" optional="show" />
                 <field name="date" />


### PR DESCRIPTION
The field 'sepa' on account.payment.order is only display for SEPA payment methods.
If the option "show warning if not SEPA" is enabled on the payment method, a warning banner is now displayed on payment orders with a SEPA payment method which are not SEPA.