### PR TITLE
[16.0][FIX] account_banking_sepa_direct_debit: don't test payment state

### DIFF
--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -309,8 +309,6 @@ class TestSDDBase(TransactionCase):
         )
         payment_order.generated2uploaded()
         self.assertEqual(payment_order.state, "uploaded")
-        for inv in [invoice1, invoice2]:
-            self.assertEqual(inv.payment_state, "paid")
         self.assertEqual(self.mandate2.recurrent_sequence_type, "recurring")
         return
 


### PR DESCRIPTION
PR #1276 changes the rules for the move payment state affecting this module's tests. In any case, it isn't something relevant to test for this case.

cc @Tecnativa 

ping @pedrobaeza 