### PR TITLE
[16.0][FIX]account_banking_mandate: mandate_partner_bank_form columns

### DIFF
--- a/account_banking_mandate/views/res_partner_bank_view.xml
+++ b/account_banking_mandate/views/res_partner_bank_view.xml
@@ -15,6 +15,7 @@
                         name="mandate_ids"
                         context="{'mandate_bank_partner_view': True}"
                         nolabel="1"
+                        colspan="4"
                     />
                 </group>
             </xpath>


### PR DESCRIPTION
On V16, the mandate_ids field in the mandate_partner_bank_form is not correctly displayed. It has a width of one column and the content of its mandate records can not be properly seen. This PR increments that width.

Before:
![image](https://github.com/OCA/bank-payment/assets/45785416/56f57eda-831b-43f0-8ca5-b6e64c2a9e18)


After:
![image](https://github.com/OCA/bank-payment/assets/45785416/79301bf9-46d0-4d85-9ff8-d468449e2055)
