### PR TITLE
[16.0][IMP] account_payment_purchase: Add propagation of payment mode from purchase to invoice

### DIFF
--- a/account_payment_purchase/models/account_move.py
+++ b/account_payment_purchase/models/account_move.py
@@ -19,8 +19,7 @@ class AccountMove(models.Model):
             self.purchase_vendor_bill_id.purchase_order_id.supplier_partner_bank_id.id
             or self.purchase_id.supplier_partner_bank_id.id
         )
-
-        res = super()._onchange_purchase_auto_complete() or {}
+        res = {}
         if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
             res["warning"] = {
                 "title": _("Warning"),
@@ -37,4 +36,5 @@ class AccountMove(models.Model):
             return res
         elif self.partner_bank_id.id != new_bank:
             self.partner_bank_id = new_bank
+        res = super()._onchange_purchase_auto_complete()
         return res

--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -53,3 +53,9 @@ class PurchaseOrder(models.Model):
             else:
                 order.supplier_partner_bank_id = False
                 order.payment_mode_id = False
+
+    def _prepare_invoice(self):
+        """Propagate payment mode to invoice"""
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals["payment_mode_id"] = self.payment_mode_id.id
+        return invoice_vals

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -111,6 +111,16 @@ class TestAccountPaymentPurchase(TransactionCase):
         self.assertEqual(
             result and result.get("warning", {}).get("title", False), "Warning"
         )
+        # Test payment mode in direct invoicing from purchase
+        purchase3 = self.purchase.copy()
+        payment_mode3 = self.payment_mode.copy()
+        purchase3.payment_mode_id = payment_mode3
+        purchase3.button_confirm()
+        purchase3.order_line.qty_received = 1
+        purchase3.action_create_invoice()
+        self.assertEqual(
+            purchase3.invoice_ids.payment_mode_id, purchase3.payment_mode_id
+        )
 
     def test_from_purchase_order_invoicing_bank(self):
         # Test partner_bank


### PR DESCRIPTION
When you set a payment mode in the purchase order and then you generate an invoice, the payment mode is not propagated. I propose to inherit _prepare_invoice method and return the payment mode.