### PR TITLE
[16.0][IMP] account_payment_order: read access for group_account_readonly

### DIFF
--- a/account_payment_order/security/ir.model.access.csv
+++ b/account_payment_order/security/ir.model.access.csv
@@ -1,6 +1,8 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_payment_order,Full access on account.payment.order to Payment Manager,model_account_payment_order,group_account_payment,1,1,1,1
+access_account_payment_order_readonly,Readonly access on account.payment.order to group_account_readonly,model_account_payment_order,account.group_account_readonly,1,0,0,0
 access_account_payment_line,Full access on account.payment.line to Payment Manager,model_account_payment_line,group_account_payment,1,1,1,1
+access_account_payment_line_readonly,Readonly access on account.payment.line to group_account_readonly,model_account_payment_line,account.group_account_readonly,1,0,0,0
 access_bank_payment_line,Full access on account.payment to Payment Manager,account.model_account_payment,group_account_payment,1,1,1,1
 base.access_res_partner_bank_group_partner_manager,Full access on res.partner.bank to Account Payment group,base.model_res_partner_bank,group_account_payment,1,1,1,1
 base.access_res_bank_group_partner_manager,Full access on res.bank to Account Payment group,base.model_res_bank,group_account_payment,1,1,1,1


### PR DESCRIPTION
Give readonly access to payment orders to the Accounting / Read Only group.

closes #1419