### PR TITLE
[17.0][FIX] account_payment_mode: error when payment mode

### DIFF
--- a/account_payment_mode/models/account_journal.py
+++ b/account_payment_mode/models/account_journal.py
@@ -19,8 +19,13 @@ class AccountJournal(models.Model):
         method_info = self.env[
             "account.payment.method"
         ]._get_payment_method_information()
+        allowed_modes = ["unique"]
+        if "payment_provider_id" in self.env["account.payment.method.line"]._fields:
+            allowed_modes.append("electronic")
         unique_codes = tuple(
-            code for code, info in method_info.items() if info.get("mode") == "unique"
+            code
+            for code, info in method_info.items()
+            if info.get("mode") in allowed_modes
         )
         all_in = self.env["account.payment.method"].search(
             [


### PR DESCRIPTION
When installing `account_payment_mode` and a provider together, we have an error linked to a duplicate payment method : 

```
  File "/odoo/src/addons/account/models/account_payment_method.py", line 141, in _ensure_unique_name_for_journal
    self.journal_id._check_payment_method_line_ids_multiplicity()
  File "/odoo/src/addons/account/models/account_journal.py", line 540, in _check_payment_method_line_ids_multiplicity
    raise ValidationError(_(
odoo.exceptions.ValidationError: Some payment methods supposed to be unique already exists somewhere else.
(Stripe)
```

https://github.com/OCA/bank-payment/issues/977

This error is linked to `account_payment_mode` and it was considered fixed here: https://github.com/OCA/bank-payment/pull/1093 but the problem is still there: https://github.com/OCA/bank-payment/issues/1283

But now odoo is checking by `account.payment.method` mode `unique` or `electronic`, so both need to be "unique".

https://github.com/odoo/odoo/commit/d07a6969903705f5676cc3052c3fba78bdf76f45

So here I'm adapting the code to follow this logic.

I've found this PR for v16.0 (https://github.com/OCA/bank-payment/pull/1298) and I really don't know the best solution.
