### PR TITLE
[18.0][FIX] account_banking_mandate: fix mandates button display in partner view

### DIFF
--- a/account_banking_mandate/views/res_partner.xml
+++ b/account_banking_mandate/views/res_partner.xml
@@ -13,6 +13,7 @@
                 <button
                     type="action"
                     class="btn-link"
+                    colspan="2"
                     name="%(account_banking_mandate.mandate_action)d"
                     context="{'search_default_partner_id': id, 'default_partner_id': id}"
                 >


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9d03d8fc-7ebc-4d36-887a-646094b86a8e)

After:

![image](https://github.com/user-attachments/assets/c82b0cde-190d-4b0e-adab-d502e431eda0)
