### PR TITLE
[16.0][FW] account_payment_sale: blacklist of some PRs from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/account_payment_sale.json
+++ b/.oca/oca-port/blacklist/account_payment_sale.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "820": "Nothing to port from PR #820 (already ported in 2e2d1d8282825caada46f969a2f0641f07b5e44a)"
+  }
+}


### PR DESCRIPTION
The following PRs have been blacklisted:
- #820: Nothing to port from PR (already ported in 2e2d1d8282825caada46f969a2f0641f07b5e44a