### PR TITLE
[14.0][FIX] account_payment_order: always return a string in the _get_payment_order_communication

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -43,7 +43,7 @@ class AccountMove(models.Model):
         """
         Retrieve the communication string for the payment order
         """
-        communication = self.payment_reference or self.ref or self.name or ""
+        communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
             if (self.reference_type or "none") != "none":
                 communication = self.ref
@@ -62,7 +62,7 @@ class AccountMove(models.Model):
                 ]
             )
             communication += " " + " ".join(references)
-        return communication
+        return communication or ""
 
     def _prepare_new_payment_order(self, payment_mode=None):
         self.ensure_one()


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @Matthwhy 

Correction made following the same rule as the FIX that occurred in version 16.0 [[16.0][FIX] account_payment_order: Always return a string](https://github.com/OCA/bank-payment/pull/1188).

In version 14.0, we currently have the following error:

```
Erro:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1374, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 406, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 391, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account_payment_order/wizard/account_payment_line_create.py", line 179, in create_payment_lines
    self.move_line_ids.create_payment_line_from_move_line(self.order_id)
  File "/opt/odoo/auto/addons/account_payment_order/models/account_move_line.py", line 121, in create_payment_line_from_move_line
    vals_list.append(mline._prepare_payment_line_vals(payment_order))
  File "/opt/odoo/auto/addons/account_payment_order/models/account_move_line.py", line 92, in _prepare_payment_line_vals
    communication_type, communication = self._get_communication()
  File "/opt/odoo/auto/addons/account_payment_order/models/account_move_line.py", line 87, in _get_communication
    communication += " " + " ".join(references)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: unsupported operand type(s) for +=: 'bool' and 'str'
```