### PR TITLE
[IMP] account_payment_partner: Handle ir_property table rename in migrations

### DIFF
--- a/account_payment_partner/migrations/18.0.1.0.0/post-migration.py
+++ b/account_payment_partner/migrations/18.0.1.0.0/post-migration.py
@@ -12,3 +12,18 @@ def migrate(env, version):
     openupgrade_180.convert_company_dependent(
         env, "res.partner", "customer_payment_mode_id"
     )
+    # Drop temporary ir_property table created in pre-migration
+    cr = env.cr
+    cr.execute(
+        """
+        SELECT EXISTS (
+            SELECT FROM pg_tables
+            WHERE schemaname = 'public' AND tablename = 'ir_property'
+        ) AND EXISTS (
+            SELECT FROM pg_tables
+            WHERE schemaname = 'public' AND tablename = '_ir_property'
+        )
+        """
+    )
+    if cr.fetchone()[0]:
+        openupgrade.logged_query(cr, "DROP TABLE IF EXISTS ir_property")

--- a/account_payment_partner/migrations/18.0.1.0.0/pre-migration.py
+++ b/account_payment_partner/migrations/18.0.1.0.0/pre-migration.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Le Filament (https://le-filament.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    """Create temporary copy of _ir_property as ir_property.
+
+    In Odoo 18.0, the ir_property table was renamed to _ir_property.
+    However, openupgrade_180.convert_company_dependent() still references
+    the old table name. This pre-migration creates a temporary copy to
+    allow the post-migration to work correctly.
+    """
+    # Check if _ir_property exists and ir_property doesn't
+    cr.execute(
+        """
+        SELECT EXISTS (
+            SELECT FROM pg_tables
+            WHERE schemaname = 'public' AND tablename = '_ir_property'
+        )
+        """
+    )
+    if cr.fetchone()[0]:
+        cr.execute(
+            """
+            SELECT EXISTS (
+                SELECT FROM pg_tables
+                WHERE schemaname = 'public' AND tablename = 'ir_property'
+            )
+            """
+        )
+        if not cr.fetchone()[0]:
+            # Create temporary copy of _ir_property as ir_property
+            openupgrade.logged_query(
+                cr,
+                """
+                CREATE TABLE ir_property AS
+                SELECT * FROM _ir_property
+                """,
+            )


### PR DESCRIPTION
In Odoo 18.0, the ir_property table is renamed to _ir_property when using the Enterprise Migration Service. This adds a pre-migration to create a temporary copy for compatibility with openupgrade_180.convert_company_dependent(), and cleans it up in post-migration.

Related: 

https://github.com/OCA/bank-payment/issues/1507
https://github.com/OCA/bank-payment/issues/1498

https://github.com/OCA/bank-payment/pull/1492