### PR TITLE
[16.0] [FIX] account_payment_sale: correction for grouping criteria on invoices creation when payment_mode_id is not set

### DIFF
--- a/account_payment_sale/__manifest__.py
+++ b/account_payment_sale/__manifest__.py
@@ -11,6 +11,10 @@
     "author": "Akretion, " "Tecnativa, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",
     "depends": ["sale", "account_payment_partner"],
-    "data": ["views/sale_order_view.xml", "views/sale_report_templates.xml"],
+    "data": [
+        "views/sale_order_view.xml",
+        "views/sale_report_templates.xml",
+        "data/account_payment_mode.xml",
+    ],
     "auto_install": True,
 }

--- a/account_payment_sale/data/account_payment_mode.xml
+++ b/account_payment_sale/data/account_payment_mode.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="payment_method_momentary" model="account.payment.method">
+        <field name="name">Momentary Payment Method</field>
+        <field name="code">0000</field>
+        <field name="payment_type">inbound</field>
+        <field name="active" eval="False" />
+    </record>
+
+    <record id="payment_mode_momentary" model="account.payment.mode">
+        <field name="name">Momentary Payment Mode</field>
+        <field name="payment_method_id" ref="payment_method_momentary" />
+        <field name="company_id" ref="base.main_company" />
+        <field name="bank_account_link">variable</field>
+        <field name="active" eval="False" />
+    </record>
+</odoo>

--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -52,3 +52,17 @@ class SaleOrder(models.Model):
         if "payment_mode_id" not in keys:
             keys.append("payment_mode_id")
         return keys
+
+    def _create_invoices(self, grouped=False, final=False, date=None):
+        momentary_mode = self.env.ref("account_payment_sale.payment_mode_momentary")
+        for order in self:
+            if not order.payment_mode_id:
+                order.payment_mode_id = momentary_mode
+
+        res = super()._create_invoices(grouped=grouped, final=final, date=date)
+
+        for order in self:
+            if order.payment_mode_id == momentary_mode:
+                order.payment_mode_id = None
+
+        return res

--- a/account_payment_sale/static/description/index.html
+++ b/account_payment_sale/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -424,7 +425,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
When having invoices where `payment_mode_id` is `None` and then trying to create invoices from tree view with other invoices with `payment_mode_id` assigned is returning an Error:
```
File "/opt/odoo/odoo-base/odoo-server/addons/sale/models/sale_order.py", line 1151, in _create_invoices
    invoice_vals_list = sorted(
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```
Here we create inactive records to handle this issue, assigning `payment_mode_momentary` to the invoices with no `payment_mode_id` before the creation of the invoices. After that, we unassign `payment_mode_id` from the invoices.