### PR TITLE
[15.0][FIX] account_payment_order: Filter bank on company

### DIFF
--- a/account_payment_order/models/account_move_line.py
+++ b/account_payment_order/models/account_move_line.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
-from odoo.fields import first
 
 
 class AccountMoveLine(models.Model):
@@ -70,7 +69,11 @@ class AccountMoveLine(models.Model):
             # in this case
         if payment_order.payment_type == "outbound":
             amount_currency *= -1
-        partner_bank_id = self.partner_bank_id.id or first(self.partner_id.bank_ids).id
+        partner_bank_id = self.partner_bank_id.id
+        if not partner_bank_id:
+            partner_bank_id = self.partner_id.bank_ids.filtered(
+                lambda bank: not bank.company_id or bank.company_id == self.company_id
+            )[:1].id
         vals = {
             "order_id": payment_order.id,
             "partner_bank_id": partner_bank_id,

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -142,7 +142,9 @@ class AccountPaymentLine(models.Model):
     def partner_id_change(self):
         partner_bank = False
         if self.partner_id.bank_ids:
-            partner_bank = self.partner_id.bank_ids[0]
+            partner_bank = self.partner_id.bank_ids.filtered(
+                lambda bank: not bank.company_id or bank.company_id == self.company_id
+            )[:1]
         self.partner_bank_id = partner_bank
 
     @api.onchange("move_line_id")


### PR DESCRIPTION
In multi company setup, we need to filter res.partner.bank for current (payment order) company, or shared partner bank account (No company set)