### PR TITLE
[15.0][FIX] account_payment_order: Remove readonly=1 to move lines to allow to remove records

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -49,8 +49,6 @@
                     <field
                         name="move_line_ids"
                         nolabel="1"
-                        readonly="1"
-                        force_save="1"
                         context="{'tree_view_ref': 'account_payment_order.view_move_line_tree'}"
                     >
                         <tree>


### PR DESCRIPTION
Related to https://github.com/OCA/bank-payment/pull/1146

Remove readonly=1 to move lines to allow to remove records

Undo https://github.com/OCA/bank-payment/pull/1146/commits/b579d5ef0ef3357b1698cb0e16ae02a52dcc5d23

Another approach is https://github.com/OCA/bank-payment/pull/1147/commits/1e5d146d07a03d41a947bd4ae100e3757ba56a63, but it only works from v16.

Please @pedrobaeza can you review it?

@Tecnativa TT45211