### PR TITLE
[15.0][FIX] account_payment_purchase: Leave the partner_bank_id field empty in purchase invoice process

### DIFF
--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -29,7 +29,7 @@ class PurchaseOrder(models.Model):
 
     @api.onchange("partner_id", "company_id")
     def onchange_partner_id(self):
-        res = super(PurchaseOrder, self).onchange_partner_id()
+        res = super().onchange_partner_id()
         if self.partner_id:
             self = self.with_company(self.company_id)
             self.supplier_partner_bank_id = self._get_default_supplier_partner_bank(
@@ -40,3 +40,10 @@ class PurchaseOrder(models.Model):
             self.supplier_partner_bank_id = False
             self.payment_mode_id = False
         return res
+
+    def _prepare_invoice(self):
+        """Leave the bank account empty so that account_payment_partner set the
+        correct value with compute."""
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals.pop("partner_bank_id")
+        return invoice_vals

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -1,8 +1,8 @@
 # Copyright 2013-2015 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - Vicent Cubells
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields
 from odoo.tests import Form, TransactionCase, tagged
 
 
@@ -10,7 +10,17 @@ from odoo.tests import Form, TransactionCase, tagged
 class TestAccountPaymentPurchase(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(TestAccountPaymentPurchase, cls).setUpClass()
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
         cls.journal = cls.env["account.journal"].create(
             {"name": "Test journal", "code": "TEST", "type": "general"}
         )
@@ -52,35 +62,31 @@ class TestAccountPaymentPurchase(TransactionCase):
                 "seller_ids": [(0, 0, {"name": cls.partner.id})],
             }
         )
-        cls.purchase = cls.env["purchase.order"].create(
-            {
-                "partner_id": cls.partner.id,
-                "payment_mode_id": cls.payment_mode.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "Test line",
-                            "product_qty": 1.0,
-                            "product_id": cls.mto_product.id,
-                            "product_uom": cls.uom_id,
-                            "date_planned": fields.Datetime.today(),
-                            "price_unit": 1.0,
-                        },
-                    )
-                ],
-            }
-        )
+        order_form = Form(cls.env["purchase.order"])
+        order_form.partner_id = cls.partner
+        with order_form.order_line.new() as line_form:
+            line_form.product_id = cls.mto_product
+            line_form.product_qty = 1
+        cls.purchase = order_form.save()
 
     def test_onchange_partner_id_purchase_order(self):
-        self.purchase.onchange_partner_id()
         self.assertEqual(self.purchase.payment_mode_id, self.payment_mode)
 
-    def test_purchase_order_invoicing(self):
-        self.purchase.onchange_partner_id()
+    def test_purchase_order_create_invoice(self):
         self.purchase.button_confirm()
+        self.purchase.order_line.qty_received = 1
+        res = self.purchase.action_create_invoice()
+        invoice = self.env[res["res_model"]].browse(res["res_id"])
+        self.assertEqual(invoice.partner_bank_id, self.bank)
+        # Remove the invoice and try another use case
+        invoice.unlink()
+        self.payment_method_out.bank_account_required = False
+        res = self.purchase.action_create_invoice()
+        invoice2 = self.env[res["res_model"]].browse(res["res_id"])
+        self.assertFalse(invoice2.partner_bank_id)
 
+    def test_purchase_order_invoicing(self):
+        self.purchase.button_confirm()
         invoice = self.env["account.move"].create(
             {"partner_id": self.partner.id, "move_type": "in_invoice"}
         )


### PR DESCRIPTION
Leave the `partner_bank_id` field empty in purchase invoice process

Example use case:
- Create a Supplier and set a bank account.
- Creating a purchase order with a Supplier Bank Account
- The payment method of the payment method must have the Bank Account Required box unchecked.
- Confirm the purchase order and create the invoice with the "Create Bill" button.
- The invoice must have the bank account empty.

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT46502