### PR TITLE
[18.0][FIX] account_payment_*: test should only be executed after all modules have been installed

### DIFF
--- a/account_payment_mode/tests/test_account_payment_mode.py
+++ b/account_payment_mode/tests/test_account_payment_mode.py
@@ -3,10 +3,12 @@
 
 from odoo import Command
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import BaseCommon
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPaymentMode(BaseCommon):
     @classmethod
     def setUpClass(cls):

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -1,11 +1,12 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 
 from .common import CommonTestCase
 
 
+@tagged("post_install", "-at_install")
 class TestSaleOrder(CommonTestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
to resolve red CI of modules that depend on `account_payment_*`, for example: https://github.com/OCA/bank-payment/pull/1465

```
2025-05-15 06:00:07,580 391 ERROR odoo odoo.addons.account_payment_sale.tests.test_sale_order: ERROR: TestSaleOrder.test_change_sale_company
Traceback (most recent call last):
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/account_payment_sale/tests/test_sale_order.py", line 130, in test_change_sale_company
    other_company = self.env["res.company"].create({"name": "other company"})
```

```
2025-05-15 06:00:02,595 391 ERROR odoo odoo.tests.suite: ERROR: setUpClass (odoo.addons.account_payment_mode.tests.test_account_payment_mode.TestAccountPaymentMode)
Traceback (most recent call last):
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/account_payment_mode/tests/test_account_payment_mode.py", line 24, in setUpClass
    cls.company_2 = cls.env["res.company"].create({"name": "Company 2"})
```