### PR TITLE
[15.0][IMP] account_payment_order: Add Default Tranfer Move Date configuration

### DIFF
--- a/account_payment_order/i18n/account_payment_order.pot
+++ b/account_payment_order/i18n/account_payment_order.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-17 06:21+0000\n"
+"PO-Revision-Date: 2024-06-17 06:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -522,6 +524,7 @@ msgstr ""
 
 #. module: account_payment_order
 #: model:ir.model.fields,help:account_payment_order.field_account_payment_order__message_has_error
+#: model:ir.model.fields,help:account_payment_order.field_account_payment_order__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr ""
 
@@ -744,6 +747,11 @@ msgid "No pending AR/AP lines to add on %s"
 msgstr ""
 
 #. module: account_payment_order
+#: model:ir.model.fields.selection,name:account_payment_order.selection__account_payment_mode__transfer_date_option__now_date_maturity
+msgid "Now + Payment date as due date"
+msgstr ""
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__name
 msgid "Number"
 msgstr ""
@@ -945,6 +953,11 @@ msgid "Payment Type"
 msgstr ""
 
 #. module: account_payment_order
+#: model:ir.model.fields.selection,name:account_payment_order.selection__account_payment_mode__transfer_date_option__payment_date
+msgid "Payment date"
+msgstr ""
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_move_line__payment_line_ids
 msgid "Payment lines"
 msgstr ""
@@ -969,6 +982,11 @@ msgstr ""
 #. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__activity_user_id
 msgid "Responsible User"
+msgstr ""
+
+#. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__message_has_sms_error
+msgid "SMS Delivery error"
 msgstr ""
 
 #. module: account_payment_order
@@ -1155,6 +1173,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__payment_line_ids
 #: model_terms:ir.ui.view,arch_db:account_payment_order.account_payment_order_form
 msgid "Transactions"
+msgstr ""
+
+#. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_mode__transfer_date_option
+msgid "Transfer moves dates"
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es.po
+++ b/account_payment_order/i18n/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-19 07:23+0000\n"
-"PO-Revision-Date: 2024-03-25 18:32+0000\n"
+"POT-Creation-Date: 2024-06-17 06:21+0000\n"
+"PO-Revision-Date: 2024-06-17 08:22+0200\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: account_payment_order
 #: code:addons/account_payment_order/models/account_move.py:0
@@ -548,6 +548,7 @@ msgstr "Si está marcado hay nuevos mensajes que requieren su atención."
 
 #. module: account_payment_order
 #: model:ir.model.fields,help:account_payment_order.field_account_payment_order__message_has_error
+#: model:ir.model.fields,help:account_payment_order.field_account_payment_order__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
 msgstr "Si se encuentra marcado, algunos mensajes tienen error de envío."
 
@@ -787,6 +788,11 @@ msgid "No pending AR/AP lines to add on %s"
 msgstr "No hay líneas AR/AP pendientes para añadir en %s"
 
 #. module: account_payment_order
+#: model:ir.model.fields.selection,name:account_payment_order.selection__account_payment_mode__transfer_date_option__now_date_maturity
+msgid "Now + Payment date as due date"
+msgstr "Ahora + Fecha de pago como fecha de vencimiento"
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__name
 msgid "Number"
 msgstr "Número"
@@ -990,6 +996,11 @@ msgid "Payment Type"
 msgstr "Tipo de pago"
 
 #. module: account_payment_order
+#: model:ir.model.fields.selection,name:account_payment_order.selection__account_payment_mode__transfer_date_option__payment_date
+msgid "Payment date"
+msgstr "Fecha de pago"
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_move_line__payment_line_ids
 msgid "Payment lines"
 msgstr "Líneas de pago"
@@ -1015,6 +1026,11 @@ msgstr "Tipo de Referencia"
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__activity_user_id
 msgid "Responsible User"
 msgstr "Usuario responsable"
+
+#. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_order__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Error de entrega del SMS"
 
 #. module: account_payment_order
 #: model:ir.model.fields.selection,name:account_payment_order.selection__account_payment_line_create__payment_mode__same
@@ -1222,6 +1238,11 @@ msgid "Transactions"
 msgstr "Transacciones"
 
 #. module: account_payment_order
+#: model:ir.model.fields,field_description:account_payment_order.field_account_payment_mode__transfer_date_option
+msgid "Transfer moves dates"
+msgstr "Fechas de movimientos de transferencia"
+
+#. module: account_payment_order
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_line_create__date_type
 #: model:ir.model.fields,field_description:account_payment_order.field_account_payment_mode__default_date_type
 msgid "Type of Date Filter"
@@ -1291,247 +1312,3 @@ msgstr "el"
 msgid "otherwise, new payment orders will be created (one per payment mode)."
 msgstr ""
 "En caso contrario, se crearán nuevas órdenes (una por cada modo de pago)."
-
-#, python-format
-#~ msgid "<b>Account Number</b>: %s - <b>Partner</b>: %s"
-#~ msgstr "<b>Número de cuenta</b>: %s - <b>Empresa</b>: %s"
-
-#, python-format
-#~ msgid ""
-#~ "No handler for this payment method. Maybe you haven't installed the "
-#~ "related Odoo module."
-#~ msgstr ""
-#~ "Sin manejador para este método de pago. Tal vez no ha instalado el módulo "
-#~ "de Odoo relacionado."
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error de entrega del SMS"
-
-#, python-format
-#~ msgid ""
-#~ "No Payment Line created for invoice %s because it already exists or "
-#~ "because this invoice is already paid."
-#~ msgstr ""
-#~ "No se ha creado línea de pago para la factura %s porque ya existe o "
-#~ "porque la factura ya está pagada."
-
-#~ msgid "Accounting Entries Options"
-#~ msgstr "Opciones de asientos contables"
-
-#~ msgid "Bank Payment Line"
-#~ msgstr "Línea de pago bancario"
-
-#~ msgid "Bank Payment Line Ref"
-#~ msgstr "Ref. de la línea de pago bancario"
-
-#~ msgid "Bank Payment Lines"
-#~ msgstr "Líneas de pago bancario"
-
-#, python-format
-#~ msgid "Debit bank line %s"
-#~ msgstr "Línea de adeudo de banco %s"
-
-#, python-format
-#~ msgid "Debit order %s"
-#~ msgstr "Orden de cobro %s"
-
-#~ msgid "Generate Accounting Entries On File Upload"
-#~ msgstr "Generar asientos contables al subir el archivo"
-
-#~ msgid "Move Option"
-#~ msgstr "Opciones de asiento"
-
-#, python-format
-#~ msgid ""
-#~ "On the payment mode '%s', you must choose an option for the 'Move Option' "
-#~ "parameter."
-#~ msgstr ""
-#~ "En el modo de pago '%s', debe escoger una opción para las 'Opciones de "
-#~ "asiento'."
-
-#~ msgid "One move per payment date"
-#~ msgstr "Un asiento por fecha de pago"
-
-#~ msgid "One move per payment line"
-#~ msgstr "Un asiento por línea de pago"
-
-#~ msgid "Order"
-#~ msgstr "Orden"
-
-#, python-format
-#~ msgid "Payment bank line %s"
-#~ msgstr "Línea de pago bancario %s"
-
-#, python-format
-#~ msgid "Payment order %s"
-#~ msgstr "Orden %s"
-
-#~ msgid "Post Move"
-#~ msgstr "Publicar movimiento"
-
-#~ msgid "Related Payment Lines"
-#~ msgstr "Líneas de pago relacionadas"
-
-#~ msgid "Search Bank Payment Lines"
-#~ msgstr "Buscar líneas de pago bancario"
-
-#~ msgid ""
-#~ "The bank payment lines are used to generate the payment file. They are "
-#~ "automatically created from transaction lines upon confirmation of the "
-#~ "payment order: one bank payment line can group several transaction lines "
-#~ "if the option 'Group Transactions in Payment Orders' is active on the "
-#~ "payment mode."
-#~ msgstr ""
-#~ "Las líneas de pago bancarias se usan para generar el archivo de pago. Se "
-#~ "crean automáticamente de las líneas de transacciones en la confirmación "
-#~ "de la orden: una línea de pago bancario puede agrupar varias líneas de "
-#~ "transacción si la opción 'Agrupar transacciones en las órdenes' está "
-#~ "activada en el modo de pago."
-
-#~ msgid "Total Amount"
-#~ msgstr "Importe total"
-
-#~ msgid "%d payment lines added to the existing draft payment order %s."
-#~ msgstr "%d líneas de pago añadidas a la orden de pago en borrador %s."
-
-#~ msgid ""
-#~ "%d payment lines added to the new draft payment order %s which has been "
-#~ "automatically created."
-#~ msgstr ""
-#~ "%d líneas de pago añadidas a una nueva orden de pago en borrador %s que "
-#~ "ha sido creada automáticamente."
-
-#~ msgid ""
-#~ "A valid BIC contains 8 or 11 characters. The BIC '%s' contains %d "
-#~ "characters, so it is not valid."
-#~ msgstr ""
-#~ "Un BIC válido contiene 8 u 11 caracteres. El BIC '%s' contiene %d "
-#~ "caracteres, por lo que no es válido."
-
-#~ msgid "Can not reconcile: no move line for payment line %s of partner '%s'."
-#~ msgstr ""
-#~ "No se puede conciliar: no hay apunte para la línea de pago %s de la "
-#~ "empresa '%s'."
-
-#~ msgid ""
-#~ "Cannot delete a payment order line whose payment order is in state '%s'. "
-#~ "You need to cancel it first."
-#~ msgstr ""
-#~ "No se puede eliminar una línea de una orden de pago cuyo estado es '%s'. "
-#~ "Primero debes cancelarla."
-
-#~ msgid "Followers (Channels)"
-#~ msgstr "Seguidores (Canales)"
-
-#~ msgid ""
-#~ "For partner '%s', the account of the account move line to pay (%s) is "
-#~ "different from the account of of the transit move line (%s)."
-#~ msgstr ""
-#~ "Para la empresa '%s', la cuenta del apunte a pagar (%s) es diferente de "
-#~ "la cuenta del apunte de tránsito (%s)."
-
-#~ msgid "Move line '%s' of partner '%s' has already been reconciled"
-#~ msgstr "El apunte '%s' de la empresa '%s' ya ha sido conciliado"
-
-#~ msgid "On payment order %s, the Payment Execution Date is in the past (%s)."
-#~ msgstr "En la orden %s, la fecha de ejecución es anterior a la actual (%s)."
-
-#~ msgid "The amount for Partner '%s' is negative or null (%.2f) !"
-#~ msgstr "El importe para el empresa '%s' es negativo o nulo (%.2f) !"
-
-#~ msgid ""
-#~ "The payment mode '%s' has the option 'Disallow Debit Before Maturity "
-#~ "Date'. The payment line %s has a maturity date %s which is after the "
-#~ "computed payment date %s."
-#~ msgstr ""
-#~ "El modo de pago '%s' tiene la opción 'No permitir adeudo antes de la "
-#~ "fecha de vencimiento'. La línea de pago %s tiene una fecha de vencimiento "
-#~ "%s que es después de la fecha de pago calculada %s."
-
-#~ msgid ""
-#~ "The payment type (%s) is not the same as the payment type of the payment "
-#~ "mode (%s)"
-#~ msgstr ""
-#~ "El tipo de pago (%s) no es el mismo que el tipo de pago del modo de pago "
-#~ "(%s)"
-
-#~ msgid "Done"
-#~ msgstr "Realizado"
-
-#~ msgid "Done Date"
-#~ msgstr "Fecha de realización"
-
-#~ msgid ""
-#~ "Journal to write payment entries when confirming payment/debit orders of "
-#~ "this mode"
-#~ msgstr ""
-#~ "Diario al que escribir los asientos contables cuando se confirme la orden "
-#~ "de cobro/pago de este modo"
-
-#~ msgid "Number of Bank Lines"
-#~ msgstr "Número de líneas bancarias"
-
-#~ msgid "Offsetting Account"
-#~ msgstr "Cuenta de compensación"
-
-#~ msgid ""
-#~ "On the payment mode '%s', you must select a value for the 'Transfer "
-#~ "Account'."
-#~ msgstr ""
-#~ "En el modo de pago '%s', debe seleccionar un valor para la 'Cuenta de "
-#~ "transferencia'."
-
-#~ msgid ""
-#~ "On the payment mode '%s', you must select a value for the 'Transfer "
-#~ "Journal'."
-#~ msgstr ""
-#~ "En el modo de pago '%s', debe seleccionar un valor para el 'Diario de "
-#~ "transferencia'."
-
-#~ msgid ""
-#~ "On the payment mode '%s', you must select an option for the 'Offsetting "
-#~ "Account' parameter"
-#~ msgstr ""
-#~ "En el modo de pago '%s', debe seleccionar una opción para el parámetro "
-#~ "'Cuenta de compensación'"
-
-#~ msgid ""
-#~ "Pay off lines in 'file uploaded' payment orders with a move on this "
-#~ "account. You can only select accounts that are marked for reconciliation"
-#~ msgstr ""
-#~ "Las líneas de pago de la orden se conciliarán en la 'subida de archivo' "
-#~ "con un apunte a esta cuenta. Sólo puede seleccionar las cuentas que están "
-#~ "marcadas para conciliación"
-
-#~ msgid "Transaction Lines"
-#~ msgstr "Líneas de transacción"
-
-#~ msgid "Transfer Account"
-#~ msgstr "Cuenta de transferencia"
-
-#~ msgid "Transfer Journal"
-#~ msgstr "Diario de transferencia"
-
-#~ msgid "Transfer Journal Entries"
-#~ msgstr "Asientos de transferencia"
-
-#~ msgid "Due date"
-#~ msgstr "Fecha de vencimiento"
-
-#~ msgid "ISO"
-#~ msgstr "ISO"
-
-#~ msgid "Invoice"
-#~ msgstr "Factura"
-
-#~ msgid "No Journal Entry on invoice %s"
-#~ msgstr "No se ha encontrado asiento en la factura %s"
-
-#~ msgid "Payment Order / Payment"
-#~ msgstr "Orden de Pago / Pago"
-
-#~ msgid "Account Entry"
-#~ msgstr "Asiento contable"
-
-#~ msgid "report.account_payment_order.print_account_payment_order_main"
-#~ msgstr "report.account_payment_order.print_account_payment_order_main"

--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ACSONE SA/NV
 # Copyright 2022 Tecnativa - Pedro M. Baeza
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -47,3 +48,16 @@ class AccountPayment(models.Model):
                     and pay.available_payment_method_line_ids.code == "manual"
                 )
         return res
+
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None):
+        """Overwrite date_maturity of the move_lines that are generated when related
+        to a payment order and a specific configuration.
+        """
+        vals_list = super()._prepare_move_line_default_vals(
+            write_off_line_vals=write_off_line_vals
+        )
+        payment_mode = self.payment_order_id.payment_mode_id
+        if payment_mode.transfer_date_option == "now_date_maturity":
+            for vals in vals_list:
+                vals["date_maturity"] = self.payment_line_ids[0].date
+        return vals_list

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -181,6 +181,7 @@ class AccountPaymentLine(models.Model):
         payment lines.
         """
         journal = self.order_id.journal_id
+        payment_mode = self.order_id.payment_mode_id
         vals = {
             "payment_type": self.order_id.payment_type,
             "partner_id": self.partner_id.id,
@@ -196,14 +197,13 @@ class AccountPaymentLine(models.Model):
             "payment_order_id": self.order_id.id,
             "payment_line_ids": [(6, 0, self.ids)],
         }
+        # Set today according to transfer_date_option
+        if payment_mode.transfer_date_option == "now_date_maturity":
+            vals["date"] = fields.Date.today()
         # Determine payment method line according payment method and journal
         line = self.env["account.payment.method.line"].search(
             [
-                (
-                    "payment_method_id",
-                    "=",
-                    self.order_id.payment_mode_id.payment_method_id.id,
-                ),
+                ("payment_method_id", "=", payment_mode.payment_method_id.id),
                 ("journal_id", "=", journal.id),
             ],
             limit=1,

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -56,6 +56,14 @@ class AccountPaymentMode(models.Model):
         ],
         string="Default Payment Execution Date",
     )
+    transfer_date_option = fields.Selection(
+        selection=[
+            ("payment_date", "Payment date"),
+            ("now_date_maturity", "Now + Payment date as due date"),
+        ],
+        default="payment_date",
+        string="Transfer moves dates",
+    )
     group_lines = fields.Boolean(
         string="Group Transactions in Payment Orders",
         default=True,

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -1,9 +1,11 @@
 # Copyright 2017 Camptocamp SA
 # Copyright 2017 Creu Blanca
 # Copyright 2019-2022 Tecnativa - Pedro M. Baeza
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from datetime import date, timedelta
+
+from freezegun import freeze_time
 
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
@@ -148,3 +150,49 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment_order.cancel2draft()
         payment_order.unlink()
         self.assertEqual(len(self.payment_order_obj.search(self.domain)), 0)
+
+    @freeze_time("2024-04-01")
+    def test_creation_transfer_move_date_01(self):
+        self.inbound_mode.write({"transfer_date_option": "payment_date"})
+        self.inbound_order.date_prefered = "fixed"
+        self.inbound_order.date_scheduled = "2024-06-01"
+        self.inbound_order.draft2open()
+        payment_move = self.inbound_order.payment_ids.move_id
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )
+        self.assertEqual(self.inbound_order.payment_count, 1)
+        self.inbound_order.open2generated()
+        self.inbound_order.generated2uploaded()
+        self.assertEqual(self.inbound_order.state, "uploaded")
+        payment_move = self.inbound_order.payment_ids.move_id
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )
+
+    @freeze_time("2024-04-01")
+    def test_creation_transfer_move_date_02(self):
+        self.inbound_mode.write({"transfer_date_option": "now_date_maturity"})
+        self.inbound_order.date_prefered = "fixed"
+        self.inbound_order.date_scheduled = "2024-06-01"
+        self.inbound_order.draft2open()
+        payment_move = self.inbound_order.payment_ids.move_id
+        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )
+        self.assertEqual(self.inbound_order.payment_count, 1)
+        self.inbound_order.open2generated()
+        self.inbound_order.generated2uploaded()
+        self.assertEqual(self.inbound_order.state, "uploaded")
+        payment_move = self.inbound_order.payment_ids.move_id
+        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -19,6 +19,7 @@
                         attrs="{'invisible': ['|', ('payment_type', '!=', 'inbound'), ('payment_order_ok', '!=', True)]}"
                     />
                     <field name="default_date_prefered" />
+                    <field name="transfer_date_option" />
                     <field name="group_lines" />
                 </group>
                 <group


### PR DESCRIPTION
Add Default Tranfer Move Date configuration

Options:
- **Payment date**: Set the payment date in the transfer entry (similar to the existing so far).
- **Now + Payment due date**: Set now date the payment date in the transfer entry and t he corresponding due date in journal items.

![ejemplo](https://github.com/OCA/bank-payment/assets/4117568/e1523736-5234-4863-9be1-65976a4c15e0)

Please @pedrobaeza  @carlosdauden and @sergio-teruel can you review it?

@Tecnativa TT49582