### PR TITLE
[IMP] grouped invoices: " - ".join in stead of "-".join

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -202,7 +202,7 @@ class TestSCT(SavepointCase):
             ),
             0,
         )
-        self.assertEqual(agrolait_bank_line.payment_reference, "F1341-F1342-A1301")
+        self.assertEqual(agrolait_bank_line.payment_reference, "F1341 - F1342 - A1301")
         self.assertEqual(agrolait_bank_line.partner_bank_id, invoice1.partner_bank_id)
 
         action = self.payment_order.open2generated()
@@ -288,7 +288,7 @@ class TestSCT(SavepointCase):
             asus_bank_line.currency_id.compare_amounts(asus_bank_line.amount, 3054.0),
             0,
         )
-        self.assertEqual(asus_bank_line.payment_reference, "Inv9032-Inv9033")
+        self.assertEqual(asus_bank_line.payment_reference, "Inv9032 - Inv9033")
         self.assertEqual(asus_bank_line.partner_bank_id, invoice1.partner_bank_id)
 
         action = self.payment_order.open2generated()

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -190,7 +190,7 @@ class AccountPaymentLine(models.Model):
             "date": self[:1].date,
             "currency_id": self.currency_id.id,
             "ref": self.order_id.name,
-            "payment_reference": "-".join([line.communication for line in self]),
+            "payment_reference": " - ".join([line.communication for line in self]),
             "journal_id": journal.id,
             "partner_bank_id": self.partner_bank_id.id,
             "payment_order_id": self.order_id.id,


### PR DESCRIPTION
Payment Reference (communication) in case of grouped invoices into a single payment: " - ".join in stead of "-".join since we see many vendors using "-" in their invoice numbering which makes the "-".join confusing.

![image](https://github.com/OCA/bank-payment/assets/7706945/cc31e878-6b44-4056-9907-b31529a7a337)


