### PR TITLE
[16.0][FIX] account_payment_sale: Not set the product_uom field in the sales order lines

### DIFF
--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -20,10 +20,6 @@ class TestSaleOrder(CommonTestCase):
             for (_, p) in self.products.items():
                 with sale_form.order_line.new() as order_line:
                     order_line.product_id = p
-                    order_line.name = p.name
-                    order_line.product_uom_qty = 2
-                    order_line.product_uom = p.uom_id
-                    order_line.price_unit = p.list_price
         sale = sale_form.save()
         self.assertEqual(
             sale.payment_mode_id, self.base_partner.customer_payment_mode_id


### PR DESCRIPTION
Not set the `product_uom` field in the sales order lines

If `sale_variant_configurator` is installed we will have an error about it, so it is better not to set it explicitly.

```
File "/opt/odoo/auto/addons/account_payment_sale/tests/test_sale_order.py", line 25, in create_sale_order
    order_line.product_uom = p.uom_id
File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 2355, in __setattr__
    assert not self._get_modifier(field, 'invisible'), \
AssertionError: can't write on invisible field product_uom
```

@Tecnativa