### PR TITLE
[15.0][IMP] account_payment_order: No error on unknown payment method codes

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -374,17 +374,13 @@ class AccountPaymentOrder(models.Model):
         return True
 
     def generate_payment_file(self):
-        """Returns (payment file as string, filename)"""
+        """Returns (payment file as string, filename).
+
+        By default, any method not specifically intercepted by extra modules will do
+        nothing, including the existing manual one.
+        """
         self.ensure_one()
-        if self.payment_method_id.code == "manual":
-            return (False, False)
-        else:
-            raise UserError(
-                _(
-                    "No handler for this payment method. Maybe you haven't "
-                    "installed the related Odoo module."
-                )
-            )
+        return (False, False)
 
     def open2generated(self):
         self.ensure_one()


### PR DESCRIPTION
Since v14, the tool for changing the target transfer account is to create new payment methods, and put a method line in the journal with such account.

Thus, there will be "fake" payment methods with no export handler with the only goal of having a different target account.

Raising an error on such methods when finishing the payment order, forcing to add custom code for returning `(False, False)`, is too much, so better to simply return that by default and don't block in these cases.

@Tecnativa TT47723