### PR TITLE
[17.0][FIX] account_payment_order: filter out non-draft moves when cancelling payments

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -252,7 +252,7 @@ class AccountPaymentOrder(models.Model):
 
     def action_cancel(self):
         # Unreconcile and cancel payments
-        self.payment_ids.action_draft()
+        self.payment_ids.filtered(lambda p: p.move_id.state != "draft").action_draft()
         self.payment_ids.action_cancel()
         self.write({"state": "cancel"})
         return True


### PR DESCRIPTION
## Module
account_payment_order

## Describe the bug
Clicking on the _Cancel Payments_ button on a Payment Order can raise an Exception:
<img width="1093" height="404" alt="image" src="https://github.com/user-attachments/assets/662fdf73-69b4-418a-ac9f-05dae1ec9738" />

## To Reproduce
**Affected versions**: 17.0

1. On a Supplier Invoice, click on the _Add to Payment Order_ button
2. On the Payment Order, click on the _Confirm Payments_ button, then on the _Cancel Payments_ button
-> An error message appears, as calling `action_draft()` on `draft` moves raises a UserError which blocks the "Cancel Payments" button from working properly

The _Cancel Payments_ button works properly once the Payment Order has reached the `uploaded` state, but not before, according to my tests.

This fix just filters out `account.payment`-linked moves by their state so they are only impacted by the `action_draft` call if they are not already in `draft` state.