### PR TITLE
[16.0][FIX] account_payment_sale: Force add payment mode in invoice vals

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -26,15 +26,15 @@ class SaleOrder(models.Model):
                 order.payment_mode_id = False
 
     def _get_payment_mode_vals(self, vals):
-        if self.payment_mode_id:
-            vals["payment_mode_id"] = self.payment_mode_id.id
-            if (
-                self.payment_mode_id.bank_account_link == "fixed"
-                and self.payment_mode_id.payment_method_id.code == "manual"
-            ):
-                vals[
-                    "partner_bank_id"
-                ] = self.payment_mode_id.fixed_journal_id.bank_account_id.id
+        vals["payment_mode_id"] = self.payment_mode_id.id
+        if (
+            self.payment_mode_id
+            and self.payment_mode_id.bank_account_link == "fixed"
+            and self.payment_mode_id.payment_method_id.code == "manual"
+        ):
+            vals[
+                "partner_bank_id"
+            ] = self.payment_mode_id.fixed_journal_id.bank_account_id.id
 
     def _prepare_invoice(self):
         """Copy bank partner from sale order to invoice"""

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -113,3 +113,22 @@ class TestSaleOrder(CommonTestCase):
         orders.action_confirm()
         invoices = orders._create_invoices()
         self.assertEqual(2, len(invoices))
+
+    def test_mixed_null_sale_to_invoice_payment_mode(self):
+        """
+        Data:
+            A partner with a specific payment_mode
+            A sale order created with the payment_mode of the partner
+            A sale order created with null payment_mode
+        Test case:
+            Create the invoice from the sale orders
+        Expected result:
+            Two invoices should be generated
+        """
+        order_1 = self.create_sale_order()
+        order_2 = self.create_sale_order()
+        order_2.payment_mode_id = False
+        orders = order_1 | order_2
+        orders.action_confirm()
+        invoices = orders._create_invoices()
+        self.assertEqual(2, len(invoices))


### PR DESCRIPTION
Since this PR #1246 was added, an error occurs when there are orders without payment_mode_id along with others that do have them when comparing None > int
`TypeError: '<' not supported between instances of 'NoneType' and 'int' 

The error occurs here:
https://github.com/odoo/odoo/blob/fe2fb05892e273587996a2f68cd53fc4f8604c6e/addons/sale/models/sale_order.py#L1149-L1156

Fixed by forcing payment_mode_id to be added even if it is empty because False can be compared with integer