### PR TITLE
[16.0][FIX] account_payment_order: add missing option "structured" to payment line reference type

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -51,9 +51,7 @@ class AccountMove(models.Model):
         """Retrieve the communication string for this direct item."""
         communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
-            if (self.reference_type or "none") != "none":
-                communication = self.ref
-            elif self.is_purchase_document():
+            if self.is_purchase_document():
                 communication = self.ref or self.payment_reference
             else:
                 communication = self.payment_reference or self.name

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -78,7 +78,9 @@ class AccountPaymentLine(models.Model):
         required=False, help="Label of the payment that will be seen by the destinee"
     )
     communication_type = fields.Selection(
-        selection=[("normal", "Free")], required=True, default="normal"
+        selection=[("normal", "Free"), ("structured", "Structured")],
+        required=True,
+        default="normal",
     )
     payment_ids = fields.Many2many(
         comodel_name="account.payment",

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -77,6 +77,7 @@ class TestPaymentOrderInboundBase(AccountTestInvoicingCommon):
                 invoice_line_form.price_unit = 100.0
                 invoice_line_form.account_id = self.invoice_line_account
                 invoice_line_form.tax_ids.clear()
+        invoice_form.reference_type = "structured"
         invoice = invoice_form.save()
         invoice_form = Form(invoice)
         invoice_form.payment_mode_id = self.inbound_mode


### PR DESCRIPTION
The payment line reference type takes its value from the invoice reference type, and both fields must have the same options.
The missing option "structured" causes a bug during payment creation.