### PR TITLE
[18.0][FIX] account_banking_pain_base: Fix tests if base_vat + base_bank_from_iban is installed

### DIFF
--- a/account_banking_pain_base/tests/test_account_backing.py
+++ b/account_banking_pain_base/tests/test_account_backing.py
@@ -109,7 +109,7 @@ class TestPainBase(BaseCommon):
         partner_bank = self.env["res.partner.bank"].create(
             {
                 "partner_id": self.partner.id,
-                "acc_number": "ES12345678901234567890",
+                "acc_number": "ES1299999999509999999999",
             }
         )
         payment_line = self.env["account.payment.line"].create(

--- a/account_banking_pain_base/tests/test_account_backing.py
+++ b/account_banking_pain_base/tests/test_account_backing.py
@@ -46,7 +46,7 @@ class TestPainBase(BaseCommon):
             {
                 "name": "Test Company",
                 "country_id": cls.env.ref("base.be").id,
-                "vat": "BE0123456789",
+                "vat": "BE0477472701",
             }
         )
 
@@ -103,7 +103,7 @@ class TestPainBase(BaseCommon):
     def test_default_initiating_party(self):
         self.company._default_initiating_party()
         self.assertEqual(self.company.initiating_party_issuer, "KBO-BCE")
-        self.assertEqual(self.company.initiating_party_identifier, "0123456789")
+        self.assertEqual(self.company.initiating_party_identifier, "0477472701")
 
     def test_except_messages_prepare_field(self):
         partner_bank = self.env["res.partner.bank"].create(


### PR DESCRIPTION
Fix tests if `base_vat` is installed

```
File "/opt/odoo/auto/addons/base_vat/models/res_partner.py", line 200, in check_vat
    raise ValidationError(msg)
odoo.exceptions.ValidationError:
The VAT number [BE0123456789] for partner [Test Company] does not seem to be valid. Note: the expected format is BE0477472701
```

Fix tests if `base_bank_from_iban` is installed

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/account_banking_pain_base/tests/test_account_backing.py", line 109, in test_except_messages_prepare_field
    partner_bank = self.env["res.partner.bank"].create(
  File "<decorator-gen-208>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 495, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in create
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in <listcomp>
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 30, in _add_bank_vals
    vals["bank_id"] = self._get_bank_from_iban(vals["acc_number"]).id
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 36, in _get_bank_from_iban
    iban = schwifty.IBAN(acc_number)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 77, in __init__
    self.validate(validate_bban)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 176, in validate
    self._validate_length()
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 189, in _validate_length
    raise exceptions.InvalidLength("Invalid IBAN length")
schwifty.exceptions.InvalidLength: Invalid IBAN length
```

@Tecnativa