### PR TITLE
[16.0][IMP] account_payment_sale: Improve tests to prevent error with pricelist_id field

### DIFF
--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -10,7 +10,6 @@ class TestSaleOrder(CommonTestCase):
     def create_sale_order(self, payment_mode=None):
         with Form(self.env["sale.order"]) as sale_form:
             sale_form.partner_id = self.base_partner
-            sale_form.pricelist_id = self.env.ref("product.list0")
             for (_, p) in self.products.items():
                 with sale_form.order_line.new() as order_line:
                     order_line.product_id = p


### PR DESCRIPTION
Improve tests to prevent error with `pricelist_id` field

Remove the `pricelist_id` assignment (leave the default one) because it may fail if the user does not have the `product.group_product_product_pricelist` group

`AssertionError: can't write on invisible field pricelist_id`

Locked by:
- [x] `fs_storage`: https://github.com/OCA/storage/pull/372 (Related to `account_payment_method_fs_storage` tests)

Please @pedrobaeza can you review it?

@Tecnativa