### PR TITLE
[15.0][FIX]: account_payment_order: payment line domain add uploaded state

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -128,7 +128,7 @@ class AccountMove(models.Model):
                     % move.name
                 )
             payment_lines = applicable_lines.payment_line_ids.filtered(
-                lambda l: l.state in ("draft", "open", "generated")
+                lambda l: l.state in ("draft", "open", "generated", "uploaded")
             )
             if payment_lines:
                 raise UserError(

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -127,11 +127,12 @@ class AccountPaymentLineCreate(models.TransientModel):
                 ("account_id.internal_type", "in", ["receivable", "payable"]),
             ]
         # Exclude lines that are already in a non-cancelled
-        # and non-uploaded payment order; lines that are in a
-        # uploaded payment order are proposed if they are not reconciled,
+        # and non-uploaded payment order; Now lines that are in a
+        # uploaded payment order are not proposed if they are not reconciled,
+        # this could end in multiple payment for same bill
         paylines = self.env["account.payment.line"].search(
             [
-                ("state", "in", ("draft", "open", "generated")),
+                ("state", "in", ("draft", "open", "generated", "uploaded")),
                 ("move_line_id", "!=", False),
             ]
         )


### PR DESCRIPTION
Add uploaded due to if you unreconcile a payment, you can add to payment order again and if you set the old payment order to draft, you can pay twice the bill(the old one + new one).

cc @Tecnativa TT58037
ping @carlosdauden @sergio-teruel 