### PR TITLE
[14.0][IMP] Add warning when payment order is not SEPA

### DIFF
--- a/account_banking_pain_base/models/account_payment_method.py
+++ b/account_banking_pain_base/models/account_payment_method.py
@@ -16,6 +16,7 @@ class AccountPaymentMethod(models.Model):
         "the corresponding unaccented character, so that only ASCII "
         "characters are used in the generated PAIN file.",
     )
+    warn_not_sepa = fields.Boolean(string="Warn If Not SEPA")
 
     def get_xsd_file_path(self):
         """This method is designed to be inherited in the SEPA modules"""

--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -24,7 +24,12 @@ logger = logging.getLogger(__name__)
 class AccountPaymentOrder(models.Model):
     _inherit = "account.payment.order"
 
-    sepa = fields.Boolean(compute="_compute_sepa", readonly=True, string="SEPA Payment")
+    sepa = fields.Boolean(compute="_compute_sepa", string="SEPA Payment")
+    sepa_payment_method = fields.Boolean(
+        compute="_compute_sepa",
+        string="SEPA Payment Method",
+    )
+    show_warning_not_sepa = fields.Boolean(compute="_compute_sepa")
     charge_bearer = fields.Selection(
         [
             ("SLEV", "Following Service Level"),
@@ -105,6 +110,7 @@ class AccountPaymentOrder(models.Model):
         ]
 
     @api.depends(
+        "payment_mode_id",
         "company_partner_bank_id.acc_type",
         "company_partner_bank_id.sanitized_acc_number",
         "payment_line_ids.currency_id",
@@ -115,30 +121,47 @@ class AccountPaymentOrder(models.Model):
         eur = self.env.ref("base.EUR")
         sepa_list = self._sepa_iban_prefix_list()
         for order in self:
-            sepa = True
-            if order.company_partner_bank_id.acc_type != "iban":
-                sepa = False
-            if (
-                order.company_partner_bank_id
-                and order.company_partner_bank_id.sanitized_acc_number[:2]
-                not in sepa_list
-            ):
-                sepa = False
-            for pline in order.payment_line_ids:
-                if pline.currency_id != eur:
-                    sepa = False
-                    break
-                if pline.partner_bank_id.acc_type != "iban":
-                    sepa = False
-                    break
+            sepa_payment_method = False
+            sepa = False
+            warn_not_sepa = False
+            payment_method = order.payment_mode_id.payment_method_id
+            if payment_method.pain_version:
+                sepa_payment_method = True
+                sepa = True
                 if (
-                    pline.partner_bank_id
-                    and pline.partner_bank_id.sanitized_acc_number[:2] not in sepa_list
+                    order.company_partner_bank_id
+                    and order.company_partner_bank_id.acc_type != "iban"
                 ):
                     sepa = False
-                    break
-            sepa = order.compute_sepa_final_hook(sepa)
-            self.sepa = sepa
+                if (
+                    order.company_partner_bank_id
+                    and order.company_partner_bank_id.sanitized_acc_number[:2]
+                    not in sepa_list
+                ):
+                    sepa = False
+                for pline in order.payment_line_ids:
+                    if pline.currency_id != eur:
+                        sepa = False
+                        break
+                    if (
+                        pline.partner_bank_id
+                        and pline.partner_bank_id.acc_type != "iban"
+                    ):
+                        sepa = False
+                        break
+                    if (
+                        pline.partner_bank_id
+                        and pline.partner_bank_id.sanitized_acc_number[:2]
+                        not in sepa_list
+                    ):
+                        sepa = False
+                        break
+                sepa = order.compute_sepa_final_hook(sepa)
+                if not sepa and payment_method.warn_not_sepa:
+                    warn_not_sepa = True
+            order.sepa = sepa
+            order.sepa_payment_method = sepa_payment_method
+            order.show_warning_not_sepa = warn_not_sepa
 
     def compute_sepa_final_hook(self, sepa):
         self.ensure_one()

--- a/account_banking_pain_base/static/description/index.html
+++ b/account_banking_pain_base/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -458,12 +458,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Carlos Roca</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.ooops404.com/">Ooops404</a>:
+* Eduard Brahas &lt;<a class="reference external" href="mailto:eduard&#64;ooops404.com">eduard&#64;ooops404.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_banking_pain_base/views/account_payment_method.xml
+++ b/account_banking_pain_base/views/account_payment_method.xml
@@ -10,8 +10,13 @@
         <field name="arch" type="xml">
             <field name="payment_type" position="after">
                 <field name="pain_version" />
+
                 <field
                     name="convert_to_ascii"
+                    attrs="{'invisible': [('pain_version', '=', False)]}"
+                />
+                <field
+                    name="warn_not_sepa"
                     attrs="{'invisible': [('pain_version', '=', False)]}"
                 />
             </field>

--- a/account_banking_pain_base/views/account_payment_order.xml
+++ b/account_banking_pain_base/views/account_payment_order.xml
@@ -13,26 +13,31 @@
         />
         <field name="arch" type="xml">
             <field name="company_partner_bank_id" position="after">
-                <field name="sepa" />
+                <field
+                    name="sepa"
+                    attrs="{'invisible': [('sepa_payment_method', '=', False)]}"
+                />
+                <field name="sepa_payment_method" invisible="1" />
+                <field name="show_warning_not_sepa" invisible="1" />
                 <field name="batch_booking" />
                 <field
                     name="charge_bearer"
                     attrs="{'invisible': [('sepa', '=', True)]}"
                 />
             </field>
-        </field>
-</record>
-    <record id="account_payment_order_tree" model="ir.ui.view">
-        <field name="name">pain.base.account.payment.order.tree</field>
-        <field name="model">account.payment.order</field>
-        <field
-            name="inherit_id"
-            ref="account_payment_order.account_payment_order_tree"
-        />
-        <field name="arch" type="xml">
-                <field name="description" position="after">
-                        <field name="sepa" optional="hide" />
-            </field>
+            <header position="after">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('show_warning_not_sepa', '=', False)]}"
+                >
+                        This payment order is <b
+                    >not SEPA</b>. If it is not intented, check that all payment lines are in € and that all bank accounts are valid IBANs with a country prefix in the <a
+                        href="https://en.wikipedia.org/wiki/Single_Euro_Payments_Area"
+                        target="_blank"
+                    >SEPA zone</a>.
+                </div>
+            </header>
         </field>
 </record>
 

--- a/account_banking_sepa_credit_transfer/__manifest__.py
+++ b/account_banking_sepa_credit_transfer/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account Banking SEPA Credit Transfer",
     "summary": "Create SEPA XML files for Credit Transfers",
-    "version": "14.0.2.0.2",
+    "version": "14.0.2.0.3",
     "license": "AGPL-3",
     "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",

--- a/account_banking_sepa_credit_transfer/data/account_payment_method.xml
+++ b/account_banking_sepa_credit_transfer/data/account_payment_method.xml
@@ -6,5 +6,6 @@
         <field name="payment_type">outbound</field>
         <field name="bank_account_required" eval="True" />
         <field name="pain_version">pain.001.001.03</field>
+        <field name="warn_not_sepa" eval="True" />
     </record>
 </odoo>

--- a/account_banking_sepa_credit_transfer/migrations/14.0.2.0.3/post-migration.py
+++ b/account_banking_sepa_credit_transfer/migrations/14.0.2.0.3/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    sct_method = env.ref("account_banking_sepa_credit_transfer.sepa_credit_transfer")
+    sct_method.write({"warn_not_sepa": True})

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -192,7 +192,10 @@ class TestSCT(SavepointCase):
         self.assertEqual(agrolait_pay_line1.communication, "F1341")
         self.payment_order.draft2open()
         self.assertEqual(self.payment_order.state, "open")
-        self.assertEqual(self.payment_order.sepa, True)
+        if self.payment_mode.payment_method_id.pain_version:
+            self.assertTrue(self.payment_order.sepa)
+        else:
+            self.assertFalse(self.payment_order.sepa)
         self.assertTrue(self.payment_order.payment_ids)
         agrolait_bank_line = self.payment_order.payment_ids[0]
         self.assertEqual(agrolait_bank_line.currency_id, self.eur_currency)

--- a/account_banking_sepa_direct_debit/__manifest__.py
+++ b/account_banking_sepa_direct_debit/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Account Banking SEPA Direct Debit",
     "summary": "Create SEPA files for Direct Debit",
-    "version": "14.0.2.1.1",
+    "version": "14.0.2.1.2",
     "license": "AGPL-3",
     "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment",

--- a/account_banking_sepa_direct_debit/data/account_payment_method.xml
+++ b/account_banking_sepa_direct_debit/data/account_payment_method.xml
@@ -7,5 +7,6 @@
         <field name="bank_account_required" eval="False" />
         <field name="mandate_required" eval="True" />
         <field name="pain_version">pain.008.001.02</field>
+        <field name="warn_not_sepa" eval="True" />
     </record>
 </odoo>

--- a/account_banking_sepa_direct_debit/migrations/14.0.2.1.2/post-migration.py
+++ b/account_banking_sepa_direct_debit/migrations/14.0.2.1.2/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Akretion France (http://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    sct_method = env.ref("account_banking_sepa_direct_debit.sepa_direct_debit")
+    sct_method.write({"warn_not_sepa": True})

--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -66,6 +66,9 @@ class AccountPaymentLine(models.Model):
         ondelete="restrict",
         check_company=True,
     )
+    partner_bank_acc_type = fields.Selection(
+        related="partner_bank_id.acc_type", string="Bank Account Type"
+    )
     date = fields.Date(string="Payment Date")
     # communication field is required=False because we don't want to block
     # the creation of lines from move/invoices when communication is empty

--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -59,6 +59,7 @@
                 <field name="partner_id" />
                 <field name="communication" />
                 <field name="partner_bank_id" />
+                <field name="partner_bank_acc_type" optional="hide" />
                 <field name="move_line_id" optional="hide" />
                 <field name="ml_maturity_date" optional="show" />
                 <field name="date" />


### PR DESCRIPTION
>The field 'sepa' on account.payment.order is only display for SEPA payment methods.
If the option "show warning if not SEPA" is enabled on the payment method, a warning banner is now displayed on payment orders with a SEPA payment method which are not SEPA.

Backporting of https://github.com/OCA/bank-payment/pull/1149 needed for https://github.com/OCA/l10n-italy/pull/4367