### PR TITLE
[14.0][FIX] account_payment_order: exclude cancel journal entries

### DIFF
--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -77,6 +77,8 @@ class AccountPaymentLineCreate(models.TransientModel):
             domain += [("partner_id", "in", self.partner_ids.ids)]
         if self.target_move == "posted":
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ("draft", "posted"))]
         if not self.allow_blocked:
             domain += [("blocked", "!=", True)]
         if self.date_type == "due":


### PR DESCRIPTION
Always exclude cancel journal entries in the wizard that adds payment lines to payment order.

Same behavior as in the rest of Odoo (official and OCA modules). For example, this is the behavior of the OCA module account_financial_report
https://github.com/OCA/account-financial-reporting/blob/14.0/account_financial_report/report/trial_balance.py#L75