### PR TITLE
[17.0][FIX] account_banking_pain_base : fix DbtrAcct node

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -515,6 +515,11 @@ class AccountPaymentOrder(models.Model):
             party_account_other = etree.SubElement(party_account_id, "Othr")
             party_account_other_id = etree.SubElement(party_account_other, "Id")
             party_account_other_id.text = partner_bank.sanitized_acc_number
+        if self.payment_type == "outbound" and party_type == "Dbtr":
+            currency = etree.SubElement(party_account, "Ccy")
+            currency.text = (
+                self.journal_id.currency_id.name or self.company_currency_id.name
+            )
         return True
 
     @api.model


### PR DESCRIPTION
The DbtrAcct node should contain the currency of the bank account for outgoing payments.

It's not a required element in the pain XSD but not specifying it can have bad consequences when paying from multi-currency bank accounts.

I encountered this issue twice in the last year with German and Balgian banks.

Assume you have a bank account number with two financial journals for EUR and USD.

If you initiate a USD payment from your EUR bank account than the bank will try to remove the money from your USD bank account (which is a problem if you don't have enough dollars on that account).