### PR TITLE
[14.0][IMP] account_payment_order: Fix dates in payments

### DIFF
--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -50,16 +50,3 @@ class AccountPayment(models.Model):
     def _compute_payment_line_date(self):
         for item in self:
             item.payment_line_date = item.payment_line_ids[:1].date
-
-    def _prepare_move_line_default_vals(self, write_off_line_vals=None):
-        """Overwrite date_maturity of the move_lines that are generated when related
-        to a payment order.
-        """
-        vals_list = super()._prepare_move_line_default_vals(
-            write_off_line_vals=write_off_line_vals
-        )
-        if not self.payment_order_id:
-            return vals_list
-        for vals in vals_list:
-            vals["date_maturity"] = self.payment_line_ids[:1].date
-        return vals_list

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -187,7 +187,7 @@ class AccountPaymentLine(models.Model):
             "destination_account_id": self.move_line_id.account_id.id,
             "company_id": self.order_id.company_id.id,
             "amount": sum(self.mapped("amount_currency")),
-            "date": fields.Date.today(),
+            "date": self[:1].date,
             "currency_id": self.currency_id.id,
             "ref": self.order_id.name,
             "payment_reference": " - ".join([line.communication for line in self]),

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -145,14 +145,11 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.assertEqual(len(self.payment_order_obj.search(self.domain)), 0)
 
     @freeze_time("2024-04-01")
-    def test_creation_transfer_move_date_01(self):
+    def test_creation_transfer_move_date(self):
         self.inbound_order.date_prefered = "fixed"
         self.inbound_order.date_scheduled = "2024-06-01"
         self.inbound_order.draft2open()
-        payment = self.inbound_order.payment_ids
-        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
-        payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
+        payment_move = self.inbound_order.payment_ids.move_id
         self.assertEqual(
             payment_move.line_ids.mapped("date_maturity"),
             [date(2024, 6, 1), date(2024, 6, 1)],
@@ -161,37 +158,4 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
         self.inbound_order.open2generated()
         self.inbound_order.generated2uploaded()
         self.assertEqual(self.inbound_order.state, "uploaded")
-        payment = self.inbound_order.payment_ids
-        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
-        payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
-        self.assertEqual(
-            payment_move.line_ids.mapped("date_maturity"),
-            [date(2024, 6, 1), date(2024, 6, 1)],
-        )
-
-    @freeze_time("2024-04-01")
-    def test_creation_transfer_move_date_02(self):
-        # Simulate that the invoice had a different due date
-        self.inbound_order.payment_line_ids.ml_maturity_date = "2024-06-01"
-        self.inbound_order.draft2open()
-        payment = self.inbound_order.payment_ids
-        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
-        payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
-        self.assertEqual(
-            payment_move.line_ids.mapped("date_maturity"),
-            [date(2024, 6, 1), date(2024, 6, 1)],
-        )
-        self.assertEqual(self.inbound_order.payment_count, 1)
-        self.inbound_order.open2generated()
-        self.inbound_order.generated2uploaded()
-        self.assertEqual(self.inbound_order.state, "uploaded")
-        payment = self.inbound_order.payment_ids
-        self.assertEqual(payment.payment_line_date, date(2024, 6, 1))
-        payment_move = payment.move_id
-        self.assertEqual(payment_move.date, date(2024, 4, 1))  # now
-        self.assertEqual(
-            payment_move.line_ids.mapped("date_maturity"),
-            [date(2024, 6, 1), date(2024, 6, 1)],
-        )
+        payment_move = self.inbound_order.payment_ids.move_id

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -345,7 +345,8 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         outbound_order.draft2open()
         self.assertEqual(outbound_order.payment_count, 2)
         self.assertEqual(
-            outbound_order.payment_line_ids[0].payment_ids.date, fields.Date.today()
+            outbound_order.payment_line_ids[0].date,
+            outbound_order.payment_line_ids[0].payment_ids.date,
         )
         self.assertEqual(
             outbound_order.payment_line_ids[1].date,


### PR DESCRIPTION
The date of payments is corrected because the date on which the payment order is confirmed is currently established
This means that payments are not grouped correctly.


Before:
![image](https://github.com/user-attachments/assets/68ac5fb5-03e0-4011-95ad-26c933323ee3)
![image](https://github.com/user-attachments/assets/51c321da-1ba0-47b9-a9b2-f05c1583a94f)

With this changes:
![image](https://github.com/user-attachments/assets/70fea33a-dd5d-4d34-8bcd-f6d171ec6e90)
![image](https://github.com/user-attachments/assets/a1a3f3de-49ac-4fc2-b35d-13a6e112b359)

