### PR TITLE
[18.0][IMP] account_payment_order: add smart button to access related payments

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -451,3 +451,16 @@ class AccountPaymentOrder(models.Model):
         ctx.update({"search_default_misc_filter": 0})
         action["context"] = ctx
         return action
+
+    def action_view_payments(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "account.action_account_payments"
+        )
+        action.update(
+            {
+                "domain": [("payment_order_id", "=", self.id)],
+                "context": {"default_payment_order_id": self.id},
+            }
+        )
+        return action

--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -72,6 +72,19 @@
                                 widget="statinfo"
                             />
                         </button>
+                        <button
+                            class="oe_stat_button"
+                            name="action_view_payments"
+                            invisible="payment_count == 0"
+                            type="object"
+                            icon="fa-bars"
+                        >
+                            <field
+                                string="Payments"
+                                name="payment_count"
+                                widget="statinfo"
+                            />
+                        </button>
                     </div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />


### PR DESCRIPTION
This commit adds a smart button in the payment order form view to access the related payments easily. It also provides an action to display those payments and a counter field.

This improvement facilitates navigation and batch payment creation directly from the payment order.