### PR TITLE
[15.0][IMP] account_banking_mandate: Allow to change the bank mandate on invoices if they are not paid.

### DIFF
--- a/account_banking_mandate/models/account_move.py
+++ b/account_banking_mandate/models/account_move.py
@@ -12,9 +12,7 @@ class AccountMove(models.Model):
         "account.banking.mandate",
         string="Direct Debit Mandate",
         ondelete="restrict",
-        readonly=True,
         check_company=True,
-        states={"draft": [("readonly", False)]},
     )
     mandate_required = fields.Boolean(
         related="payment_mode_id.payment_method_id.mandate_required", readonly=True

--- a/account_banking_mandate/views/account_move_view.xml
+++ b/account_banking_mandate/views/account_move_view.xml
@@ -14,7 +14,9 @@
                     name="mandate_id"
                     domain="[('partner_id', '=', commercial_partner_id), ('state', '=', 'valid')]"
                     attrs="{'required': [('mandate_required', '=', True),('move_type', 'in', ('out_invoice', 'out_refund'))],
-                    'invisible': ['|', ('mandate_required', '=', False),('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    'invisible': ['|', ('mandate_required', '=', False),('move_type', 'not in', ('out_invoice', 'out_refund'))],
+                    'readonly': [('payment_state', '=', 'paid')]
+                    }"
                 />
                 <field name="mandate_required" invisible="1" />
             </field>


### PR DESCRIPTION
cc @Tecnativa TT51723

Use case:
You already have invoices created and your customer wants change the account bank, so you need change the mandate in all pending invoices.

ping @carlosdauden @victoralmau 