### PR TITLE
[16.0][IMP] account_payment_purchase: Propagate PO payment mode when invoicing

### DIFF
--- a/account_payment_purchase/models/account_move.py
+++ b/account_payment_purchase/models/account_move.py
@@ -13,6 +13,7 @@ class AccountMove(models.Model):
     def _onchange_purchase_auto_complete(self):
         new_mode = self.purchase_id.payment_mode_id.id or False
         new_bank = self.purchase_id.supplier_partner_bank_id.id or False
+        self = self.with_context(pay_mode_propagate=False)
         res = super()._onchange_purchase_auto_complete() or {}
         if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
             res["warning"] = {

--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -56,7 +56,10 @@ class PurchaseOrder(models.Model):
 
     def _prepare_invoice(self):
         """Leave the bank account empty so that account_payment_partner set the
-        correct value with compute."""
+        correct value with compute and propagate payment mode to invoice."""
         invoice_vals = super()._prepare_invoice()
         invoice_vals.pop("partner_bank_id")
+        assign_payment_mode = self._context.get("pay_mode_propagate", True)
+        if assign_payment_mode:
+            invoice_vals["payment_mode_id"] = self.payment_mode_id.id
         return invoice_vals

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -123,6 +123,16 @@ class TestAccountPaymentPurchase(TestAccountPaymentPurchaseBase):
         self.assertEqual(
             result and result.get("warning", {}).get("title", False), "Warning"
         )
+        # Test payment mode in direct invoicing from purchase
+        purchase3 = self.purchase.copy()
+        payment_mode3 = self.payment_mode.copy()
+        purchase3.payment_mode_id = payment_mode3
+        purchase3.button_confirm()
+        purchase3.order_line.qty_received = 1
+        purchase3.action_create_invoice()
+        self.assertEqual(
+            purchase3.invoice_ids.payment_mode_id, purchase3.payment_mode_id
+        )
 
     def test_from_purchase_order_empty_mode_invoicing(self):
         self.purchase.payment_mode_id = False


### PR DESCRIPTION
Comes from https://github.com/OCA/bank-payment/pull/1225

Fixes payment mode propagation from purchase order to invoice when supplier's payment mode is different to the one on the purchase order.