### PR TITLE
[17.0][IMP] account_banking_mandate: Set sequence when creating a mandate with empty mandate reference

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -175,8 +175,7 @@ class AccountBankingMandate(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            unique_mandate_reference = vals.get("unique_mandate_reference", "/")
-            if unique_mandate_reference == "/":
+            if (vals.get("unique_mandate_reference") or "/") == "/":
                 vals["unique_mandate_reference"] = (
                     self.env["ir.sequence"].next_by_code("account.banking.mandate")
                     or "New"

--- a/account_banking_mandate/tests/test_mandate.py
+++ b/account_banking_mandate/tests/test_mandate.py
@@ -171,3 +171,28 @@ class TestMandate(TransactionCase):
             }
         )
         self.assertTrue(mandate.unique_mandate_reference)
+
+    def test_mandate_reference_06(self):
+        """
+        Test case: create a mandate with False as reference (empty with UX)
+        Expected result: the reference of the created mandate is not False
+        """
+        bank_account = self.env.ref("account_payment_mode.res_partner_12_iban")
+        mandate_1 = self.env["account.banking.mandate"].create(
+            {
+                "partner_bank_id": bank_account.id,
+                "signature_date": "2015-01-01",
+                "company_id": self.company.id,
+                "unique_mandate_reference": False,
+            }
+        )
+        self.assertTrue(mandate_1.unique_mandate_reference)
+        mandate_2 = self.env["account.banking.mandate"].create(
+            {
+                "partner_bank_id": bank_account.id,
+                "signature_date": "2015-01-01",
+                "company_id": self.company.id,
+                "unique_mandate_reference": "",
+            }
+        )
+        self.assertTrue(mandate_2.unique_mandate_reference)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/bank-payment/pull/1324

Set sequence when creating a mandate with empty mandate reference

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT50317