### PR TITLE
[16.0][FIX] account_payment_order: Restrict payment lines button to payment group

### DIFF
--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -46,6 +46,7 @@
                     attrs="{'invisible': [('payment_line_count', '=', 0)]}"
                     icon="fa-bars"
                     help="Payment Order Lines"
+                    groups="account_payment_order.group_account_payment"
                 >
                     <field
                         string="Payment Lines"


### PR DESCRIPTION
If not, you get an access error when accessing the invoice if you don't have such permission:

```
You are not allowed to access 'Payment Lines' (account.payment.line) records.

This operation is allowed for the following groups:
      - Extra Rights/Accounting / Payments

Contact your administrator to request access if necessary
```

@Tecnativa TT45952