### PR TITLE
[FIX] account_payment_mode: check if records to converts exists

### DIFF
--- a/account_payment_mode/migrations/16.0.2.0.0/post-migrate.py
+++ b/account_payment_mode/migrations/16.0.2.0.0/post-migrate.py
@@ -6,6 +6,10 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     """Migrate note field from Text to Html"""
-    openupgrade.convert_field_to_html(
-        env.cr, "account_payment_mode", "note", "note", False, True
-    )
+
+    if openupgrade.column_exists(env.cr, "account_payment_mode", "note"):
+        records = env["account.payment.mode"].search_count([("note", "!=", False)])
+        if records:
+            openupgrade.convert_field_to_html(
+                env.cr, "account_payment_mode", "note", "note", False, True
+            )


### PR DESCRIPTION
When the field conversion method is called on record without value set, Odoo crash because no value to be converted are present in database