### PR TITLE
[16.0][FIX+IMP] account_payment_order: Define the value of the communication field correctly

### DIFF
--- a/account_payment_order/__manifest__.py
+++ b/account_payment_order/__manifest__.py
@@ -27,6 +27,7 @@
         "wizard/account_payment_line_create_view.xml",
         "wizard/account_invoice_payment_line_multi_view.xml",
         "views/account_payment_mode.xml",
+        "views/account_payment_views.xml",
         "views/account_payment_order.xml",
         "views/account_payment_line.xml",
         "views/account_move_line.xml",

--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -43,42 +43,6 @@ class AccountMoveLine(models.Model):
             else:
                 ml.partner_bank_id = ml.partner_bank_id
 
-    def _get_linked_move_communication(self):
-        """
-        This will collect the references from referral moves:
-            - Reversal moves
-            - Partial payments
-        """
-        self.ensure_one()
-        references = []
-        # Build a recordset to gather moves from which references have already
-        # taken in order to avoid duplicates
-        reference_moves = self.env["account.move"].browse()
-        # If we have credit note(s) - reversal_move_id is a one2many
-        if self.move_id.reversal_move_id:
-            references.extend(
-                [
-                    move.payment_reference or move.ref
-                    for move in self.move_id.reversal_move_id
-                    if move.payment_reference or move.ref
-                ]
-            )
-            reference_moves |= self.move_id.reversal_move_id
-        # Retrieve partial payments - e.g.: manual credit notes
-        (
-            invoice_partials,
-            exchange_diff_moves,
-        ) = self.move_id._get_reconciled_invoices_partials()
-        for (_, _, payment_move_line,) in (
-            invoice_partials + exchange_diff_moves
-        ):
-            payment_move = payment_move_line.move_id
-            if payment_move not in reference_moves and (
-                payment_move.payment_reference or payment_move.ref
-            ):
-                references.append(payment_move.payment_reference or payment_move.ref)
-        return references
-
     def _get_communication(self):
         """
         Retrieve the communication string for the payment order
@@ -86,25 +50,12 @@ class AccountMoveLine(models.Model):
         aplo = self.env["account.payment.line"]
         # default values for communication_type and communication
         communication_type = "normal"
-        communication = self.ref or self.name
+        communication = self.move_id._get_payment_order_communication_full()
         # change these default values if move line is linked to an invoice
         if self.move_id.is_invoice():
             if (self.move_id.reference_type or "none") != "none":
-                communication = self.move_id.ref
                 ref2comm_type = aplo.invoice_reference_type2communication_type()
                 communication_type = ref2comm_type[self.move_id.reference_type]
-            else:
-                if (
-                    self.move_id.move_type in ("in_invoice", "in_refund")
-                    and self.move_id.ref
-                ):
-                    communication = self.move_id.payment_reference or self.move_id.ref
-                elif "out" in self.move_id.move_type:
-                    # Force to only put invoice number here
-                    communication = self.move_id.payment_reference or self.move_id.name
-                references = self._get_linked_move_communication()
-                if references:
-                    communication += " " + " ".join(references)
         return communication_type, communication
 
     def _prepare_payment_line_vals(self, payment_order):

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -92,6 +92,21 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         with self.assertRaises(ValidationError):
             self.inbound_order.date_scheduled = date.today() - timedelta(days=1)
 
+    def test_invoice_communication_01(self):
+        self.assertEqual(
+            self.invoice.name, self.invoice._get_payment_order_communication_direct()
+        )
+        self.invoice.ref = "R1234"
+        self.assertEqual(
+            self.invoice.name, self.invoice._get_payment_order_communication_direct()
+        )
+
+    def test_invoice_communication_02(self):
+        self.invoice.payment_reference = "R1234"
+        self.assertEqual(
+            "R1234", self.invoice._get_payment_order_communication_direct()
+        )
+
     def test_creation(self):
         payment_order = self.inbound_order
         self.assertEqual(len(payment_order.ids), 1)

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -261,6 +261,21 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         with self.assertRaises(ValidationError):
             outbound_order.date_scheduled = date.today() - timedelta(days=2)
 
+    def test_invoice_communication_01(self):
+        self.assertEqual(
+            "F1242", self.invoice._get_payment_order_communication_direct()
+        )
+        self.invoice.ref = "F1243"
+        self.assertEqual(
+            "F1243", self.invoice._get_payment_order_communication_direct()
+        )
+
+    def test_invoice_communication_02(self):
+        self.invoice.payment_reference = "R1234"
+        self.assertEqual(
+            "F1242", self.invoice._get_payment_order_communication_direct()
+        )
+
     def test_manual_line_and_manual_date(self):
         # Create payment order
         outbound_order = self.env["account.payment.order"].create(
@@ -326,6 +341,9 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         and the credit note one
         """
         self.invoice.action_post()
+        self.assertEqual(
+            "F1242", self.invoice._get_payment_order_communication_direct()
+        )
         self.refund = self._create_supplier_refund(self.invoice)
         with Form(self.refund) as refund_form:
             refund_form.ref = "R1234"
@@ -333,6 +351,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
                 line_form.price_unit = 75.0
 
         self.refund.action_post()
+        self.assertEqual("R1234", self.refund._get_payment_order_communication_direct())
 
         self.env["account.invoice.payment.line.multi"].with_context(
             active_model="account.move", active_ids=self.invoice.ids
@@ -359,13 +378,18 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         """
         self.invoice.payment_reference = "F/1234"
         self.invoice.action_post()
+        self.assertEqual(
+            "F1242", self.invoice._get_payment_order_communication_direct()
+        )
         self.refund = self._create_supplier_refund(self.invoice)
         with Form(self.refund) as refund_form:
             refund_form.ref = "R1234"
+            refund_form.payment_reference = "FR/1234"
             with refund_form.invoice_line_ids.edit(0) as line_form:
                 line_form.price_unit = 75.0
 
         self.refund.action_post()
+        self.assertEqual("R1234", self.refund._get_payment_order_communication_direct())
 
         # The user add the outstanding payment to the invoice
         invoice_line = self.invoice.line_ids.filtered(
@@ -387,7 +411,8 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
 
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
-        self.assertEqual("F/1234 R1234", payment_order.payment_line_ids.communication)
+        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
+        self.assertNotIn("FR/1234", payment_order.payment_line_ids.communication)
 
     def test_supplier_manual_refund(self):
         """
@@ -400,11 +425,15 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         and the credit note one
         """
         self.invoice.action_post()
+        self.assertEqual(
+            "F1242", self.invoice._get_payment_order_communication_direct()
+        )
         self.refund = self._create_supplier_refund(self.invoice, manual=True)
         with Form(self.refund) as refund_form:
             refund_form.ref = "R1234"
 
         self.refund.action_post()
+        self.assertEqual("R1234", self.refund._get_payment_order_communication_direct())
 
         (self.invoice.line_ids + self.refund.line_ids).filtered(
             lambda line: line.account_type == "liability_payable"

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -126,7 +126,12 @@
                             string="Payment Transactions"
                             attrs="{'invisible': [('state', 'in', ('draft', 'cancel'))]}"
                         >
-                            <field name="payment_ids" edit="0" create="0" />
+                            <field
+                                name="payment_ids"
+                                edit="0"
+                                create="0"
+                                context="{'tree_view_ref': 'account_payment_order.view_account_payment_tree_payment_order'}"
+                            />
                         </page>
                     </notebook>
                 </sheet>

--- a/account_payment_order/views/account_payment_views.xml
+++ b/account_payment_order/views/account_payment_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_payment_tree_payment_order" model="ir.ui.view">
+        <field name="name">account.payment.tree</field>
+        <field name="model">account.payment</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="account.view_account_payment_tree" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="payment_reference" />
+            </field>
+        </field>
+    </record>
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="name">account.payment.form</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form" />
+        <field name="arch" type="xml">
+            <field name="ref" position="after">
+                <field
+                    name="payment_reference"
+                    attrs="{'invisible': [('payment_reference', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
FWP 15.0: https://github.com/OCA/bank-payment/pull/1153

Changes done:
- [x] Define the value of the `communication` field correctly
- [x] Add `payment_ref` field to `account.payment` tree and form views

Example use case:
![factura](https://github.com/OCA/bank-payment/assets/4117568/c51ac5e7-0e86-4856-a6f6-f499beda02ea)
![order-pago-1](https://github.com/OCA/bank-payment/assets/4117568/f5afafcf-4118-4a5d-bd9f-901216a89af5)
![orden-pago-2](https://github.com/OCA/bank-payment/assets/4117568/81fe9d32-2b28-436b-b47d-5822587eaa30)
![orden-pago-3](https://github.com/OCA/bank-payment/assets/4117568/aceefd5e-c827-405f-9fff-463e3e1ac1f9)

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT45153