### PR TITLE
 [15.0][IMP] account_banking_mandate: Allow to set a specific mandate reference or sequence + multi-company compatibility + model_create_multi

### DIFF
--- a/account_banking_mandate/data/mandate_reference_sequence.xml
+++ b/account_banking_mandate/data/mandate_reference_sequence.xml
@@ -5,5 +5,6 @@
         <field name="code">account.banking.mandate</field>
         <field name="prefix">BM</field>
         <field name="padding" eval="7" />
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -60,7 +60,7 @@ class AccountBankingMandate(models.Model):
         required=True,
         default=lambda self: self.env.company,
     )
-    unique_mandate_reference = fields.Char(tracking=10, copy=False)
+    unique_mandate_reference = fields.Char(tracking=10, copy=False, default="/")
     signature_date = fields.Date(
         string="Date of Signature of the Mandate",
         tracking=50,
@@ -175,8 +175,8 @@ class AccountBankingMandate(models.Model):
 
     @api.model
     def create(self, vals=None):
-        unique_mandate_reference = vals.get("unique_mandate_reference")
-        if not unique_mandate_reference or unique_mandate_reference == "New":
+        unique_mandate_reference = vals.get("unique_mandate_reference", "/")
+        if unique_mandate_reference == "/":
             vals["unique_mandate_reference"] = (
                 self.env["ir.sequence"].next_by_code("account.banking.mandate") or "New"
             )

--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -173,14 +173,16 @@ class AccountBankingMandate(models.Model):
                         % mandate.unique_mandate_reference
                     )
 
-    @api.model
-    def create(self, vals=None):
-        unique_mandate_reference = vals.get("unique_mandate_reference", "/")
-        if unique_mandate_reference == "/":
-            vals["unique_mandate_reference"] = (
-                self.env["ir.sequence"].next_by_code("account.banking.mandate") or "New"
-            )
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            unique_mandate_reference = vals.get("unique_mandate_reference", "/")
+            if unique_mandate_reference == "/":
+                vals["unique_mandate_reference"] = (
+                    self.env["ir.sequence"].next_by_code("account.banking.mandate")
+                    or "New"
+                )
+        return super().create(vals_list)
 
     @api.onchange("partner_bank_id")
     def mandate_partner_bank_change(self):

--- a/account_banking_mandate/models/account_move.py
+++ b/account_banking_mandate/models/account_move.py
@@ -20,25 +20,26 @@ class AccountMove(models.Model):
         related="payment_mode_id.payment_method_id.mandate_required", readonly=True
     )
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Fill the mandate_id from the partner if none is provided on
         creation, using same method as upstream."""
         onchanges = {
             "_onchange_partner_id": ["mandate_id"],
             "_onchange_payment_mode_id": ["mandate_id"],
         }
-        for onchange_method, changed_fields in list(onchanges.items()):
-            if any(f not in vals for f in changed_fields):
-                move = self.new(vals)
-                move = move.with_company(move.company_id.id)
-                getattr(move, onchange_method)()
-                for field in changed_fields:
-                    if field not in vals and move[field]:
-                        vals[field] = move._fields[field].convert_to_write(
-                            move[field], move
-                        )
-        return super().create(vals)
+        for vals in vals_list:
+            for onchange_method, changed_fields in list(onchanges.items()):
+                if any(f not in vals for f in changed_fields):
+                    move = self.new(vals)
+                    move = move.with_company(move.company_id.id)
+                    getattr(move, onchange_method)()
+                    for field in changed_fields:
+                        if field not in vals and move[field]:
+                            vals[field] = move._fields[field].convert_to_write(
+                                move[field], move
+                            )
+        return super().create(vals_list)
 
     def set_mandate(self):
         if self.payment_mode_id.payment_method_id.mandate_required:

--- a/account_banking_mandate/tests/test_mandate.py
+++ b/account_banking_mandate/tests/test_mandate.py
@@ -175,9 +175,8 @@ class TestMandate(TransactionCase):
 
     def test_mandate_reference_03(self):
         """
-        Test case: create a mandate with "New" as reference
-        Expected result: the reference of the created mandate is not empty and
-        is not "New"
+        Test case: create a mandate with "TEST" as reference
+        Expected result: the reference of the created mandate is "TEST"
         """
         bank_account = self.env.ref("account_payment_mode.res_partner_12_iban")
         mandate = self.env["account.banking.mandate"].create(
@@ -185,15 +184,32 @@ class TestMandate(TransactionCase):
                 "partner_bank_id": bank_account.id,
                 "signature_date": "2015-01-01",
                 "company_id": self.company.id,
-                "unique_mandate_reference": "New",
+                "unique_mandate_reference": "TEST",
             }
         )
         self.assertTrue(mandate.unique_mandate_reference)
-        self.assertNotEqual(mandate.unique_mandate_reference, "New")
+        self.assertEqual(mandate.unique_mandate_reference, "TEST")
+
+    def test_mandate_reference_04(self):
+        """
+        Test case: create a mandate with "/" as reference
+        Expected result: the reference of the created mandate is not "/"
+        """
+        bank_account = self.env.ref("account_payment_mode.res_partner_12_iban")
+        mandate = self.env["account.banking.mandate"].create(
+            {
+                "partner_bank_id": bank_account.id,
+                "signature_date": "2015-01-01",
+                "company_id": self.company.id,
+                "unique_mandate_reference": "/",
+            }
+        )
+        self.assertTrue(mandate.unique_mandate_reference)
+        self.assertNotEqual(mandate.unique_mandate_reference, "/")
 
     def test_mandate_reference_05(self):
         """
-        Test case: create a mandate with False as reference
+        Test case: create a mandate without reference
         Expected result: the reference of the created mandate is not empty
         """
         bank_account = self.env.ref("account_payment_mode.res_partner_12_iban")
@@ -202,23 +218,6 @@ class TestMandate(TransactionCase):
                 "partner_bank_id": bank_account.id,
                 "signature_date": "2015-01-01",
                 "company_id": self.company.id,
-                "unique_mandate_reference": False,
-            }
-        )
-        self.assertTrue(mandate.unique_mandate_reference)
-
-    def test_mandate_reference_06(self):
-        """
-        Test case: create a mandate with a empty string as reference
-        Expected result: the reference of the created mandate is not empty
-        """
-        bank_account = self.env.ref("account_payment_mode.res_partner_12_iban")
-        mandate = self.env["account.banking.mandate"].create(
-            {
-                "partner_bank_id": bank_account.id,
-                "signature_date": "2015-01-01",
-                "company_id": self.company.id,
-                "unique_mandate_reference": "",
             }
         )
         self.assertTrue(mandate.unique_mandate_reference)

--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -50,7 +50,7 @@
                             <field
                                 name="unique_mandate_reference"
                                 class="oe_inline"
-                                readonly="1"
+                                attrs="{'readonly': [('id', '!=', False)]}"
                             />
                         </h1>
                     </div>


### PR DESCRIPTION
Forward-port of #1143.

Changes done:

- Allow sequence to be multi-company.
- Allow to set a specific mandate reference or sequence.
- Change to @api.model_create_multi 

@Tecnativa