### PR TITLE
[17.0][FIX] account_banking_sepa_direct_debit: unit tests

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -256,6 +256,9 @@ class TestSCT(TransactionCase):
         return
 
     def test_usd_currency_sct(self):
+        # Set a currency_exchange_journal on the company to avoid an exception
+        # due to the use of a foreign currency
+        self.main_company.write({"currency_exchange_journal_id": self.bank_journal.id})
         invoice1 = self.create_invoice(
             self.partner_asus.id,
             "account_payment_mode.res_partner_2_iban",

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -104,6 +104,10 @@ class TestSDDBase(TransactionCase):
                 ],
             }
         )
+        # Set a currency_exchange_journal on the company to avoid an exception
+        # due to the use of a foreign currency
+        cls.main_company.write({"currency_exchange_journal_id": cls.bank_journal.id})
+        cls.company_B.write({"currency_exchange_journal_id": cls.bank_journal.id})
         # update payment mode
         cls.payment_mode = cls.env.ref(
             "account_banking_sepa_direct_debit.payment_mode_inbound_sepa_dd1"


### PR DESCRIPTION
Since [this commit](https://github.com/odoo/odoo/commit/2d2a7729a77f8004aa046998ce75cd85280b3a6e), the tests fail on the account_banking_sepa_direct_debit and the account_banking_sepa_credit_transfer modules, due to the use of foreign currencies in the tests without having the currency_exchange_journal journal setted in the company

Example: #1265