### PR TITLE
[FIX] account_payment_partner: keep the default value for partner_bank_id

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -120,8 +120,6 @@ class AccountMove(models.Model):
                             continue
                     else:
                         move.partner_bank_id = False
-            else:
-                move.partner_bank_id = False
         return res
 
     @api.depends("line_ids.matched_credit_ids", "line_ids.matched_debit_ids")


### PR DESCRIPTION
The Odoo default computation for partner_bank_id on customer invoices sets the first bank account of the company.

The override in account_payment_partner resets it to false if there is no payment mode defined.

Since for customer invoices we usually don't define a payment mode (unless when using direct debit), this partner_bank_id field is therefore emptied.

This is problematic for instance when generating UBL invoices with the official Odoo module, because the bank account is mandatory to create a valid Peppol document.

Therefore I propose to keep the default behaviour if there is no payment mode on the invoice.