### PR TITLE
[18.0][FIX] account_payment_partner: missing migration scripts

### DIFF
--- a/account_payment_partner/migrations/18.0.1.0.0/post-migration.py
+++ b/account_payment_partner/migrations/18.0.1.0.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Le Filament (https://le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade, openupgrade_180
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade_180.convert_company_dependent(
+        env, "res.partner", "supplier_payment_mode_id"
+    )
+    openupgrade_180.convert_company_dependent(
+        env, "res.partner", "customer_payment_mode_id"
+    )


### PR DESCRIPTION
The fields customer_payment_mode_id and supplier_payment_mode_id on res_partner are company_dependent and therefore need to be migrated in v18.0 in case you come from a previous Odoo version.

This PR converts fields from ir_property.

It should be transparent if properties do not exist.