### PR TITLE
[16.0][FIX] account_banking_mandate: Use correct company when search for mandate_id

### DIFF
--- a/account_banking_mandate/models/account_move.py
+++ b/account_banking_mandate/models/account_move.py
@@ -22,9 +22,10 @@ class AccountMove(models.Model):
         related="payment_mode_id.payment_method_id.mandate_required", readonly=True
     )
 
-    @api.depends("payment_mode_id", "partner_id")
+    @api.depends("company_id", "payment_mode_id", "partner_id")
     def _compute_mandate_id(self):
         for move in self:
+            move = move.with_company(move.company_id)
             if move.payment_mode_id.payment_method_id.mandate_required:
                 move.mandate_id = move.partner_id.valid_mandate_id
             else:


### PR DESCRIPTION
In the context of a multi company user with two companies selected (Company A and Company B) and the Company B as default. If you have a Customer with two mandates (one by each company) and select it in an invoice of the company A, the mandate that is set belongs to the Company B.

This PR adds the company context of the account.move to fix this.

