### PR TITLE
[17.0][IMP] account_payment_order*: Define the correct date in the files that are generated

### DIFF
--- a/account_banking_sepa_credit_transfer/models/account_payment_order.py
+++ b/account_banking_sepa_credit_transfer/models/account_payment_order.py
@@ -83,11 +83,8 @@ class AccountPaymentOrder(models.Model):
             priority = payment_line.priority
             local_instrument = payment_line.local_instrument
             categ_purpose = payment_line.category_purpose
-            # The field line.date is the requested payment date
-            # taking into account the 'date_prefered' setting
-            # cf account_banking_payment_export/models/account_payment.py
-            # in the inherit of action_open()
-            key = (line.date, priority, local_instrument, categ_purpose)
+            # The field line.payment_line_date is the requested payment date
+            key = (line.payment_line_date, priority, local_instrument, categ_purpose)
             if key in lines_per_group:
                 lines_per_group[key].append(line)
             else:

--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -93,11 +93,8 @@ class AccountPaymentOrder(models.Model):
                     )
                     % payment_line.mandate_id.unique_mandate_reference
                 )
-            # The field line.date is the requested payment date
-            # taking into account the 'date_preferred' setting
-            # cf account_banking_payment_export/models/account_payment.py
-            # in the inherit of action_open()
-            key = (line.date, priority, categ_purpose, seq_type, scheme)
+            # The field line.payment_line_date is the requested payment date
+            key = (line.payment_line_date, priority, categ_purpose, seq_type, scheme)
             if key in lines_per_group:
                 lines_per_group[key].append(line)
             else:

--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -15,6 +15,7 @@ class AccountPayment(models.Model):
     order_state = fields.Selection(
         related="payment_order_id.state", string="Payment Order State"
     )
+    payment_line_date = fields.Date(compute="_compute_payment_line_date")
 
     @api.depends("payment_type", "journal_id")
     def _compute_payment_method_line_fields(self):
@@ -38,6 +39,11 @@ class AccountPayment(models.Model):
                     )
                 )
         return res
+
+    @api.depends("payment_line_ids", "payment_line_ids.date")
+    def _compute_payment_line_date(self):
+        for item in self:
+            item.payment_line_date = item.payment_line_ids[:1].date
 
     def update_payment_reference(self):
         view = self.env.ref("account_payment_order.account_payment_update_view_form")

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -135,11 +135,13 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.assertEqual(len(self.payment_order_obj.search(self.domain)), 0)
 
     @freeze_time("2024-04-01")
-    def test_creation_transfer_move_date(self):
+    def test_creation_transfer_move_date_01(self):
         self.inbound_order.date_prefered = "fixed"
         self.inbound_order.date_scheduled = "2024-06-01"
         self.inbound_order.draft2open()
-        payment_move = self.inbound_order.payment_ids.move_id
+        payment = self.inbound_order.payment_ids
+        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
+        payment_move = payment.move_id
         self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
@@ -149,7 +151,35 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.inbound_order.open2generated()
         self.inbound_order.generated2uploaded()
         self.assertEqual(self.inbound_order.state, "uploaded")
-        payment_move = self.inbound_order.payment_ids.move_id
+        payment = self.inbound_order.payment_ids
+        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
+        payment_move = payment.move_id
+        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )
+
+    @freeze_time("2024-04-01")
+    def test_creation_transfer_move_date_02(self):
+        # Simulate that the invoice had a different due date
+        self.inbound_order.payment_line_ids.ml_maturity_date = "2024-06-01"
+        self.inbound_order.draft2open()
+        payment = self.inbound_order.payment_ids
+        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
+        payment_move = payment.move_id
+        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(
+            payment_move.line_ids.mapped("date_maturity"),
+            [date(2024, 6, 1), date(2024, 6, 1)],
+        )
+        self.assertEqual(self.inbound_order.payment_count, 1)
+        self.inbound_order.open2generated()
+        self.inbound_order.generated2uploaded()
+        self.assertEqual(self.inbound_order.state, "uploaded")
+        payment = self.inbound_order.payment_ids
+        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
+        payment_move = payment.move_id
         self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/bank-payment/pull/1315

Define the correct date in the files that are generated.

Compatibility with https://github.com/OCA/bank-payment/pull/1306

The payment (`account.payment`) and the account entry (`account.move`) are defined with today's date, but the "_important_" date is the date of the line, therefore the `payment_line_date` field is created.

The modules `account_banking_sepa_sepa_direct_debit` + `account_banking_sepa_credit_transfer` to use the payment_line_date field.

The modules `l10n_es_payment_order_confirming_aef` + `l10n_es_payment_order_confirming_sabadell` of OCA/l10n-spain do not need these changes because they do not use `payment_ids`.

Please @pedrobaeza can you review it?

@Tecnativa TT49988