### PR TITLE
[18.0][FIX] account_payment_order: Don't try to go to draft if already there

### DIFF
--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -252,8 +252,8 @@ class AccountPaymentOrder(models.Model):
 
     def action_cancel(self):
         # Unreconcile and cancel payments
-        self.payment_ids.action_draft()
-        self.payment_ids.action_cancel()
+        self.payment_ids.filtered(lambda x: x.state == "posted").action_draft()
+        self.payment_ids.filtered(lambda x: x.state == "draft").action_cancel()
         self.write({"state": "cancel"})
         return True
 


### PR DESCRIPTION
Forward-port of #1537 

When cancelling a payment order in state "Confirmed", the linked payments are yet in draft, so cancelling in that moment the payment order gives an error that only posted moves can be reset to draft.

The solution is to filter which payments to move to draft.

@Tecnativa TT59926