### PR TITLE
[17.0][FIX] account_payment_order: add missing company  currency field on payment line

### DIFF
--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -88,6 +88,7 @@
                 <field name="amount_currency" string="Amount" />
                 <field name="currency_id" invisible="1" />
                 <field name="name" optional="show" />
+                <field name="company_currency_id" invisible="1" />
                 <field
                     name="amount_company_currency"
                     sum="Total in Company Currency"


### PR DESCRIPTION
Fixes https://github.com/OCA/bank-payment/issues/1379