### PR TITLE
[16.0][FIX] account_payment_order_vendor_email: Incorrect warning message when vendor email is sent successfully

### DIFF
--- a/account_payment_order_vendor_email/models/account_payment_mode.py
+++ b/account_payment_order_vendor_email/models/account_payment_mode.py
@@ -87,7 +87,7 @@ class PaymentOrder(models.Model):
                             rec.id, force_send=True
                         )
                         rec.message_post(
-                            body=_("An email is not able to send to %s vendor.")
+                            body=_("An email is sent successfully to %s vendor.")
                             % partner_name
                         )
                     else:


### PR DESCRIPTION
The code was posting the message “An email is not able to send to <vendor>” even when the email was sent successfully.
This PR updates the chatter message so it correctly reflects a successful email send.