### PR TITLE
[18.0][IMP] account_banking_mandate: add mandate field on account payment

### DIFF
--- a/account_banking_mandate/models/__init__.py
+++ b/account_banking_mandate/models/__init__.py
@@ -5,3 +5,4 @@ from . import res_partner_bank
 from . import res_partner
 from . import account_payment_line
 from . import account_move_line
+from . import account_payment

--- a/account_banking_mandate/models/account_payment.py
+++ b/account_banking_mandate/models/account_payment.py
@@ -1,0 +1,23 @@
+# Copyright 2025 ForgeFlow
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import api, fields, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    mandate_id = fields.Many2one(
+        "account.banking.mandate", compute="_compute_mandate_id"
+    )
+
+    @api.depends(
+        "payment_line_ids.mandate_id",
+        "move_id.mandate_id",
+    )
+    def _compute_mandate_id(self):
+        for payment in self:
+            payment.mandate_id = (
+                payment.move_id.mandate_id or payment.payment_line_ids[:1].mandate_id
+            )


### PR DESCRIPTION
In V18 account.payment does not inherit from account.move model anymore, as payments may not create a journal entry. To handle this new behavior we add a computed mandate field in account.payment that takes it either from its related move or from the payment lines.