### PR TITLE
[16.0][IMP] account_payment_order: Apply readonly=True to Payment Date field of transactions

### DIFF
--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -19,7 +19,7 @@
                             domain="[('reconciled','=', False), ('account_id.reconcile', '=', True)] "
                         />
                         <!-- we removed the filter on amount_to_pay, because we want to be able to select refunds -->
-                        <field name="date" />
+                        <field name="date" readonly="1" force_save="1" />
                         <field name="ml_maturity_date" readonly="1" />
                         <field name="amount_currency" />
                         <field name="currency_id" />


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/bank-payment/pull/1296 + https://github.com/OCA/bank-payment/pull/1299

Apply readonly=True to Payment Date field of transactions

Transactions (`payment_line_ids`) are readonly=True when the payment order is confirmed

@Tecnativa