### PR TITLE
[16.0][FIX] account_payment_method_fs_storage: improve test by removing usage of datas

### DIFF
--- a/account_payment_method_fs_storage/tests/test_account_payment_method_fs_storage.py
+++ b/account_payment_method_fs_storage/tests/test_account_payment_method_fs_storage.py
@@ -18,17 +18,22 @@ class TestAccountPaymentMethodFsStorage(AccountTestInvoicingCommon):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.company = cls.company_data["company"]
 
-        cls.fs_storage = cls.env.ref("fs_storage.default_fs_storage")
+        cls.fs_storage = cls.env["fs.storage"].create(
+            {
+                "name": "Odoo Filesystem Backend",
+                "protocol": "odoofs",
+                "code": "odoofstest",
+            }
+        )
 
         cls.fs_storage.write(
             {
                 "use_on_payment_method": True,
             }
         )
-        cls.payment_method = cls.env.ref(
-            "account.account_payment_method_manual_out"
-        ).copy(
+        cls.payment_method = cls.env["account.payment.method"].create(
             {
+                "payment_type": "outbound",
                 "storage": str(cls.fs_storage.id),
                 "name": "method test",
                 "code": "test",


### PR DESCRIPTION
No modification in the behavior, simply a correction in the test suite.

The usage of data within `account_payment_method_fs_storage`'tests seems to create an error:
https://github.com/OCA/bank-payment/pull/1360

I 'manually' created the same data in my tests.