### PR TITLE
[14.0][WIP][IMP] account_payment_order: Add support for individual payment orders by partner

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -107,9 +107,19 @@ class AccountMove(models.Model):
             if not payment_modes:
                 raise UserError(_("No Payment Mode on invoice %s") % move.name)
             for payment_mode in payment_modes:
-                payorder = apoo.search(
-                    move.get_account_payment_domain(payment_mode), limit=1
-                )
+                if payment_mode.individual_payment:
+                    payorder = apoo.search(
+                        [
+                            ("payment_line_ids.partner_id", "=", move.partner_id.id),
+                            ("payment_mode_id", "=", payment_mode.id),
+                            ("state", "=", "draft"),
+                        ],
+                        limit=1,
+                    )
+                else:
+                    payorder = apoo.search(
+                        move.get_account_payment_domain(payment_mode), limit=1
+                    )
                 new_payorder = False
                 if not payorder:
                     payorder = apoo.create(

--- a/account_payment_order/models/account_payment_mode.py
+++ b/account_payment_order/models/account_payment_mode.py
@@ -23,6 +23,11 @@ class AccountPaymentMode(models.Model):
         "that has a payment line with a payment date before the maturity "
         "date.",
     )
+    individual_payment = fields.Boolean(
+        string="Individual Payment per Partner",
+        help="Enable this option to process payments individually"
+        " for this partner instead of combining them in a single payment order.",
+    )
     # Default options for the "payment.order.create" wizard
     default_payment_mode = fields.Selection(
         selection=[("same", "Same"), ("same_or_null", "Same or empty"), ("any", "Any")],

--- a/account_payment_order/views/account_payment_mode.xml
+++ b/account_payment_order/views/account_payment_mode.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="payment_type" position="after">
                 <field name="payment_order_ok" />
+                <field name="individual_payment" />
             </field>
             <group name="main" position="after">
                 <group


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 @douglascstd 

- [X] Introduced a new field individual_payment in account.payment.mode.
- [X] Added support in account.move to create payment orders restricted to a single partner when payment_mode.individual_payment is enabled.
- [ ] Prevented adding multiple partners in account.payment.order when individual_payment is active.
- [ ] Validated during creation of payment orders.
- [ ] Validated when adding payment lines.
- [ ] Validated during payment order confirmation.
- [ ] Added unit tests.