### PR TITLE
[16.0][IMP] account_banking_mandate: Display mandate_id field in the form view of account.payment.line with the same condition as the tree view.

### DIFF
--- a/account_banking_mandate/views/account_payment_line.xml
+++ b/account_banking_mandate/views/account_payment_line.xml
@@ -17,7 +17,7 @@
                 <field
                     name="mandate_id"
                     domain="[('partner_bank_id', '=', partner_bank_id), ('state', '=', 'valid')]"
-                    attrs="{'invisible': [('mandate_required', '=', False)], 'required': [('mandate_required', '=', True)]}"
+                    attrs="{'invisible': [('payment_type', '!=', 'inbound')], 'required': [('mandate_required', '=', True)]}"
                     context="{'default_partner_bank_id': partner_bank_id}"
                 />
             </field>


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1157

Display `mandate_id` field in the form view of `account.payment.line` with the same condition as the tree view.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT45405