### PR TITLE
[14.0][FIX/IMP] account_payment_order: use payment_reference if present for out payments

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -48,7 +48,7 @@ class AccountMove(models.Model):
             if (self.reference_type or "none") != "none":
                 communication = self.ref
             elif self.is_purchase_document():
-                communication = self.ref or self.payment_reference
+                communication = self.payment_reference or self.ref or ""
             else:
                 communication = self.payment_reference or self.name
         # If we have credit note(s) - reversal_move_id is a one2many

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -278,8 +278,9 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual("F1243", self.invoice._get_payment_order_communication())
 
     def test_invoice_communication_02(self):
-        self.invoice.payment_reference = "R1234"
         self.assertEqual("F1242", self.invoice._get_payment_order_communication())
+        self.invoice.payment_reference = "R1234"
+        self.assertEqual("R1234", self.invoice._get_payment_order_communication())
 
     def test_invoice_communication_03(self):
         self.invoice.ref = False
@@ -302,6 +303,11 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
             "ref %s" % reverse_move.ref,
             self.invoice._get_payment_order_communication(),
         )
+
+    def test_supplier_invoice_payment_reference(self):
+        self.invoice.payment_reference = "+++F1234+++"
+        self.invoice.action_post()
+        self.assertEqual("+++F1234+++", self.invoice._get_payment_order_communication())
 
     def test_manual_line_and_manual_date(self):
         # Create payment order
@@ -459,7 +465,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         """
         self.invoice.payment_reference = "F/1234"
         self.invoice.action_post()
-        self.assertEqual("F1242", self.invoice._get_payment_order_communication())
+        self.assertEqual("F/1234", self.invoice._get_payment_order_communication())
         self.refund = self._create_supplier_refund(self.invoice)
         with Form(self.refund) as refund_form:
             refund_form.ref = "R1234"
@@ -468,7 +474,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
                 line_form.price_unit = 75.0
 
         self.refund.action_post()
-        self.assertEqual("R1234", self.refund._get_payment_order_communication())
+        self.assertEqual("FR/1234", self.refund._get_payment_order_communication())
 
         # The user add the outstanding payment to the invoice
         invoice_line = self.invoice.line_ids.filtered(
@@ -490,8 +496,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
 
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
-        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
-        self.assertNotIn("FR/1234", payment_order.payment_line_ids.communication)
+        self.assertEqual("F/1234 FR/1234", payment_order.payment_line_ids.communication)
 
     def test_supplier_manual_refund(self):
         """


### PR DESCRIPTION
Supersedes #1331 