### PR TITLE
[18.0][FIX] account_banking_mandate: Make partner bank domain to work

### DIFF
--- a/account_banking_mandate/models/account_banking_mandate.py
+++ b/account_banking_mandate/models/account_banking_mandate.py
@@ -21,12 +21,6 @@ class AccountBankingMandate(models.Model):
     _check_company_auto = True
     _rec_names_search = ["unique_mandate_reference", "partner_bank_id.acc_number"]
 
-    def _get_default_partner_bank_id_domain(self):
-        if "default_partner_id" in self.env.context:
-            return [("partner_id", "=", self.env.context.get("default_partner_id"))]
-        else:
-            return []
-
     format = fields.Selection(
         [("basic", "Basic Mandate")],
         default="basic",
@@ -43,11 +37,11 @@ class AccountBankingMandate(models.Model):
         comodel_name="res.partner.bank",
         string="Bank Account",
         tracking=40,
-        domain=lambda self: self._get_default_partner_bank_id_domain(),
         ondelete="restrict",
         index="btree",
         check_company=True,
     )
+    partner_bank_domain = fields.Binary(compute="_compute_partner_bank_domain")
     partner_id = fields.Many2one(
         comodel_name="res.partner",
         related="partner_bank_id.partner_id",
@@ -95,6 +89,15 @@ class AccountBankingMandate(models.Model):
             "A Mandate with the same reference already exists for this company!",
         )
     ]
+
+    @api.depends("format")  # A field with default for triggering the compute
+    @api.depends_context("default_partner_id")
+    def _compute_partner_bank_domain(self):
+        self.partner_bank_domain = []
+        if "default_partner_id" in self.env.context:
+            self.partner_bank_domain = [
+                ("partner_id", "=", self.env.context["default_partner_id"])
+            ]
 
     @api.depends("unique_mandate_reference", "partner_bank_id.acc_number")
     def _compute_display_name(self):

--- a/account_banking_mandate/views/account_banking_mandate_view.xml
+++ b/account_banking_mandate/views/account_banking_mandate_view.xml
@@ -59,6 +59,7 @@
                         <field
                             name="partner_bank_id"
                             options="{'create_name_field': 'acc_number'}"
+                            domain="partner_bank_domain"
                             invisible="context.get('mandate_bank_partner_view')"
                         />
                         <field


### PR DESCRIPTION
The old mechanism with the field domain and the lambda is not working anymore (it was hackish anyway), so let's use the modern approach of binary computed domain and apply such domain on the view.

@Tecnativa TT58529