### PR TITLE
[16.0][FIX] account_payment_mode: default inbound methods

### DIFF
--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -20,7 +20,13 @@ class AccountJournal(models.Model):
             "account.payment.method"
         ]._get_payment_method_information()
         unique_codes = tuple(
-            code for code, info in method_info.items() if info.get("mode") == "unique"
+            code
+            for code, info in method_info.items()
+            if info.get("mode")
+            in (
+                "unique",
+                "electronic",
+            )
         )
         all_in = self.env["account.payment.method"].search(
             [


### PR DESCRIPTION
Exclude electronic payment methods as they should be linked only to one journal.