### PR TITLE
[18.0][MOD] account_payment_order: Restrict move line domain to no show cancel lines

### DIFF
--- a/account_payment_order/views/account_payment_line.xml
+++ b/account_payment_order/views/account_payment_line.xml
@@ -14,7 +14,9 @@
                         <field name="name" />
                         <field
                             name="move_line_id"
-                            domain="[('reconciled','=', False), ('account_id.reconcile', '=', True)] "
+                            domain="[('reconciled','=', False),
+                            ('account_id.reconcile', '=', True),
+                            ('parent_state', '!=', 'cancel')]"
                         />
                         <!-- we removed the filter on amount_to_pay, because we want to be able to
                         select refunds -->


### PR DESCRIPTION
## Is your feature request related to a problem?
Yes. The field `move_line_id` in `account.payment.line` is currently showing accounting entries that are in *draft* or *cancelled* state.  
Additionally, when an account has the reconcile flag enabled, entries from accounts like inventory or bank clearing accounts are displayed, even though they should not be selectable in payments.  
This can cause wrong reconciliations and incorrect payment allocations.

## Describe the solution you'd like
Restrict the domain of `move_line_id` so that only posted receivable and payable move lines are shown.  

**Proposed domain:**
```xml
[('reconciled','=', False),
 ('account_id.reconcile', '=', True),
 ('parent_state', '=', 'posted'),
 ('account_id.account_type', 'in', ('asset_receivable', 'liability_payable'))]
```

## Describe alternatives you've considered
- Keeping the current domain: not acceptable since it allows invalid move lines.  
- Filtering only by `parent_state='posted'`: this still allows non-receivable/payable accounts to appear, which is not correct for payments.  

## Additional context
By restricting the domain to posted receivable/payable move lines, we ensure that only valid customer and vendor entries are selectable, which matches the payment process and avoids reconciliation errors.