### PR TITLE
[16.0][FIX] account_banking_mandate_contact: Post-install test + fallback to load CoA

### DIFF
--- a/account_banking_mandate_contact/tests/test_account_payment_order.py
+++ b/account_banking_mandate_contact/tests/test_account_payment_order.py
@@ -2,16 +2,27 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl
 
 from odoo import fields
+from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
 
+@tagged("-at_install", "post_install")
 class TestAccountPaymentOrder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
         cls.product = cls.env["product.product"].create({"name": "Test product"})
         cls.partner_bank_core = cls._create_res_partner_bank("N-CORE")

--- a/account_banking_mandate_contact/tests/test_account_payment_order.py
+++ b/account_banking_mandate_contact/tests/test_account_payment_order.py
@@ -29,13 +29,23 @@ class TestAccountPaymentOrder(TransactionCase):
         cls.mandate_core = cls._create_mandate(cls.partner_bank_core, "CORE")
         cls.partner_bank_b2b = cls._create_res_partner_bank("N-B2B")
         cls.mandate_b2b = cls._create_mandate(cls.partner_bank_b2b, "B2B")
-        payment_method_vals = {
-            "name": "SEPA",
-            "code": "sepa_direct_debit",
-            "payment_type": "inbound",
-            "bank_account_required": True,
-        }
-        cls.method_sepa = cls.env["account.payment.method"].create(payment_method_vals)
+        # Use the method created by account_banking_sepa_sepa_direct_debit or create a new one
+        cls.method_sepa = cls.env["account.payment.method"].search(
+            [("code", "=", "sepa_direct_debit")], limit=1
+        )
+        if not cls.method_sepa:
+            payment_method_vals = {
+                "name": "SEPA",
+                "code": "sepa_direct_debit",
+                "payment_type": "inbound",
+                "bank_account_required": True,
+            }
+            cls.method_sepa = cls.env["account.payment.method"].create(
+                payment_method_vals
+            )
+        # Always set mandate_required=False to avoid incorrect behavior if
+        # account_banking_sepa_sepa_direct_debit is already installed
+        cls.method_sepa.mandate_required = False
         cls.journal_bank = cls.env["account.journal"].create(
             {
                 "name": "BANK",


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa