### PR TITLE
[16.0] account_payment_order: re-implement allow_blocked

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -110,6 +110,18 @@ class AccountMove(models.Model):
                 for line in applicable_lines.filtered(
                     lambda x: x.payment_mode_id == payment_mode
                 ):
+                    if line.blocked and not payment_mode.allow_blocked:
+                        raise UserError(
+                            _(
+                                "The journal item '%(line)s' related to "
+                                "journal entry '%(move)s' is marked as litigation, "
+                                "and the payment mode '%(pay_mode)s' "
+                                "doesn't allow litigation lines.",
+                                line=line.display_name,
+                                move=move.display_name,
+                                pay_mode=payment_mode.display_name,
+                            )
+                        )
                     line.create_payment_line_from_move_line(payorder)
                     count += 1
                 if new_payorder:

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -177,6 +177,21 @@ class AccountPaymentLine(models.Model):
             )
         if not self.communication:
             raise UserError(_("Communication is empty on payment line %s.") % self.name)
+        if (
+            self.move_line_id
+            and self.move_line_id.blocked
+            and not self.order_id.payment_mode_id.allow_blocked
+        ):
+            raise UserError(
+                _(
+                    "Journal item '%(move_line)s' linked to payment line "
+                    "'%(payment_line)s' is marked as litigation and the payment mode "
+                    "'%(payment_mode)s' doesn't allow litigation journal items.",
+                    move_line=self.move_line_id.display_name,
+                    payment_line=self.display_name,
+                    payment_mode=self.order_id.payment_mode_id.display_name,
+                )
+            )
 
     def _prepare_account_payment_vals(self):
         """Prepare the dictionary to create an account payment record from a set of

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -23,6 +23,7 @@ class AccountPaymentMode(models.Model):
         "that has a payment line with a payment date before the maturity "
         "date.",
     )
+    allow_blocked = fields.Boolean(string="Allow Litigation Journal Items")
     # Default options for the "payment.order.create" wizard
     default_payment_mode = fields.Selection(
         selection=[("same", "Same"), ("same_or_null", "Same or empty"), ("any", "Any")],

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -20,6 +20,7 @@
                     />
                     <field name="default_date_prefered" />
                     <field name="group_lines" />
+                    <field name="allow_blocked" />
                 </group>
                 <group
                     name="payment_order_create_defaults"

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -34,7 +34,11 @@
                     <field name="payment_mode" />
                     <field name="target_move" widget="radio" />
                     <field name="invoice" />
-                    <field name="allow_blocked" />
+                    <field
+                        name="allow_blocked"
+                        attrs="{'invisible': [('payment_mode_allow_blocked', '=', False)]}"
+                    />
+                    <field name="payment_mode_allow_blocked" invisible="1" />
                     <label
                         for="populate"
                         string="Click on Add All Move Lines to auto-select the move lines matching the above criteria or click on Add an item to manually select the move lines filtered by the above criteria."


### PR DESCRIPTION
allow_blocked has been moved from the wizard that adds payment lines to the payment mode. That way, users cannot modify it. And they cannot by-pass it by using the button "add to payment order" on the invoice. The 'blocked' status is also check upon confirmation of the payment order (in case it has been marked as blocked AFTER being added to the payment order).