### PR TITLE
[18.0][FIX] account_banking_mandate: _rec_names_search

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -19,6 +19,7 @@ class AccountBankingMandate(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "signature_date desc"
     _check_company_auto = True
+    _rec_names_search = ["unique_mandate_reference", "partner_bank_id.acc_number"]
 
     def _get_default_partner_bank_id_domain(self):
         if "default_partner_id" in self.env.context:


### PR DESCRIPTION
Solution to warning issued when searching for mandates to assign to a sale order from the "sale.order" form view.

`odoo.models: Cannot search on display_name, no _rec_name or _rec_names_search defined on account.banking.mandate`