### PR TITLE
[18.0][FIX] account_payment_order_grouped_output: tree > list

### DIFF
--- a/account_payment_order_grouped_output/models/account_payment_order.py
+++ b/account_payment_order_grouped_output/models/account_payment_order.py
@@ -196,7 +196,7 @@ class AccountPaymentOrder(models.Model):
         if self.grouped_move_count == 1:
             action.update(
                 {
-                    "view_mode": "form,tree,kanban",
+                    "view_mode": "form,list,kanban",
                     "views": False,
                     "view_id": False,
                     "res_id": self.grouped_move_ids.id,


### PR DESCRIPTION
Leftover of the migration.

@Tecnativa TT59083