### PR TITLE
[15.0][IMP] account_payment_order: Integrate Default Tranfer Move Date option (now_date_maturity)

### DIFF
--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -51,13 +51,13 @@ class AccountPayment(models.Model):
 
     def _prepare_move_line_default_vals(self, write_off_line_vals=None):
         """Overwrite date_maturity of the move_lines that are generated when related
-        to a payment order and a specific configuration.
+        to a payment order.
         """
         vals_list = super()._prepare_move_line_default_vals(
             write_off_line_vals=write_off_line_vals
         )
-        payment_mode = self.payment_order_id.payment_mode_id
-        if payment_mode.transfer_date_option == "now_date_maturity":
-            for vals in vals_list:
-                vals["date_maturity"] = self.payment_line_ids[0].date
+        if not self.payment_order_id:
+            return vals_list
+        for vals in vals_list:
+            vals["date_maturity"] = self.payment_line_ids[0].date
         return vals_list

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -188,7 +188,7 @@ class AccountPaymentLine(models.Model):
             "destination_account_id": self.move_line_id.account_id.id,
             "company_id": self.order_id.company_id.id,
             "amount": sum(self.mapped("amount_currency")),
-            "date": self[:1].date,
+            "date": fields.Date.today(),
             "currency_id": self.currency_id.id,
             "ref": self.order_id.name,
             "payment_reference": " - ".join([line.communication for line in self]),
@@ -197,9 +197,6 @@ class AccountPaymentLine(models.Model):
             "payment_order_id": self.order_id.id,
             "payment_line_ids": [(6, 0, self.ids)],
         }
-        # Set today according to transfer_date_option
-        if payment_mode.transfer_date_option == "now_date_maturity":
-            vals["date"] = fields.Date.today()
         # Determine payment method line according payment method and journal
         line = self.env["account.payment.method.line"].search(
             [

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -56,14 +56,6 @@ class AccountPaymentMode(models.Model):
         ],
         string="Default Payment Execution Date",
     )
-    transfer_date_option = fields.Selection(
-        selection=[
-            ("payment_date", "Payment date"),
-            ("now_date_maturity", "Now + Payment date as due date"),
-        ],
-        default="payment_date",
-        string="Transfer moves dates",
-    )
     group_lines = fields.Boolean(
         string="Group Transactions in Payment Orders",
         default=True,

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -152,31 +152,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.assertEqual(len(self.payment_order_obj.search(self.domain)), 0)
 
     @freeze_time("2024-04-01")
-    def test_creation_transfer_move_date_01(self):
-        self.inbound_mode.write({"transfer_date_option": "payment_date"})
-        self.inbound_order.date_prefered = "fixed"
-        self.inbound_order.date_scheduled = "2024-06-01"
-        self.inbound_order.draft2open()
-        payment_move = self.inbound_order.payment_ids.move_id
-        self.assertEqual(payment_move.date, date(2024, 6, 1))
-        self.assertEqual(
-            payment_move.line_ids.mapped("date_maturity"),
-            [date(2024, 6, 1), date(2024, 6, 1)],
-        )
-        self.assertEqual(self.inbound_order.payment_count, 1)
-        self.inbound_order.open2generated()
-        self.inbound_order.generated2uploaded()
-        self.assertEqual(self.inbound_order.state, "uploaded")
-        payment_move = self.inbound_order.payment_ids.move_id
-        self.assertEqual(payment_move.date, date(2024, 6, 1))
-        self.assertEqual(
-            payment_move.line_ids.mapped("date_maturity"),
-            [date(2024, 6, 1), date(2024, 6, 1)],
-        )
-
-    @freeze_time("2024-04-01")
-    def test_creation_transfer_move_date_02(self):
-        self.inbound_mode.write({"transfer_date_option": "now_date_maturity"})
+    def test_creation_transfer_move_date(self):
         self.inbound_order.date_prefered = "fixed"
         self.inbound_order.date_scheduled = "2024-06-01"
         self.inbound_order.draft2open()

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -342,8 +342,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         outbound_order.draft2open()
         self.assertEqual(outbound_order.payment_count, 2)
         self.assertEqual(
-            outbound_order.payment_line_ids[0].date,
-            outbound_order.payment_line_ids[0].payment_ids.date,
+            outbound_order.payment_line_ids[0].payment_ids.date, fields.Date.today()
         )
         self.assertEqual(outbound_order.payment_line_ids[1].date, date.today())
         self.assertEqual(

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -19,7 +19,6 @@
                         attrs="{'invisible': ['|', ('payment_type', '!=', 'inbound'), ('payment_order_ok', '!=', True)]}"
                     />
                     <field name="default_date_prefered" />
-                    <field name="transfer_date_option" />
                     <field name="group_lines" />
                 </group>
                 <group


### PR DESCRIPTION
Integrate Default Tranfer Move Date option (now_date_maturity)

Related to https://github.com/OCA/bank-payment/pull/1289

In v13 the existing behavior was defined with today's date the Transfer Move, therefore, we define that behavior by default without configuration since it is the expected behavior.

https://github.com/OCA/bank-payment/pull/805/files

@Tecnativa TT49582