### PR TITLE
[17.0] [IMP] account_payment_purchase: let indivual partners have bank accounts in puchase

### DIFF
--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -15,7 +15,7 @@ class PurchaseOrder(models.Model):
         store=True,
         precompute=True,
         string="Supplier Bank Account",
-        domain="[('partner_id', '=', partner_id),"
+        domain="[('partner_id', 'parent_of', partner_id),"
         "('company_id', 'in', [False, company_id])]",
         check_company=True,
         help="Select the bank account of your supplier on which your company "


### PR DESCRIPTION
In the vendor bills of the base account module you can select any bank account that belongs to the vendor company, even if the selected vendor is an individual contact of the company. 

I think that the bank account field in the purchase should behave the same way. Currently you can not select a bank account if the selected vendor is an individual.

Links of account module:

https://github.com/odoo/odoo/blob/1df4efd64c353bbc6b21f01b7ef12308bdfc9780/addons/account/models/account_move.py#L333
https://github.com/odoo/odoo/blob/1df4efd64c353bbc6b21f01b7ef12308bdfc9780/addons/account/views/account_move_views.xml#L937
https://github.com/odoo/odoo/blob/1df4efd64c353bbc6b21f01b7ef12308bdfc9780/addons/account/models/account_move.py#L1406

T-6102