### PR TITLE
[15.0][IMP] account_payment_order: Display a message with the archived bank accounts

### DIFF
--- a/account_payment_order/i18n/account_payment_order.pot
+++ b/account_payment_order/i18n/account_payment_order.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-19 07:23+0000\n"
+"PO-Revision-Date: 2024-02-19 07:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -28,6 +30,12 @@ msgid ""
 "%(count)d payment lines added to the new draft payment order <a href=# data-"
 "oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
 "has been automatically created."
+msgstr ""
+
+#. module: account_payment_order
+#: code:addons/account_payment_order/models/account_payment_order.py:0
+#, python-format
+msgid "<b>Account Number</b>: %s - <b>Partner</b>: %s"
 msgstr ""
 
 #. module: account_payment_order
@@ -823,6 +831,11 @@ msgid "Partner Bank Account"
 msgstr ""
 
 #. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__partner_banks_archive_msg
+msgid "Partner Banks Archive Msg"
+msgstr ""
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_line_create__partner_ids
 msgid "Partners"
 msgstr ""
@@ -1058,6 +1071,11 @@ msgstr ""
 #, python-format
 msgid ""
 "The invoice %(move)s is already added in the payment order(s) %(order)s."
+msgstr ""
+
+#. module: account_payment_order
+#: model_terms:ir.ui.view,arch_db:account_payment_order.account_payment_order_form
+msgid "The following bank accounts are archived:"
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es.po
+++ b/account_payment_order/i18n/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-05 10:20+0000\n"
-"PO-Revision-Date: 2023-09-21 17:37+0000\n"
+"POT-Creation-Date: 2024-02-19 07:23+0000\n"
+"PO-Revision-Date: 2024-02-19 08:25+0100\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: account_payment_order
 #: code:addons/account_payment_order/models/account_move.py:0
@@ -40,6 +40,12 @@ msgstr ""
 "%(count)d líneas de pago añadidas a la nueva orden <a href=# data-oe-"
 "model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, que ha "
 "sido creada automáticamente."
+
+#. module: account_payment_order
+#: code:addons/account_payment_order/models/account_payment_order.py:0
+#, python-format
+msgid "<b>Account Number</b>: %s - <b>Partner</b>: %s"
+msgstr "<b>Número de cuenta</b>: %s - <b>Empresa</b>: %s"
 
 #. module: account_payment_order
 #: model_terms:ir.ui.view,arch_db:account_payment_order.print_account_payment_order_document
@@ -868,6 +874,11 @@ msgid "Partner Bank Account"
 msgstr "Cuenta bancaria"
 
 #. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__partner_banks_archive_msg
+msgid "Partner Banks Archive Msg"
+msgstr ""
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_line_create__partner_ids
 msgid "Partners"
 msgstr "Contactos"
@@ -1112,6 +1123,11 @@ msgid ""
 "The invoice %(move)s is already added in the payment order(s) %(order)s."
 msgstr ""
 "La factura %(move)s ya está agregada en la(s) orden(es) de pago %(order)s."
+
+#. module: account_payment_order
+#: model_terms:ir.ui.view,arch_db:account_payment_order.account_payment_order_form
+msgid "The following bank accounts are archived:"
+msgstr "Las siguientes cuentas bancarias están archivadas:"
 
 #. module: account_payment_order
 #: code:addons/account_payment_order/models/account_move.py:0

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -28,6 +28,9 @@ class AccountPaymentOrder(models.Model):
         states={"draft": [("readonly", False)]},
         check_company=True,
     )
+    partner_banks_archive_msg = fields.Html(
+        compute="_compute_partner_banks_archive_msg",
+    )
     payment_type = fields.Selection(
         selection=[("inbound", "Inbound"), ("outbound", "Outbound")],
         readonly=True,
@@ -144,6 +147,28 @@ class AccountPaymentOrder(models.Model):
         compute="_compute_move_count", string="Number of Journal Entries"
     )
     description = fields.Char()
+
+    @api.depends(
+        "payment_line_ids.partner_bank_id", "payment_line_ids.partner_bank_id.active"
+    )
+    def _compute_partner_banks_archive_msg(self):
+        """Information message to show archived bank accounts and to be able
+        to act on them before confirmation (avoid duplicates)."""
+        for item in self:
+            msg_lines = []
+            for partner_bank in item.payment_line_ids.filtered(
+                lambda x: x.partner_bank_id and not x.partner_bank_id.active
+            ).mapped("partner_bank_id"):
+                msg_line = _(
+                    "<b>Account Number</b>: %(number)s - <b>Partner</b>: %(name)s"
+                ) % {
+                    "number": partner_bank.acc_number,
+                    "name": partner_bank.partner_id.display_name,
+                }
+                msg_lines.append(msg_line)
+            item.partner_banks_archive_msg = (
+                "<br/>".join(msg_lines) if len(msg_lines) > 0 else False
+            )
 
     @api.depends("payment_mode_id")
     def _compute_allowed_journal_ids(self):

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -32,6 +32,15 @@ class TestPaymentOrderOutboundBase(AccountTestInvoicingCommon):
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test Partner",
+                "bank_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "acc_number": "TEST-NUMBER",
+                        },
+                    )
+                ],
             }
         )
         cls.invoice_line_account = cls.env["account.account"].create(
@@ -213,6 +222,11 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         line_created_due.populate()
         line_created_due.create_payment_lines()
         self.assertGreater(len(order.payment_line_ids), 0)
+        self.assertFalse(order.partner_banks_archive_msg)
+        order.payment_line_ids.partner_bank_id.action_archive()
+        self.assertTrue(order.partner_banks_archive_msg)
+        order.payment_line_ids.partner_bank_id.action_unarchive()
+        self.assertFalse(order.partner_banks_archive_msg)
         order.draft2open()
         order.open2generated()
         order.generated2uploaded()

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -58,6 +58,16 @@
                         statusbar_visible="draft,open,generated,uploaded"
                     />
                 </header>
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('partner_banks_archive_msg', '=', False)]}"
+                >
+                    The following bank accounts are archived: <field
+                        name="partner_banks_archive_msg"
+                        readonly="1"
+                    />
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/bank-payment/pull/1223 + https://github.com/OCA/bank-payment/pull/1224

Display a message with the archived bank accounts.

![ejemplo](https://github.com/OCA/bank-payment/assets/4117568/adb147df-9009-45b3-b562-ea1fdca37ff6)

Please @pedrobaeza can you review it?

@Tecnativa TT47789