### PR TITLE
[16.0][FIX] account_payment_sale: Sale Default Payment Mode need to belong to the same Company as the Order

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -20,10 +20,9 @@ class SaleOrder(models.Model):
     @api.depends("partner_id")
     def _compute_payment_mode(self):
         for order in self:
-            if order.partner_id:
-                order.payment_mode_id = order.partner_id.customer_payment_mode_id
-            else:
-                order.payment_mode_id = False
+            order.payment_mode_id = order.partner_id.with_company(
+                order.company_id
+            ).customer_payment_mode_id
 
     def _get_payment_mode_vals(self, vals):
         if self.payment_mode_id:


### PR DESCRIPTION
Sale Default Payment Mode need to belong to the same Company as the Order, simple PR and should not affect the actual behavior, but with this avoid error in some CI Multi-Company cases, for example:

```bash
    raise UserError("\n".join(lines))
odoo.exceptions.UserError: Incompatible companies on records:
- 'SN l10n_br_sale - Produtos' belongs to company 'Empresa Simples Nacional' and 'Payment Mode' (payment_mode_id: 'Inbound Credit Trf Société Générale') belongs to another company.
```

