### PR TITLE
[17.0][FIX] account_payment_order: Fix chatter HTML link formatting on invoice payment

### DIFF
--- a/account_payment_order/i18n/account_payment_order.pot
+++ b/account_payment_order/i18n/account_payment_order.pot
@@ -18,8 +18,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -27,9 +27,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/am.po
+++ b/account_payment_order/i18n/am.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/ar.po
+++ b/account_payment_order/i18n/ar.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/ca.po
+++ b/account_payment_order/i18n/ca.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/ca_ES.po
+++ b/account_payment_order/i18n/ca_ES.po
@@ -19,8 +19,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -28,9 +28,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/cs.po
+++ b/account_payment_order/i18n/cs.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/da_DK.po
+++ b/account_payment_order/i18n/da_DK.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/de.po
+++ b/account_payment_order/i18n/de.po
@@ -21,8 +21,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -30,9 +30,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/el_GR.po
+++ b/account_payment_order/i18n/el_GR.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es.po
+++ b/account_payment_order/i18n/es.po
@@ -24,24 +24,21 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
-msgstr ""
-"%(count)d líneas de pago añadidas a la orden existente <a href=# data-oe-"
-"model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
+msgstr "%(count)d líneas de pago añadidas a la orden existente "
+"%(payorder_link)s."
 
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
-"%(count)d líneas de pago añadidas a la nueva orden <a href=# data-oe-"
-"model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, que ha "
-"sido creada automáticamente."
+"%(count)d líneas de pago añadidas a la nueva orden "
+"%(payorder_link)s, que ha sido creada automáticamente."
 
 #. module: account_payment_order
 #: model_terms:ir.ui.view,arch_db:account_payment_order.print_account_payment_order_document

--- a/account_payment_order/i18n/es_AR.po
+++ b/account_payment_order/i18n/es_AR.po
@@ -21,8 +21,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -30,9 +30,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_CL.po
+++ b/account_payment_order/i18n/es_CL.po
@@ -21,8 +21,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -30,9 +30,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_CR.po
+++ b/account_payment_order/i18n/es_CR.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_EC.po
+++ b/account_payment_order/i18n/es_EC.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_ES.po
+++ b/account_payment_order/i18n/es_ES.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_MX.po
+++ b/account_payment_order/i18n/es_MX.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/es_VE.po
+++ b/account_payment_order/i18n/es_VE.po
@@ -19,13 +19,14 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +34,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/et.po
+++ b/account_payment_order/i18n/et.po
@@ -18,13 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/fi.po
+++ b/account_payment_order/i18n/fi.po
@@ -18,13 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/fr.po
+++ b/account_payment_order/i18n/fr.po
@@ -24,25 +24,22 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 "%(count)d lignes de paiement ajoutées à l'ordre de paiement brouillon "
-"existant <a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a>."
+"existant %(payorder_link)s."
 
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 "%(count)d lignes de paiement ajoutées au nouvel ordre de paiement en "
-"brouillon<a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a>, qui a été automatiquement créé."
+"brouillon %(payorder_link)s, qui a été automatiquement créé."
 
 #. module: account_payment_order
 #: model_terms:ir.ui.view,arch_db:account_payment_order.print_account_payment_order_document

--- a/account_payment_order/i18n/fr_FR.po
+++ b/account_payment_order/i18n/fr_FR.po
@@ -16,13 +16,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.3.2\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -30,9 +31,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/gl.po
+++ b/account_payment_order/i18n/gl.po
@@ -18,13 +18,14 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/hr.po
+++ b/account_payment_order/i18n/hr.po
@@ -19,13 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +34,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/it.po
+++ b/account_payment_order/i18n/it.po
@@ -24,25 +24,22 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 "%(count)d righe di pagamento aggiunte all'ordine di pagamento esistente in "
-"bozza <a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a>."
+"bozza %(payorder_link)s."
 
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 "%(count)d righe di pagamento aggiunte al nuovo ordine di pagamento in bozza "
-"<a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a> che è stato creato automaticamente."
+"%(payorder_link)s che è stato creato automaticamente."
 
 #. module: account_payment_order
 #: model_terms:ir.ui.view,arch_db:account_payment_order.print_account_payment_order_document

--- a/account_payment_order/i18n/lt.po
+++ b/account_payment_order/i18n/lt.po
@@ -19,13 +19,14 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 
+
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +34,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/nb_NO.po
+++ b/account_payment_order/i18n/nb_NO.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/nl.po
+++ b/account_payment_order/i18n/nl.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/nl_BE.po
+++ b/account_payment_order/i18n/nl_BE.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/nl_NL.po
+++ b/account_payment_order/i18n/nl_NL.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/pl.po
+++ b/account_payment_order/i18n/pl.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/pt.po
+++ b/account_payment_order/i18n/pt.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/pt_BR.po
+++ b/account_payment_order/i18n/pt_BR.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/pt_PT.po
+++ b/account_payment_order/i18n/pt_PT.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/ro.po
+++ b/account_payment_order/i18n/ro.po
@@ -24,8 +24,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -33,9 +33,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/ru.po
+++ b/account_payment_order/i18n/ru.po
@@ -25,8 +25,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -34,9 +34,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/sl.po
+++ b/account_payment_order/i18n/sl.po
@@ -25,8 +25,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -34,9 +34,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/sv.po
+++ b/account_payment_order/i18n/sv.po
@@ -21,25 +21,22 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 "%(count)d betalningsrader som läggs till i det befintliga utkastet till "
-"betalningsorder <a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a>."
+"betalningsorder %(payorder_link)s."
 
 #. module: account_payment_order
 #. odoo-python
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 "%(count)d betalningsrader läggs till i det nya utkastet till betalningsorder "
-"<a href=# data-oe-model=account.payment.order data-oe-"
-"id=%(order_id)d>%(name)s</a>, som har skapats automatiskt."
+"%(payorder_link)s, som har skapats automatiskt."
 
 #. module: account_payment_order
 #: model_terms:ir.ui.view,arch_db:account_payment_order.print_account_payment_order_document

--- a/account_payment_order/i18n/th.po
+++ b/account_payment_order/i18n/th.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/tr.po
+++ b/account_payment_order/i18n/tr.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/i18n/vi.po
+++ b/account_payment_order/i18n/vi.po
@@ -23,8 +23,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the existing draft payment order <a href=# "
-"data-oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>."
+"%(count)d payment lines added to the existing draft payment order "
+"%(payorder_link)s."
 msgstr ""
 
 #. module: account_payment_order
@@ -32,9 +32,8 @@ msgstr ""
 #: code:addons/account_payment_order/models/account_move.py:0
 #, python-format
 msgid ""
-"%(count)d payment lines added to the new draft payment order <a href=# data-"
-"oe-model=account.payment.order data-oe-id=%(order_id)d>%(name)s</a>, which "
-"has been automatically created."
+"%(count)d payment lines added to the new draft payment order "
+"%(payorder_link)s, which has been automatically created."
 msgstr ""
 
 #. module: account_payment_order

--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -3,6 +3,8 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from markupsafe import Markup
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -172,24 +174,23 @@ class AccountMove(models.Model):
                     move.message_post(
                         body=_(
                             "%(count)d payment lines added to the new draft payment "
-                            "order <a href=# data-oe-model=account.payment.order "
-                            "data-oe-id=%(order_id)d>%(name)s</a>, which has been "
-                            "automatically created.",
+                            "order %(payorder_link)s, which has been automatically "
+                            "created.",
                             count=count,
-                            order_id=payorder.id,
-                            name=payorder.name,
+                            payorder_link=Markup(
+                                payorder._get_html_link(title=payorder.name)
+                            ),
                         )
                     )
                 else:
                     move.message_post(
                         body=_(
                             "%(count)d payment lines added to the existing draft "
-                            "payment order "
-                            "<a href=# data-oe-model=account.payment.order "
-                            "data-oe-id=%(order_id)d>%(name)s</a>.",
+                            "payment order %(payorder_link)s.",
                             count=count,
-                            order_id=payorder.id,
-                            name=payorder.name,
+                            payorder_link=Markup(
+                                payorder._get_html_link(title=payorder.name)
+                            ),
                         )
                     )
         action = self.env["ir.actions.act_window"]._for_xml_id(


### PR DESCRIPTION
Fixes the chatter messages posted on invoices when clicking on the `Add to Payment Order` button, which were not escaped.

Before:
![before](https://github.com/user-attachments/assets/441c7cd6-2b21-4a12-9c50-090412cdc0c6)

After:
![after](https://github.com/user-attachments/assets/9ce3f473-cd7a-4e62-9cf2-e0445a48c5b9)

