### PR TITLE
[16.0][IMP] account_payment_order_grouped_output: Maturity date in grouped moves

### DIFF
--- a/account_payment_order_grouped_output/models/account_payment_order.py
+++ b/account_payment_order_grouped_output/models/account_payment_order.py
@@ -149,6 +149,8 @@ class AccountPaymentOrder(models.Model):
             ),
             "currency_id": payment.currency_id.id,
             "amount_currency": payment.amount * sign,
+            # Same logic as the individual payments
+            "date_maturity": payment.payment_line_ids[0].date,
         }
         return vals
 
@@ -181,6 +183,8 @@ class AccountPaymentOrder(models.Model):
             ),
             "currency_id": payments[0].currency_id.id,
             "amount_currency": amount_payment_currency * sign,
+            # All the lines should have the same date following _prepare_trf_moves
+            "date_maturity": payments.payment_line_ids[:1].date,
         }
         return vals
 


### PR DESCRIPTION
Forward-port of https://github.com/OCA/bank-payment/pull/1341

For propagating maturity dates from the individual payment moves to the grouped ones, 2 actions are taken:

- For the counterpart that will neutralize each payment, we put the maturity date according to the same logic as the payment one.
- For the grouped AR/AP, we put the first payment date  of all the grouped payments, as all of them should be the same after grouping by this criterium in _prepare_trf_moves.

It includes a regression test.

@Tecnativa TT50671