### PR TITLE
[15.0][OU-FIX] account_payment_order: ensure payment lines availables for new payments before creating moves

### DIFF
--- a/account_payment_order/migrations/15.0.2.0.0/post-migration.py
+++ b/account_payment_order/migrations/15.0.2.0.0/post-migration.py
@@ -175,12 +175,12 @@ def migrate(env, version):
     )
     _insert_account_payments(env)
     _create_hooks(env)
+    _insert_payment_line_payment_link(env)
     create_moves_from_orphan_account_payments(env)
     openupgrade.logged_query(
         env.cr, "ALTER TABLE account_payment ALTER move_id SET NOT NULL"
     )
     _delete_hooks(env)
-    _insert_payment_line_payment_link(env)
     openupgrade.delete_records_safely_by_xml_id(
         env, ["account_payment_order.bank_payment_line_company_rule"]
     )


### PR DESCRIPTION
During this migration within `15.0`, for some cases (like e.g. payment orders at `generated` state) new payments are created. Later in the same process new moves with their correspondent move lines are created, and, at last, links between new payments and their payment lines are restored.

For these payments move lines creation requires payment lines link already set, because date maturity for move lines will be set from payment line date. Then, if payment line links is not set at this point an error is raised.

This fixes it, ensuring that these links are set immediately after payment creation.

Fixes #1368 , when we're coming from `15.0`.