### PR TITLE
[16.0][FIX] account_payment_order: For inbound payments, communication should always show invoice.name

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -54,7 +54,7 @@ class AccountMove(models.Model):
             if self.is_purchase_document():
                 communication = self.payment_reference or self.ref
             else:
-                communication = self.payment_reference or self.name
+                communication = self.name or self.payment_reference
         return communication or ""
 
     def _get_payment_order_communication_full(self):

--- a/account_payment_order/tests/test_payment_order_inbound.py
+++ b/account_payment_order/tests/test_payment_order_inbound.py
@@ -119,7 +119,7 @@ class TestPaymentOrderInbound(TestPaymentOrderInboundBase):
     def test_invoice_communication_02(self):
         self.invoice.payment_reference = "R1234"
         self.assertEqual(
-            "R1234", self.invoice._get_payment_order_communication_direct()
+            self.invoice.name, self.invoice._get_payment_order_communication_direct()
         )
 
     def test_creation(self):


### PR DESCRIPTION
Currently is ok for `outbound` payment to show `payment_reference` or `ref`.
But for `inbound` is showing `payment_reference` that is not always equal to `invoice.name`.  For `inbound`, `communication` should always be `invoice.name`.