### PR TITLE
[17.0][IMP] account_payment_order: Shorten the vertical used space

### DIFF
--- a/account_payment_order/views/account_invoice_view.xml
+++ b/account_payment_order/views/account_invoice_view.xml
@@ -50,13 +50,21 @@
             <field name="payment_mode_id" position="after">
                 <field name="payment_order_ok" invisible="1" />
             </field>
+            <!-- First we place the rest of the elements for the new reference distribution -->
             <field name="payment_reference" position="before">
-                <field
-                    name="reference_type"
-                    readonly="state != 'draft'"
-                    invisible="move_type not in ('out_invoice', 'out_refund')"
-                    required="move_type in ('out_invoice', 'out_refund')"
-                />
+                <label for="payment_reference" />
+                <div name="payment_reference_div" class="d-flex">
+                    <field
+                        name="reference_type"
+                        readonly="state != 'draft'"
+                        invisible="move_type not in ('out_invoice', 'out_refund')"
+                        required="move_type in ('out_invoice', 'out_refund')"
+                    />
+                </div>
+            </field>
+            <!-- Then we move the std field, as this can only be on a first level -->
+            <field name="reference_type" position="after">
+                <field name="payment_reference" position="move" />
             </field>
         </field>
 </record>


### PR DESCRIPTION
Forward-port of #1383 

Having 2 lines for the reference (one for the type and the other for the reference itself) steals vertical space to the really important things in the invoice: the lines, so we compact them into one line for better ergonomics.

**Before:**

![imagen](https://github.com/user-attachments/assets/78cecaab-d6df-41cb-a400-201e1676fb82)

**After:**

![imagen](https://github.com/user-attachments/assets/33c5a020-9ec4-437f-a6e3-67170d68dfd6)


@Tecnativa 