### PR TITLE
[16.0][IMP] account_banking_mandate_contact: Improve tests (remove mock)

### DIFF
--- a/account_banking_mandate/models/account_payment_method.py
+++ b/account_banking_mandate/models/account_payment_method.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2020 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountPaymentMethod(models.Model):
@@ -11,3 +11,12 @@ class AccountPaymentMethod(models.Model):
         help="Activate this option if this payment method requires your "
         "customer to sign a direct debit mandate with your company.",
     )
+
+    @api.model
+    def _get_payment_method_information(self):
+        res = super()._get_payment_method_information()
+        res["sepa_direct_debit"] = {
+            "mode": "multi",
+            "domain": [("type", "=", "bank")],
+        }
+        return res

--- a/account_banking_mandate_contact/tests/test_account_payment_order.py
+++ b/account_banking_mandate_contact/tests/test_account_payment_order.py
@@ -1,12 +1,8 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl
 
-from unittest.mock import patch
-
 from odoo import fields
 from odoo.tests.common import Form, TransactionCase
-
-from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 
 
 class TestAccountPaymentOrder(TransactionCase):
@@ -35,9 +31,13 @@ class TestAccountPaymentOrder(TransactionCase):
             "payment_type": "inbound",
             "bank_account_required": True,
         }
-        cls.method_sepa = cls._create_multi_bank_payment_method(payment_method_vals)
+        cls.method_sepa = cls.env["account.payment.method"].create(payment_method_vals)
         cls.journal_bank = cls.env["account.journal"].create(
-            {"name": "BANK", "type": "bank", "code": "bank"}
+            {
+                "name": "BANK",
+                "type": "bank",
+                "code": "bank",
+            }
         )
         payment_form = Form(cls.env["account.payment.mode"])
         payment_form.name = "SEPA (CORE)"
@@ -59,27 +59,6 @@ class TestAccountPaymentOrder(TransactionCase):
         )
         payment_order_form.payment_mode_id = cls.payment_core
         cls.payment_order = payment_order_form.save()
-
-    @classmethod
-    def _create_multi_bank_payment_method(cls, payment_method_vals):
-        method_get_payment_method_information = (
-            AccountPaymentMethod._get_payment_method_information
-        )
-
-        def _get_payment_method_information(cls):
-            res = method_get_payment_method_information(cls)
-            res[payment_method_vals["code"]] = {
-                "mode": "multi",
-                "domain": [("type", "=", "bank")],
-            }
-            return res
-
-        with patch.object(
-            AccountPaymentMethod,
-            "_get_payment_method_information",
-            _get_payment_method_information,
-        ):
-            return cls.env["account.payment.method"].create(payment_method_vals)
 
     @classmethod
     def _create_res_partner_bank(cls, acc_number):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1259

`account_banking_mandate_contact`: Improve tests
Changes done:
- Add _get_payment_method_information() compatibility from account_banking_mandate
- Remove mock from account_banking_mandate_contact tests

@Tecnativa