### PR TITLE
[16.0][FIX/IMP] account_payment_order: use payment_reference if present for out payments

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
         communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
             if self.is_purchase_document():
-                communication = self.ref or self.payment_reference
+                communication = self.payment_reference or self.ref
             else:
                 communication = self.payment_reference or self.name
         return communication or ""


### PR DESCRIPTION
When a payment reference (field `payment_reference`) is provided on the vendor bill, it should be used in priority over the vendor bill number (field `ref`).

One reason is that the `ref` field is normally different for each invoice of the same supplier (it is used in Odoo's standard duplicate warning), but the payment reference maybe the same for all payments to the same supplier. For instance some suppliers request that the customer id is used on the payment communication and it is the same on all their invoices.

Another reason is that some suppliers use a structured payment communication scheme, and that one only makes sense in the payment_reference field.