### PR TITLE
[16.0][FIX] account_payment_order: Fix inconsistency between payment line and account payment date

### DIFF
--- a/account_banking_mandate_contact/tests/test_account_payment_order.py
+++ b/account_banking_mandate_contact/tests/test_account_payment_order.py
@@ -96,7 +96,9 @@ class TestAccountPaymentOrder(TransactionCase):
     def test_invoice_payment_mode(self):
         self.assertEqual(self.invoice.state, "posted")
         self.assertEqual(self.invoice.payment_mode_id, self.payment_core)
-        self.assertEqual(self.invoice.invoice_date_due, fields.Date.today())
+        self.assertEqual(
+            self.invoice.invoice_date_due, fields.Date.context_today(self.invoice)
+        )
 
     def test_account_payment_order_core(self):
         line_create_form = Form(
@@ -105,7 +107,7 @@ class TestAccountPaymentOrder(TransactionCase):
             )
         )
         line_create_form.date_type = "due"
-        line_create_form.due_date = fields.Date.today()
+        line_create_form.due_date = fields.Date.context_today(self.payment_order)
         line_create = line_create_form.save()
         line_create.populate()
         line_create.create_payment_lines()
@@ -123,7 +125,7 @@ class TestAccountPaymentOrder(TransactionCase):
             )
         )
         line_create_form.date_type = "due"
-        line_create_form.due_date = fields.Date.today()
+        line_create_form.due_date = fields.Date.context_today(self.payment_order)
         line_create = line_create_form.save()
         line_create.populate()
         line_create.create_payment_lines()

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -189,13 +189,16 @@ class AccountPaymentLine(models.Model):
         """
         journal = self.order_id.journal_id
         payment_mode = self.order_id.payment_mode_id
+        date = fields.Date.today()
+        if self.filtered("date"):
+            date = min(self.filtered("date").mapped("date"))
         vals = {
             "payment_type": self.order_id.payment_type,
             "partner_id": self.partner_id.id,
             "destination_account_id": self.move_line_id.account_id.id,
             "company_id": self.order_id.company_id.id,
             "amount": sum(self.mapped("amount_currency")),
-            "date": fields.Date.today(),
+            "date": date,
             "currency_id": self.currency_id.id,
             "ref": self.order_id.name,
             # Put the name as the wildcard for forcing a unique name. If not, Odoo gets

--- a/account_payment_order/readme/CONTRIBUTORS.rst
+++ b/account_payment_order/readme/CONTRIBUTORS.rst
@@ -12,6 +12,7 @@
 * Jose María Alzaga <jose.alzaga@aselcis.com>
 * Meyomesse Gilles <meyomesse.gilles@gmail.com>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 
 * `DynApps <https://www.dynapps.be>`_:
 

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -165,7 +165,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment = self.inbound_order.payment_ids
         self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
         payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
             [date(2024, 6, 1), date(2024, 6, 1)],
@@ -177,7 +177,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment = self.inbound_order.payment_ids
         self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
         payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
             [date(2024, 6, 1), date(2024, 6, 1)],
@@ -191,7 +191,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment = self.inbound_order.payment_ids
         self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
         payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
             [date(2024, 6, 1), date(2024, 6, 1)],
@@ -203,7 +203,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         payment = self.inbound_order.payment_ids
         self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
         payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        self.assertEqual(payment_move.date, date(2024, 6, 1))
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
             [date(2024, 6, 1), date(2024, 6, 1)],

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -344,13 +344,14 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         )
         self.assertEqual(len(outbound_order.payment_line_ids), 0)
         # Create a manual payment order line with custom date
+        payment_date = date.today() + timedelta(days=8)
         vals = {
             "order_id": outbound_order.id,
             "partner_id": self.partner.id,
             "communication": "manual line and manual date",
             "currency_id": outbound_order.payment_mode_id.company_id.currency_id.id,
             "amount_currency": 192.38,
-            "date": date.today() + timedelta(days=8),
+            "date": payment_date,
         }
         self.env["account.payment.line"].create(vals)
         self.assertEqual(len(outbound_order.payment_line_ids), 1)
@@ -373,7 +374,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         outbound_order.draft2open()
         self.assertEqual(outbound_order.payment_count, 2)
         self.assertEqual(
-            outbound_order.payment_line_ids[0].payment_ids.date, fields.Date.today()
+            outbound_order.payment_line_ids[0].payment_ids.date, payment_date
         )
         self.assertEqual(outbound_order.payment_line_ids[1].date, date.today())
         self.assertEqual(


### PR DESCRIPTION
The payment line date contains the scheduled payment execution date, but the account payment is created with the current date as the payment date. This causes the execution date (ReqdColltnDt) in the XML file to be incorrect.

This PR fixes the account payment date by setting it to the scheduled date from the payment line.

![image](https://github.com/user-attachments/assets/d6046887-76dc-4981-ab1d-9f62817be62a)
