### PR TITLE
[17.0][FIX] account_payment_partner: DeprecationWarning: XML 

### DIFF
--- a/account_payment_partner/static/description/index.html
+++ b/account_payment_partner/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
Fix Deprecation Warning declarations in HTML module descriptions are deprecated since Odoo 17 when installing module