### PR TITLE
[17.0][FIX] account_payment_purchase: copy the fields to supplier invoices.

### DIFF
--- a/account_payment_purchase/models/account_move.py
+++ b/account_payment_purchase/models/account_move.py
@@ -10,17 +10,20 @@ class AccountMove(models.Model):
 
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
     def _onchange_purchase_auto_complete(self):
-        new_mode = (
-            self.purchase_vendor_bill_id.purchase_order_id.payment_mode_id.id
-            or self.purchase_id.payment_mode_id.id
-        )
-        new_bank = (
-            self.purchase_vendor_bill_id.purchase_order_id.supplier_partner_bank_id.id
-            or self.purchase_id.supplier_partner_bank_id.id
-        )
+        old_mode = self.payment_mode_id.id
+        old_bank = self.partner_bank_id.id
+        purchase_id = self.purchase_vendor_bill_id.purchase_order_id or self.purchase_id
+        if purchase_id:
+            new_invoice_vals = purchase_id.with_company(
+                purchase_id.company_id
+            )._prepare_invoice()
+            new_mode = new_invoice_vals.get("payment_mode_id", False)
+            new_bank = new_invoice_vals.get("partner_bank_id", False)
+        else:
+            new_mode = new_bank = False
 
         res = super()._onchange_purchase_auto_complete() or {}
-        if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
+        if old_mode and new_mode and old_mode != new_mode:
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different payment mode."),
@@ -28,12 +31,11 @@ class AccountMove(models.Model):
             return res
         elif self.payment_mode_id.id != new_mode:
             self.payment_mode_id = new_mode
-        if self.partner_bank_id and new_bank and self.partner_bank_id.id != new_bank:
+        if old_bank and new_bank and old_bank != new_bank:
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different supplier bank."),
             }
-            return res
         elif self.partner_bank_id.id != new_bank:
             self.partner_bank_id = new_bank
         return res


### PR DESCRIPTION
The account_payment_purchase says that the new fields (Bank Account and Payment Mode) are copied from partner to purchase order, but they are not.

This PR fixes it, but respecting the constrains of the compute of account_payment_partner, the payment mode has to require a bank account to copy the bank account. (Related with #1303)

I have added this constraint to the compute of the bank_account_id of the purchase, but it can be manually edited.

I have also adapted the _onchange_purchase_auto_complete to use the new function.

T-6102