### PR TITLE
[18.0][FIX] account_payment_partner: fix column_invisible in list view view_move_line_tree

### DIFF
--- a/account_payment_partner/views/account_move_line.xml
+++ b/account_payment_partner/views/account_move_line.xml
@@ -31,7 +31,7 @@
                     name="payment_mode_id"
                     optional="hide"
                     force_save="1"
-                    column_invisible="account_type not in ['asset_receivable', 'liability_payable']"
+                    invisible="account_type not in ['asset_receivable', 'liability_payable']"
                     readonly="account_type not in ['asset_receivable', 'liability_payable'] or reconciled"
                 />
             </field>


### PR DESCRIPTION
Error en <list/> view in account.move.line

https://github.com/user-attachments/assets/0a52dfb3-b1e2-4de3-bc7f-a6fb4fa09e6a

I made this correction because the field uses the optional="hide" option. The column_invisible attribute only works with true or false values, or with a context expression.

The account_type field is indeed present in the list view: https://github.com/odoo/odoo/blob/d7fc418da523fbe610b6667d7e5065ab2bc7d9bd/addons/account/views/account_move_views.xml#L195