### PR TITLE
[16.0][FIX] account_payment_partner: payment mode filter for credit note/refund

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -9,9 +9,6 @@ from odoo import api, fields, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    payment_mode_filter_type_domain = fields.Char(
-        compute="_compute_payment_mode_filter_type_domain"
-    )
     partner_bank_filter_type_domain = fields.Many2one(
         comodel_name="res.partner", compute="_compute_partner_bank_filter_type_domain"
     )
@@ -37,16 +34,6 @@ class AccountMove(models.Model):
         help="Technical field for supporting the editability of the payment mode",
         compute="_compute_has_reconciled_items",
     )
-
-    @api.depends("move_type")
-    def _compute_payment_mode_filter_type_domain(self):
-        for move in self:
-            if move.move_type in ("out_invoice", "in_refund"):
-                move.payment_mode_filter_type_domain = "inbound"
-            elif move.move_type in ("in_invoice", "out_refund"):
-                move.payment_mode_filter_type_domain = "outbound"
-            else:
-                move.payment_mode_filter_type_domain = False
 
     @api.depends("partner_id", "move_type")
     def _compute_partner_bank_filter_type_domain(self):

--- a/account_payment_partner/models/account_payment_mode.py
+++ b/account_payment_partner/models/account_payment_mode.py
@@ -1,10 +1,11 @@
 # Copyright 2017 ForgeFlow S.L.
 # Copyright 2018 Tecnativa - Carlos Dauden
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountPaymentMode(models.Model):
@@ -31,6 +32,25 @@ class AccountPaymentMode(models.Model):
         help="This payment mode will be used when doing "
         "refunds coming from the current payment mode.",
     )
+    is_valid_for_move_type = fields.Boolean(
+        store=False,
+        search="_search_is_valid_for_move_type",
+    )
+
+    def _search_is_valid_for_move_type(self, operator, value):
+        if operator != "=":
+            raise UserError(_("Invalid search operator"))
+        move_type = value
+        if move_type == "out_invoice":
+            return [("payment_type", "=", "inbound")]
+        elif move_type == "in_invoice":
+            return [("payment_type", "=", "outbound")]
+        elif move_type in ("in_refund", "out_refund"):
+            # We allow any payment mode to also allow to decrease amount of
+            # payment order.  For instance, in a debit order for a partner, we
+            # decrease the debited amount by the credit notes.
+            return [("payment_type", "in", ("inbound", "outbound"))]
+        return [("payment_type", "=", False)]
 
     @api.constrains("company_id")
     def account_invoice_company_constrains(self):

--- a/account_payment_partner/readme/CONTRIBUTORS.rst
+++ b/account_payment_partner/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
 
   * Raf Ven <raf.ven@dynapps.be>
 * Marçal Isern <marsal.isern@qubiq.es>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/account_payment_partner/views/account_move_view.xml
+++ b/account_payment_partner/views/account_move_view.xml
@@ -26,13 +26,12 @@
             <field name="partner_bank_id" position="before">
                 <field
                     name="payment_mode_id"
-                    domain="[('payment_type', '=', payment_mode_filter_type_domain), ('company_id', '=', company_id)]"
+                    domain="[('is_valid_for_move_type', '=', move_type), ('company_id', '=', company_id)]"
                     widget="selection"
                     attrs="{'readonly': [('has_reconciled_items', '=', True)], 'invisible': [('move_type', 'not in', ('out_invoice','out_refund','in_invoice','in_refund'))]}"
                 />
                 <field name="has_reconciled_items" invisible="1" />
                 <field name="bank_account_required" invisible="1" />
-                <field name="payment_mode_filter_type_domain" invisible="1" />
                 <field name="partner_bank_filter_type_domain" invisible="1" />
             </field>
             <xpath


### PR DESCRIPTION
Allow to freely choose inbound or outbound payment mode for credit note/refund

When you create a credit note, you may want to include it in the next debit order to decrease the amount debited from open invoices. For example, partnerA has an invoice for $500 and a credit note for $100. You want to make a debit order for $400. For this you need to put the same payment mode on the invoice and credit note.

This behavior has been lost in the migration to v13:
* In v12: https://github.com/OCA/bank-payment/blob/12.0/account_payment_partner/views/account_invoice_view.xml#L29
* In migration PR: https://github.com/OCA/bank-payment/pull/649/files#diff-560b5e454acd270e25223d56b85967eaec36fe9a08eac999124990650aa32f6cR46

cc @rven @alexis-via @pedrobaeza @lmignon @sbidoul 