### PR TITLE
[FIX][17.0] account_payment_order: Fix dynamic domain

### DIFF
--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -190,7 +190,6 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
             )
         )
         line_create.payment_mode = "any"
-        line_create.move_line_filters_change()
         line_create.populate()
         line_create.create_payment_lines()
         line_created_due = (

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -53,11 +53,13 @@
                     name="move_lines"
                     string="Selected Move Lines to Create Transactions"
                 >
+                    <field name="move_line_domain" invisible="1" />
                     <field
                         name="move_line_ids"
                         nolabel="1"
                         force_save="1"
                         context="{'tree_view_ref': 'account_payment_order.view_move_line_tree', 'form_view_ref':'account_payment_order.view_move_line_form_no_edit'}"
+                        domain="move_line_domain"
                         colspan="2"
                     >
                         <tree>


### PR DESCRIPTION
The return domain in onchange is deprecated in v17 and does not work. A calculated Json field was created to store the domain.