### PR TITLE
[16.0][IMP] account_banking_mandate_contact: Make field company-dependent

### DIFF
--- a/account_banking_mandate_contact/__manifest__.py
+++ b/account_banking_mandate_contact/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Account Banking Mandate Contact",
     "summary": "Assign specific banking mandates in contact level",
-    "version": "16.0.1.0.4",
+    "version": "16.0.1.1.0",
     "development_status": "Production/Stable",
     "category": "Banking addons",
     "website": "https://github.com/OCA/bank-payment",

--- a/account_banking_mandate_contact/migrations/16.0.1.1.0/post-migration.py
+++ b/account_banking_mandate_contact/migrations/16.0.1.1.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.convert_to_company_dependent(
+        env, "res.partner", "old_contact_mandate_id", "contact_mandate_id"
+    )

--- a/account_banking_mandate_contact/migrations/16.0.1.1.0/pre-migration.py
+++ b/account_banking_mandate_contact/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    openupgrade.rename_columns(
+        cr, {"res_partner": [("contact_mandate_id", "old_contact_mandate_id")]}
+    )

--- a/account_banking_mandate_contact/models/account_move_line.py
+++ b/account_banking_mandate_contact/models/account_move_line.py
@@ -13,6 +13,7 @@ class AccountMoveLine(models.Model):
         vals = super(AccountMoveLine, self)._prepare_payment_line_vals(payment_order)
         if payment_order.payment_type != "inbound" or self.move_id.mandate_id:
             return vals
+        self = self.with_company(self.company_id)
         mandate = (
             self.move_id.partner_shipping_id.valid_mandate_id
             or self.move_id.partner_id.valid_mandate_id

--- a/account_banking_mandate_contact/models/res_partner.py
+++ b/account_banking_mandate_contact/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -10,9 +10,12 @@ class ResPartner(models.Model):
     contact_mandate_id = fields.Many2one(
         comodel_name="account.banking.mandate",
         string="Contact Mandate",
+        company_dependent=True,
     )
 
+    @api.depends_context("company")
     def _compute_valid_mandate_id(self):
+        self = self.with_company(self.env.company)
         partners_to_process = self.filtered(
             lambda x: x.contact_mandate_id.state == "valid"
         )

--- a/account_banking_mandate_sale_contact/models/sale_order.py
+++ b/account_banking_mandate_sale_contact/models/sale_order.py
@@ -23,6 +23,7 @@ class SaleOrder(models.Model):
                     or order.company_id.sale_default_mandate_contact
                 )
                 if partner_mandate_config:
+                    order = order.with_company(order.company_id)
                     mandate = False
                     if partner_mandate_config == "partner_id":
                         mandate = order.partner_id.contact_mandate_id


### PR DESCRIPTION
Banking mandates, on contrary than the partner banks, have to be company specific, as the mandate is signed between the company and the partner, not for all the companies in Odoo.

Thus, if we set a specific banking mandate for a contact, it should be restricted just to the company in which the mandate was signed.

Let's make the field company dependent for avoiding the problem.

@Tecnativa TT58428