### PR TITLE
[16.0][FW] account_payment_partner: blacklist PR #1046 from 15.0

### DIFF
--- a/.oca/oca-port/blacklist/account_payment_partner.json
+++ b/.oca/oca-port/blacklist/account_payment_partner.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "1046": "Already ported through #1048"
+  }
+}


### PR DESCRIPTION
The following PRs have been blacklisted:
- #1046: Already ported through #1048