### PR TITLE
[14.0][IMP] account_payment_sale: Add payment mode in invoicing grouping criteria

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -40,3 +40,14 @@ class SaleOrder(models.Model):
         vals = super()._prepare_invoice()
         self._get_payment_mode_vals(vals)
         return vals
+
+    @api.model
+    def _get_invoice_grouping_keys(self) -> list:
+        """
+        When several sale orders are generating invoices,
+        we want to add the payment mode in grouping criteria.
+        """
+        keys = super()._get_invoice_grouping_keys()
+        if "payment_mode_id" not in keys:
+            keys.append("payment_mode_id")
+        return keys

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -96,3 +96,22 @@ class TestSaleOrder(CommonTestCase):
         self.assertEqual(len(invoice), 1)
         self.assertEqual(invoice.payment_mode_id, self.payment_mode_2)
         self.assertFalse(invoice.partner_bank_id)
+
+    def test_several_sale_to_invoice_payment_mode(self):
+        """
+        Data:
+            A partner with a specific payment_mode
+            A sale order created with the payment_mode of the partner
+            A sale order created with another payment mode
+        Test case:
+            Create the invoice from the sale orders
+        Expected result:
+            Two invoices should be generated
+        """
+        payment_mode_2 = self.env.ref("account_payment_mode.payment_mode_outbound_dd1")
+        order_1 = self.create_sale_order()
+        order_2 = self.create_sale_order(payment_mode_2)
+        orders = order_1 | order_2
+        orders.action_confirm()
+        invoices = orders._create_invoices()
+        self.assertEqual(2, len(invoices))


### PR DESCRIPTION
Backport of https://github.com/OCA/bank-payment/pull/1246
Before merging let's check if we have the same problem mentioned in https://github.com/OCA/bank-payment/pull/1268