### PR TITLE
[16.0][FIX] account_*: Post-install test + fallback to load CoA

### DIFF
--- a/account_banking_mandate/tests/test_invoice_mandate.py
+++ b/account_banking_mandate/tests/test_invoice_mandate.py
@@ -5,12 +5,13 @@ from unittest.mock import patch
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("post_install", "-at_install")
 class TestInvoiceMandate(TransactionCase):
     def test_post_invoice_01(self):
         self.assertEqual(self.invoice.mandate_id, self.mandate)
@@ -208,6 +209,16 @@ class TestInvoiceMandate(TransactionCase):
         res = super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.company = cls.env.ref("base.main_company")
+        if not cls.company.chart_template_id:
+            # Load a CoA if there's none in the company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.company, install_demo=False)
+
         cls.partner = cls._create_res_partner("Peter with ACME Bank")
         cls.acme_bank = cls._create_res_bank(
             "ACME Bank", "GEBABEBB03B", "Charleroi", cls.env.ref("base.be")

--- a/account_banking_mandate/tests/test_mandate.py
+++ b/account_banking_mandate/tests/test_mandate.py
@@ -5,17 +5,27 @@ from datetime import timedelta
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("post_install", "-at_install")
 class TestMandate(TransactionCase):
     @classmethod
     def setUpClass(cls):
         res = super(TestMandate, cls).setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.company = cls.env.ref("base.main_company")
+        if not cls.company.chart_template_id:
+            # Load a CoA if there's none in the company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.company, install_demo=False)
         cls.company_2 = cls.env["res.company"].create({"name": "Company 2"})
         cls.company_2.partner_id.company_id = cls.company_2.id
         cls.bank_account = cls.env.ref("account_payment_mode.res_partner_12_iban")

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -5,11 +5,12 @@
 from odoo import _, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Date
-from odoo.tests.common import Form, TransactionCase
+from odoo.tests.common import Form, TransactionCase, tagged
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPaymentPartner(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -24,13 +25,20 @@ class TestAccountPaymentPartner(TransactionCase):
 
         # Refs
         cls.company = cls.env.ref("base.main_company")
-
-        cls.company_2 = cls.env["res.company"].create({"name": "Company 2"})
-        charts = cls.env["account.chart.template"].search([])
+        charts = cls.env["account.chart.template"].search([("visible", "=", True)])
         if charts:
             cls.chart = charts[0]
         else:
             raise ValidationError(_("No Chart of Account Template has been defined !"))
+        if not cls.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                coa = cls.chart
+            coa.try_loading(company=cls.company, install_demo=False)
+
+        cls.company_2 = cls.env["res.company"].create({"name": "Company 2"})
+        charts = cls.env["account.chart.template"].search([])
         cls.env.user.company_ids = [(4, cls.company_2.id)]
         cls.env.ref("base.user_admin").company_ids = [(4, cls.company_2.id)]
         cls.chart.try_loading(cls.company_2)

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -9,11 +9,20 @@ from odoo.tools import mute_logger
 
 
 @tagged("-at_install", "post_install")
-class TestAccountPaymentPurchase(TransactionCase):
+class TestAccountPaymentPurchaseBase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.journal = cls.env["account.journal"].create(
             {"name": "Test journal", "code": "TEST", "type": "general"}
         )
@@ -62,6 +71,8 @@ class TestAccountPaymentPurchase(TransactionCase):
             line_form.product_qty = 1
         cls.purchase = order_form.save()
 
+
+class TestAccountPaymentPurchase(TestAccountPaymentPurchaseBase):
     def test_onchange_partner_id_purchase_order(self):
         self.assertEqual(self.purchase.payment_mode_id, self.payment_mode)
 

--- a/account_payment_purchase_stock/tests/test_account_payment_purchase_stock.py
+++ b/account_payment_purchase_stock/tests/test_account_payment_purchase_stock.py
@@ -5,11 +5,11 @@
 from odoo import fields
 
 from odoo.addons.account_payment_purchase.tests.test_account_payment_purchase import (
-    TestAccountPaymentPurchase,
+    TestAccountPaymentPurchaseBase,
 )
 
 
-class TestAccountPaymentPurchaseStock(TestAccountPaymentPurchase):
+class TestAccountPaymentPurchaseStock(TestAccountPaymentPurchaseBase):
     def test_purchase_stock_order_invoicing(self):
         self.purchase.onchange_partner_id()
         self.purchase.button_confirm()

--- a/account_payment_sale/tests/common.py
+++ b/account_payment_sale/tests/common.py
@@ -1,16 +1,26 @@
 # Copyright 2018 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, tagged
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("post_install", "-at_install")
 class CommonTestCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.bank = cls.env["res.partner.bank"].create(
             {"acc_number": "test", "partner_id": cls.env.user.company_id.partner_id.id}
         )


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with errors like:

```
odoo.exceptions.RedirectWarning: ('Cannot find a chart of accounts for this company, You should configure it. \nPlease go to Account Configuration.', 246, 'Go to the configuration panel', None)
```

or

```
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale
```

or

```
psycopg2.errors.CheckViolation: new row for relation "account_move_line" violates check constraint "account_move_line_check_accountable_required_fields"
```

All of them provoked by the lack of a CoA installed.

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA, and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa 