### PR TITLE
[16.0][FIX] account_payment_order: Always return a string in the _get_payment_order_order_communication_direct() method.

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -49,7 +49,7 @@ class AccountMove(models.Model):
 
     def _get_payment_order_communication_direct(self):
         """Retrieve the communication string for this direct item."""
-        communication = self.payment_reference or self.ref or self.name or ""
+        communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
             if (self.reference_type or "none") != "none":
                 communication = self.ref
@@ -57,7 +57,7 @@ class AccountMove(models.Model):
                 communication = self.ref or self.payment_reference
             else:
                 communication = self.payment_reference or self.name
-        return communication
+        return communication or ""
 
     def _get_payment_order_communication_full(self):
         """Retrieve the full communication string for the payment order.

--- a/account_payment_order/tests/test_account_payment.py
+++ b/account_payment_order/tests/test_account_payment.py
@@ -7,6 +7,7 @@ from odoo.tests import tagged
 
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
 @tagged("-at_install", "post_install")
@@ -14,7 +15,7 @@ class TestAccountPayment(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
-
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         Method_get_payment_method_information = (
             AccountPaymentMethod._get_payment_method_information
         )

--- a/account_payment_order/tests/test_payment_mode.py
+++ b/account_payment_order/tests/test_payment_mode.py
@@ -6,12 +6,14 @@ from unittest.mock import patch
 from odoo.tests.common import TransactionCase
 
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
 class TestPaymentMode(TransactionCase):
-    def setUp(self):
-        super(TestPaymentMode, self).setUp()
-
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         Method_get_payment_method_information = (
             AccountPaymentMethod._get_payment_method_information
         )
@@ -24,24 +26,24 @@ class TestPaymentMode(TransactionCase):
             return res
 
         # Company
-        self.company = self.env.ref("base.main_company")
+        cls.company = cls.env.ref("base.main_company")
 
-        self.journal_c1 = self.env["account.journal"].create(
+        cls.journal_c1 = cls.env["account.journal"].create(
             {
                 "name": "Journal 1",
                 "code": "J1",
                 "type": "bank",
-                "company_id": self.company.id,
+                "company_id": cls.company.id,
             }
         )
 
-        self.account = self.env["account.account"].search(
-            [("reconcile", "=", True), ("company_id", "=", self.company.id)], limit=1
+        cls.account = cls.env["account.account"].search(
+            [("reconcile", "=", True), ("company_id", "=", cls.company.id)], limit=1
         )
 
-        self.manual_out = self.env.ref("account.account_payment_method_manual_out")
+        cls.manual_out = cls.env.ref("account.account_payment_method_manual_out")
 
-        self.manual_in = self.env.ref("account.account_payment_method_manual_in")
+        cls.manual_in = cls.env.ref("account.account_payment_method_manual_in")
 
         with patch.object(
             AccountPaymentMethod,
@@ -49,7 +51,7 @@ class TestPaymentMode(TransactionCase):
             _get_payment_method_information,
         ):
 
-            self.electronic_out = self.env["account.payment.method"].create(
+            cls.electronic_out = cls.env["account.payment.method"].create(
                 {
                     "name": "Electronic Out",
                     "code": "electronic_out",
@@ -57,14 +59,14 @@ class TestPaymentMode(TransactionCase):
                 }
             )
 
-        self.payment_mode_c1 = self.env["account.payment.mode"].create(
+        cls.payment_mode_c1 = cls.env["account.payment.mode"].create(
             {
                 "name": "Direct Debit of suppliers from Bank 1",
                 "bank_account_link": "variable",
-                "payment_method_id": self.manual_out.id,
-                "company_id": self.company.id,
-                "fixed_journal_id": self.journal_c1.id,
-                "variable_journal_ids": [(6, 0, [self.journal_c1.id])],
+                "payment_method_id": cls.manual_out.id,
+                "company_id": cls.company.id,
+                "fixed_journal_id": cls.journal_c1.id,
+                "variable_journal_ids": [(6, 0, [cls.journal_c1.id])],
             }
         )
 

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -10,6 +10,7 @@ from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
 @tagged("-at_install", "post_install")
@@ -17,6 +18,7 @@ class TestPaymentOrderInboundBase(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.company = cls.company_data["company"]
         cls.env.user.company_id = cls.company.id
         cls.partner = cls.env["res.partner"].create(


### PR DESCRIPTION
Always return a string in the `_get_payment_order_order_communication_direct()` method.

Related to: https://github.com/OCA/bank-payment/issues/1178

Please @pedrobaeza can you review it?

@Tecnativa