### PR TITLE
[17.0][FW] [IMP] account_payment_sale: Add payment mode in invoicing grouping criteria

### DIFF
--- a/.oca/oca-port/blacklist/account_payment_sale.json
+++ b/.oca/oca-port/blacklist/account_payment_sale.json
@@ -1,0 +1,6 @@
+{
+  "pull_requests": {
+    "orphaned_commits": "Not relevant",
+    "1269": "Nothing to port from PR (already done through 6d4af78f71bcdd46d47068eee7cf7e39db373aab)"
+  }
+}

--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -41,3 +41,14 @@ class SaleOrder(models.Model):
         vals = super()._prepare_invoice()
         self._get_payment_mode_vals(vals)
         return vals
+
+    @api.model
+    def _get_invoice_grouping_keys(self) -> list:
+        """
+        When several sale orders are generating invoices,
+        we want to add the payment mode in grouping criteria.
+        """
+        keys = super()._get_invoice_grouping_keys()
+        if "payment_mode_id" not in keys:
+            keys.append("payment_mode_id")
+        return keys

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -94,3 +94,22 @@ class TestSaleOrder(CommonTestCase):
         self.assertEqual(len(invoice), 1)
         self.assertEqual(invoice.payment_mode_id, self.payment_mode_2)
         self.assertFalse(invoice.partner_bank_id)
+
+    def test_several_sale_to_invoice_payment_mode(self):
+        """
+        Data:
+            A partner with a specific payment_mode
+            A sale order created with the payment_mode of the partner
+            A sale order created with another payment mode
+        Test case:
+            Create the invoice from the sale orders
+        Expected result:
+            Two invoices should be generated
+        """
+        payment_mode_2 = self.env.ref("account_payment_mode.payment_mode_outbound_dd1")
+        order_1 = self.create_sale_order()
+        order_2 = self.create_sale_order(payment_mode_2)
+        orders = order_1 | order_2
+        orders.action_confirm()
+        invoices = orders._create_invoices()
+        self.assertEqual(2, len(invoices))


### PR DESCRIPTION
Port of #1246 from 16.0 to 17.0.

The following PRs have been blacklisted:
- Orphaned commits: Not relevant (32d4d472 + d0f2e51e + c2f1a137 + 8f88e8a0)
- #1269: Nothing to port from PR (already done through 6d4af78f71bcdd46d47068eee7cf7e39db373aab)