### PR TITLE
[17.0][IMP] account_payment_order: Mark invoices in a payment order as in payment

### DIFF
--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -313,8 +313,6 @@ class TestSDDBase(TransactionCase):
         )
         payment_order.generated2uploaded()
         self.assertEqual(payment_order.state, "uploaded")
-        for inv in [invoice1, invoice2]:
-            self.assertEqual(inv.payment_state, "paid")
         self.assertEqual(self.mandate2.recurrent_sequence_type, "recurring")
         return
 

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -234,3 +234,12 @@ class AccountMove(models.Model):
             }
         )
         return action
+
+    @api.model
+    def _get_invoice_in_payment_state(self):
+        """Called from _compute_payment_state method.
+        Consider in_payment all the moves that are included in a payment order.
+        """
+        if self.line_ids.payment_line_ids:
+            return "in_payment"
+        return super()._get_invoice_in_payment_state()

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -112,25 +112,20 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
     def test_creation(self):
         payment_order = self.inbound_order
         self.assertEqual(len(payment_order.ids), 1)
-
         payment_order.write({"journal_id": self.journal.id})
-
         self.assertEqual(len(payment_order.payment_line_ids), 1)
         self.assertFalse(payment_order.payment_ids)
-
         # Open payment order
         payment_order.draft2open()
-
         self.assertEqual(payment_order.payment_count, 1)
-
         # Generate and upload
         payment_order.open2generated()
         payment_order.generated2uploaded()
-
         self.assertEqual(payment_order.state, "uploaded")
+        self.assertEqual(self.invoice.payment_state, "in_payment")
         with self.assertRaises(UserError):
             payment_order.unlink()
-
+        # Cancel order
         payment_order.action_uploaded_cancel()
         self.assertEqual(payment_order.state, "cancel")
         payment_order.cancel2draft()


### PR DESCRIPTION
Forward-port of #1276 

Odoo core already includes a mechanism, only activated in enterprise, to mark invoices reconciled against a payment as "In payment", not as "Paid", and then when the bank reconciliation is done, passed to "Paid".

As we already refactored the payment order transfer entries generation to be done by payments, the only missing bits is to override the method that returns the payment state to put.

We have limited this new payment state though to those invoices that are part of a payment order, not all including those which were paid pressing the button "Register payment", as that's out of the scope of this module.

TT49386