### PR TITLE
[16.0][IMP] account_payment_order_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/account_payment_order_tier_validation/views/account_payment_order.xml
+++ b/account_payment_order_tier_validation/views/account_payment_order.xml
@@ -23,7 +23,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="Payment Orders validated and ready to be confirmed"
                 />
             </filter>


### PR DESCRIPTION
Change the use of the `validated` field to `validation_status`

Related to https://github.com/OCA/server-ux/pull/1084

Please @pedrobaeza can you review it?

@Tecnativa