### PR TITLE
[17.0][FIX] account_payment_order: Assure partner bank account in payments

### DIFF
--- a/account_payment_order/models/account_payment.py
+++ b/account_payment_order/models/account_payment.py
@@ -45,6 +45,15 @@ class AccountPayment(models.Model):
         for item in self:
             item.payment_line_date = item.payment_line_ids[:1].date
 
+    @api.depends("payment_line_ids")
+    def _compute_partner_bank_id(self):
+        # Force the payment line bank account. The grouping function has already
+        # assured that there's no more than one bank account in the group
+        order_pays = self.filtered("payment_line_ids")
+        for pay in order_pays:
+            pay.partner_bank_id = pay.payment_line_ids.partner_bank_id
+        return super(AccountPayment, self - order_pays)._compute_partner_bank_id()
+
     def update_payment_reference(self):
         view = self.env.ref("account_payment_order.account_payment_update_view_form")
         return {

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -203,6 +203,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         line_created_due.create_payment_lines()
         self.assertGreater(len(order.payment_line_ids), 0)
         order.draft2open()
+        self.assertEqual(order.payment_ids[0].partner_bank_id, self.partner.bank_ids)
         order.open2generated()
         order.generated2uploaded()
         self.assertEqual(order.move_ids[0].date, order.payment_ids[0].date)


### PR DESCRIPTION
Forward-port of #1346 

On certain v16 instances, although the partner bank account that is being pre-set in the account.payment creation values dictionary:

https://github.com/OCA/bank-payment/blob/fc7783669f40d85/account_payment_order/models/account_payment_line.py#L206

it's being marked as dirty (it's a computed writable field), and thus, being recomputed before being saved, getting an invalid value (on direct debits, the company's bank account).

The triggers that lead to this situation are unknown due to the low level where it's happening and the tons of interactions being taken in place, so the best way to deal with this is to override the compute method that computes this value, so even if the field is recomputed, it gets the correct value.

Let's be pragmatic...

@Tecnativa TT50804