### PR TITLE
[13.0][FIX]account_payment_purchase: return result from onchange and get properties with correct company

### DIFF
--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -29,8 +29,9 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("partner_id", "company_id")
     def onchange_partner_id(self):
-        super(PurchaseOrder, self).onchange_partner_id()
+        res = super(PurchaseOrder, self).onchange_partner_id()
         if self.partner_id:
+            self = self.with_context(force_company=self.company_id.id)
             self.supplier_partner_bank_id = self._get_default_supplier_partner_bank(
                 self.partner_id
             )
@@ -38,3 +39,4 @@ class PurchaseOrder(models.Model):
         else:
             self.supplier_partner_bank_id = False
             self.payment_mode_id = False
+        return res


### PR DESCRIPTION
Before the change, the result of the onnchange was not being returned when it should always be for onchange methods.
Also, set the context with the `force_company` again to get the correct value for the `supplier_payment_mode_id` `res.partner` property.

cc @ForgeFlow