### PR TITLE
[16.0][FIX] account_banking_sepa_direct_debit: Compact report when not English

### DIFF
--- a/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
+++ b/account_banking_sepa_direct_debit/views/report_sepa_direct_debit_mandate.xml
@@ -18,21 +18,17 @@
                     <h4 t-if="doc.scheme != 'B2B'">
                         <strong>Sepa Direct Debit Mandate</strong>
                         <t t-if="is_not_english">
-                            <br />
                             <span
                                 class="native_lang native_lang_small"
-                                t-esc="'Sepa Direct Debit Mandate'"
-                            />
+                            >(Sepa Direct Debit Mandate)</span>
                         </t>
                     </h4>
                     <h4 t-if="doc.scheme == 'B2B'">
                         <strong>Sepa Business-To-Business Direct debit Mandate</strong>
                         <t t-if="is_not_english">
-                            <br />
                             <span
                                 class="native_lang native_lang_small"
-                                t-esc="'Sepa Business-To-Business Direct debit Mandate'"
-                            />
+                            >(Sepa Business-To-Business Direct debit Mandate)</span>
                         </t>
                     </h4>
                 </div>


### PR DESCRIPTION
Backport of #1521 and #1522

To fit in one page. As if not, the title is split into 2 lines.

**Before**
<img width="1090" height="212" alt="imagen" src="https://github.com/user-attachments/assets/71bbf91b-39d4-4e9e-9600-b359e18ad1d4" />
<img width="1083" height="195" alt="imagen" src="https://github.com/user-attachments/assets/99a1217f-09f3-4757-be85-9d5c5d8295c6" />

**After**
<img width="1037" height="177" alt="imagen" src="https://github.com/user-attachments/assets/c6b00af8-572b-4f1d-ac9e-00c94d2192ab" />

@Tecnativa