### PR TITLE
[14.0][IMP] account_banking_sepa_direct_debit: increase report signature space

### DIFF
--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -341,7 +341,7 @@
                                     />
                                 </t>
                             </div>
-                            <div class="col-10 offset-2 under-line mt16" />
+                            <div class="col-10 offset-2 under-line mt16 py-5" />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The space of the mandate signature in the sepa_direct_debit_mandate_document is too small to be used

Before:
![image](https://github.com/OCA/bank-payment/assets/45785416/e7747e8c-53be-49cf-955f-09cea2573047)

After:
![image](https://github.com/OCA/bank-payment/assets/45785416/a460ba22-d2a1-4b2a-beaa-794773aca1b6)
