### PR TITLE
[16.0] reference_type usability improvements

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -25,6 +25,7 @@ class AccountMove(models.Model):
         selection=[("none", "Free Reference"), ("structured", "Structured Reference")],
         states={"draft": [("readonly", False)]},
         default="none",
+        string="Payment Reference Type",
     )
     payment_line_count = fields.Integer(compute="_compute_payment_line_count")
 

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -23,7 +23,6 @@ class AccountMove(models.Model):
     # payment mode or company level
     reference_type = fields.Selection(
         selection=[("none", "Free Reference"), ("structured", "Structured Reference")],
-        readonly=True,
         states={"draft": [("readonly", False)]},
         default="none",
     )

--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -61,7 +61,7 @@
             <field name="payment_reference" position="before">
                 <field
                     name="reference_type"
-                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))],
+                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))],
                             'required': [('move_type', 'in', ('out_invoice', 'out_refund'))]}"
                 />
             </field>

--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -61,8 +61,7 @@
             <field name="payment_reference" position="before">
                 <field
                     name="reference_type"
-                    attrs="{'readonly':[('state','!=','draft')],
-                            'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))],
+                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))],
                             'required': [('move_type', 'in', ('out_invoice', 'out_refund'))]}"
                 />
             </field>


### PR DESCRIPTION
This PR makes the Reference Type
- modifiable, included on posted invoices, because the standard payment reference field is modifiable on posted invoices too
- visible on all bill types, because we want to be able to use structured communications on vendor bills (same visibility as the standard payment_reference field)