### PR TITLE
[15.0][FIX] account_payment_order: Apply readonly=True to Payment Date field of transactions

### DIFF
--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -18,11 +18,7 @@
                         />
                         <!-- we removed the filter on amount_to_pay, because we want to be able to select refunds -->
                         <field name="state" invisible="1" />
-                        <field
-                            name="date"
-                            attrs="{'readonly': [('state', '!=', 'confirmed')]}"
-                            force_save="1"
-                        />
+                        <field name="date" readonly="1" force_save="1" />
                         <field name="ml_maturity_date" readonly="1" />
                         <field name="amount_currency" />
                         <field name="currency_id" />


### PR DESCRIPTION
Apply readonly=True to Payment Date field of transactions

Transactions (`payment_line_ids`) are readonly=True when the payment order is confirmed

@Tecnativa