### PR TITLE
[16.0][FIX] account_payment_partner: Fix tests compatibility (hr_expense + partner_multi_company)

### DIFF
--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -31,11 +31,9 @@ class TestAccountPaymentPartner(TransactionCase):
             cls.chart = charts[0]
         else:
             raise ValidationError(_("No Chart of Account Template has been defined !"))
-        old_company = cls.env.user.company_id
-        cls.env.user.company_id = cls.company_2.id
+        cls.env.user.company_ids = [(4, cls.company_2.id)]
         cls.env.ref("base.user_admin").company_ids = [(4, cls.company_2.id)]
-        cls.chart.try_loading()
-        cls.env.user.company_id = old_company.id
+        cls.chart.try_loading(cls.company_2)
 
         # refs
         cls.manual_out = cls.env.ref("account.account_payment_method_manual_out")


### PR DESCRIPTION
Fix tests compatibility (`hr_expense` + `partner_multi_company`)

If we have both modules installed we will get the following error in the tests.
```
Incompatible companies on records:
- "OdooBot, Pieter Parter's Farm" belongs to company 'Company 2' and 'Supplier Payment Mode' (supplier_payment_mode_id: 'Credit Transfer to Suppliers') belongs to another company.
- "OdooBot, Pieter Parter's Farm" belongs to company 'Company 2' and 'Customer Payment Mode' (customer_payment_mode_id: 'Inbound Credit Trf Société Générale') belongs to another company.
```

@Tecnativa