### PR TITLE
[18.0][FIX] account_banking_sepa_direct_debit: generation of 'Instruction Identification' and 'End to End Identification'

### DIFF
--- a/account_banking_sepa_direct_debit/models/account_payment_order.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_order.py
@@ -164,7 +164,7 @@ class AccountPaymentOrder(models.Model):
                 )
                 instruction_identification.text = self._prepare_field(
                     "Instruction Identification",
-                    "str(line.move_id.id)",
+                    "str(line.id)",
                     {"line": line},
                     35,
                     gen_args=gen_args,
@@ -174,7 +174,7 @@ class AccountPaymentOrder(models.Model):
                 )
                 end2end_identification.text = self._prepare_field(
                     "End to End Identification",
-                    "str(line.move_id.id)",
+                    "str(line.id)",
                     {"line": line},
                     35,
                     gen_args=gen_args,


### PR DESCRIPTION
BEFORE
![sdd_bug](https://github.com/user-attachments/assets/e6b486d2-13e2-45fb-8ce8-27768abf1fe7)

AFTER
![fix_sdd](https://github.com/user-attachments/assets/3ffe4205-c4d2-4b9a-9758-49c352a886a9)



In Odoo v18, a draft account.payment don't have a move_id. So payment.move_id.id is False when generating the payment file (the account.payment are confirmed when going from 'generated' to 'uploaded'). So we can't use payment.move_id.id to generate 'Instruction Identification' and 'End to End Identification' in the generation of the SEPA XML file.

BTW, I don't think using the ID of the move or the ID of the account.payment in the identification tags of the SEPA XML file is a good practise... but that's another story. This change was introduced by the move to account.payment.

I found this bug while working on OCA/bank-payment-alternative... I'll fix it there too.