### PR TITLE
[16.0][FIX] account_banking_sepa_credit_transfer: tests integration issues

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -299,15 +299,6 @@ class TestSCT(TransactionCase):
         self.assertEqual(self.payment_order.state, "open")
         self.assertEqual(self.payment_order.sepa, False)
         self.assertEqual(self.payment_order.payment_count, 1)
-        asus_bank_line = self.payment_order.payment_ids[0]
-        self.assertEqual(asus_bank_line.currency_id, self.usd_currency)
-        self.assertEqual(
-            asus_bank_line.currency_id.compare_amounts(asus_bank_line.amount, 3054.0),
-            0,
-        )
-        self.assertEqual(asus_bank_line.payment_reference, "Inv9032 - Inv9033")
-        self.assertEqual(asus_bank_line.partner_bank_id, invoice1.partner_bank_id)
-
         action = self.payment_order.open2generated()
         self.assertEqual(self.payment_order.state, "generated")
         self.assertEqual(action["res_model"], "ir.attachment")

--- a/account_banking_sepa_direct_debit/tests/test_sdd.py
+++ b/account_banking_sepa_direct_debit/tests/test_sdd.py
@@ -273,17 +273,6 @@ class TestSDDBase(TransactionCase):
         payment_order.draft2open()
         self.assertEqual(payment_order.state, "open")
         self.assertEqual(payment_order.sepa, True)
-        # Check account payment
-        agrolait_bank_line = payment_order.payment_ids[0]
-        self.assertEqual(agrolait_bank_line.currency_id, self.eur_currency)
-        self.assertEqual(
-            float_compare(agrolait_bank_line.amount, 42.0, precision_digits=accpre),
-            0,
-        )
-        self.assertEqual(agrolait_bank_line.payment_reference, invoice1.name)
-        self.assertEqual(
-            agrolait_bank_line.partner_bank_id, invoice1.mandate_id.partner_bank_id
-        )
         action = payment_order.open2generated()
         self.assertEqual(payment_order.state, "generated")
         self.assertEqual(action["res_model"], "ir.attachment")


### PR DESCRIPTION
It doesn't proceed to test payment order values and it can lead to integration issues with other modules/localzations.

cc @Tecnativa TT46020

please check @pedrobaeza 