### PR TITLE
[14.0][FIX] account_payment_order: out of index date

### DIFF
--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -61,5 +61,5 @@ class AccountPayment(models.Model):
         if not self.payment_order_id:
             return vals_list
         for vals in vals_list:
-            vals["date_maturity"] = self.payment_line_ids[0].date
+            vals["date_maturity"] = self.payment_line_ids[:1].date
         return vals_list


### PR DESCRIPTION
If we had a payment order with no lines we'll be getting an index error. Better to avoid it having an empty recordset.

cc @Tecnativa 

please check @pedrobaeza 