### PR TITLE
[16.0][FIX] account_payment_purchase: Leave the partner_bank_id field empty in purchase invoice process

### DIFF
--- a/account_banking_pain_base/i18n/sv.po
+++ b/account_banking_pain_base/i18n/sv.po
@@ -114,7 +114,7 @@ msgstr "Avbokningsavgift"
 #: code:addons/account_banking_pain_base/models/account_payment_order.py:0
 #, python-format
 msgid "Cannot compute the field '{field_name}'."
-msgstr "Det går inte att beräkna fältet '{fältnamn}'."
+msgstr "Det går inte att beräkna fältet '{field_name}'."
 
 #. module: account_banking_pain_base
 #: model:ir.model.fields.selection,name:account_banking_pain_base.selection__account_payment_line__purpose__clpr
@@ -245,7 +245,7 @@ msgid ""
 msgstr ""
 "Data för utvärdering:\n"
 "\tsammanhang: {eval_ctx}\n"
-"\tfält sökväg: {fält_värde}"
+"\tfält sökväg: {field_value}"
 
 #. module: account_banking_pain_base
 #: model:ir.model.fields.selection,name:account_banking_pain_base.selection__account_payment_line__purpose__dcrd

--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -53,3 +53,10 @@ class PurchaseOrder(models.Model):
             else:
                 order.supplier_partner_bank_id = False
                 order.payment_mode_id = False
+
+    def _prepare_invoice(self):
+        """Leave the bank account empty so that account_payment_partner set the
+        correct value with compute."""
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals.pop("partner_bank_id")
+        return invoice_vals


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1247

Leave the `partner_bank_id` field empty in purchase invoice process

Example use case:
- Create a Supplier and set a bank account.
- Creating a purchase order with a Supplier Bank Account
- The payment method of the payment method must have the Bank Account Required box unchecked.
- Confirm the purchase order and create the invoice with the "Create Bill" button.
- The invoice must have the bank account empty.

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT46502