### PR TITLE
[FIX]payment order - fix compute_partner_bank_id

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -31,7 +31,7 @@ class AccountMoveLine(models.Model):
             if (
                 ml.move_id.move_type in ("in_invoice", "in_refund")
                 and not ml.reconciled
-                and ml.payment_mode_id.payment_order_ok
+                and (ml.payment_mode_id.payment_order_ok or not ml.payment_mode_id)
                 and ml.account_id.internal_type in ("receivable", "payable")
                 and not any(
                     p_state in ("draft", "open", "generated")


### PR DESCRIPTION
The bank account number of then invoice is not selected when a supplier has multiple bank account numbers and there is no payment mode set on the vendor bill.
This PR fixes this issue.