### PR TITLE
[16.0][FIX] account_payment_order_vendor_email: change message content when template is sent successfully

### DIFF
--- a/account_payment_order_vendor_email/models/account_payment_mode.py
+++ b/account_payment_order_vendor_email/models/account_payment_mode.py
@@ -87,7 +87,7 @@ class PaymentOrder(models.Model):
                             rec.id, force_send=True
                         )
                         rec.message_post(
-                            body=_("An email is not able to send to %s vendor.")
+                            body=_("An email is sent successfully to %s vendor.")
                             % partner_name
                         )
                     else:


### PR DESCRIPTION
I’ve noticed that commit https://github.com/OCA/bank-payment/pull/1288/commits/67ebba1c inadvertently changes the wrong content in the template file when sent. This appears to be an unintended side effect.