### PR TITLE
[16.0][FIX] account_payment_mode: do not propose an electronic payment method when creating a journal if it has already been assigned

### DIFF
--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import config
 
 
 class AccountJournal(models.Model):
@@ -28,7 +29,40 @@ class AccountJournal(models.Model):
                 ("code", "not in", unique_codes),  # filter out unique codes
             ]
         )
-        return all_in
+        # 'electronic' are linked to a single journal per company per provider.
+        electronic_codes = [
+            code
+            for code, info in method_info.items()
+            if info.get("mode") == "electronic"
+        ]
+        if config["test_enable"]:
+            # This is a hack to be able to test the electronic payment methods,
+            # as they are defined when you install the account_payment module,
+            # but the restrictions on electronic codes live in the account module.
+            test_code = self.env.context.get("electronic_code", False)
+            if test_code:
+                electronic_codes.append(test_code)
+        electronic_codes = tuple(electronic_codes)
+        electronic_methods = self.env["account.payment.method"].search(
+            [
+                ("payment_type", "=", "inbound"),
+                ("code", "in", electronic_codes),  # filter out unique codes
+            ]
+        )
+        electronic_method_lines_already_assigned = self.env[
+            "account.payment.method.line"
+        ].search(
+            [
+                ("payment_method_id", "in", electronic_methods.ids),
+                ("journal_id.company_id", "=", self.company_id.id),
+                ("journal_id", "!=", self.id),
+            ]
+        )
+        electronic_methods_already_assigned = (
+            electronic_method_lines_already_assigned.mapped("payment_method_id")
+        )
+        res = all_in - electronic_methods_already_assigned
+        return res
 
     @api.constrains("company_id")
     def company_id_account_payment_mode_constrains(self):

--- a/account_payment_mode/tests/test_account_payment_mode.py
+++ b/account_payment_mode/tests/test_account_payment_mode.py
@@ -131,3 +131,49 @@ class TestAccountPaymentMode(TransactionCase):
                     "fixed_journal_id": self.journal_c1.id,
                 }
             )
+
+    def test_electronic_payment_methods_proposed_once(self):
+        """Test that we cannot assign the same payment method when it's electronic
+        to two journals of the same company."""
+        method = (
+            self.env["account.payment.method"]
+            .sudo()
+            .create(
+                {
+                    "name": "Electornic method",
+                    "code": "electronic_method",
+                    "payment_type": "inbound",
+                }
+            )
+        )
+        # We call with context variable electronic_code because by default because
+        # we want to force that this payment method is considered electronic during testing,
+        # even when it's not. The electronic mode is defaulted in the account_payment
+        # module, but the restrictions for this mode live in the account module.
+        journal_model = self.journal_model.with_context(
+            electronic_code="electronic_method"
+        )
+        journal_c1_1 = journal_model.create(
+            {
+                "name": "J1_1",
+                "code": "J1_1",
+                "type": "bank",
+                "company_id": self.company.id,
+            }
+        )
+        self.assertIn(
+            method,
+            journal_c1_1.inbound_payment_method_line_ids.mapped("payment_method_id"),
+        )
+        journal_c1_2 = journal_model.create(
+            {
+                "name": "J1_2",
+                "code": "J1_2",
+                "type": "bank",
+                "company_id": self.company.id,
+            }
+        )
+        self.assertNotIn(
+            method,
+            journal_c1_2.inbound_payment_method_line_ids.mapped("payment_method_id"),
+        )


### PR DESCRIPTION
Previously, when you tried to install this module and the module payment_authorize at the same time, an error would raise because payment_authorize creates an electronic payment method, that is then assigned to the cash and bank accounts when the chart of accounts is loaded, resulting in an error.