### PR TITLE
[16.0][IMP] account_payment_order: filters account_id and analytic_account_id

### DIFF
--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -233,6 +233,76 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(order.move_ids[0].date, order.payment_ids[0].date)
         self.assertEqual(order.state, "uploaded")
 
+    def test_wizard_filters_by_account_id(self):
+        if self.invoice.state != "posted":
+            self.invoice.action_post()
+        order = self.env["account.payment.order"].create(
+            {
+                "payment_type": "outbound",
+                "payment_mode_id": self.mode.id,
+            }
+        )
+        other_payable_account = self.env["account.account"].create(
+            {
+                "name": "Other Payable Test",
+                "code": "PAYTEST",
+                "account_type": "liability_payable",
+                "company_id": self.company.id,
+            }
+        )
+        wizard_filtered = (
+            self.env["account.payment.line.create"]
+            .with_context(active_model="account.payment.order", active_id=order.id)
+            .create(
+                {
+                    "date_type": "move",
+                    "move_date": fields.Date.today(),
+                    "account_id": other_payable_account.id,
+                }
+            )
+        )
+        wizard_filtered.payment_mode = "any"
+        wizard_filtered.populate()
+        self.assertFalse(wizard_filtered.move_line_ids)
+
+    def test_wizard_filters_by_analytic_account(self):
+        if self.invoice.state != "posted":
+            self.invoice.action_post()
+        order = self.env["account.payment.order"].create(
+            {
+                "payment_type": "outbound",
+                "payment_mode_id": self.mode.id,
+            }
+        )
+        plan = self.env["account.analytic.plan"].search(
+            [("company_id", "=", self.company.id)], limit=1
+        )
+        if not plan:
+            plan = self.env["account.analytic.plan"].create(
+                {"name": "Wizard Analytic Plan", "company_id": self.company.id}
+            )
+        analytic_account = self.env["account.analytic.account"].create(
+            {
+                "name": "Wizard Analytic Test",
+                "company_id": self.company.id,
+                "plan_id": plan.id,
+            }
+        )
+        wizard_analytic = (
+            self.env["account.payment.line.create"]
+            .with_context(active_model="account.payment.order", active_id=order.id)
+            .create(
+                {
+                    "date_type": "move",
+                    "move_date": fields.Date.today(),
+                    "analytic_account_id": analytic_account.id,
+                }
+            )
+        )
+        wizard_analytic.payment_mode = "any"
+        wizard_analytic.populate()
+        self.assertFalse(wizard_analytic.move_line_ids)
+
     def _line_creation(self, outbound_order):
         vals = {
             "order_id": outbound_order.id,

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -38,6 +38,14 @@ class AccountPaymentLineCreate(models.TransientModel):
     payment_mode = fields.Selection(
         selection=[("same", "Same"), ("same_or_null", "Same or Empty"), ("any", "Any")],
     )
+    account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="Account",
+    )
+    analytic_account_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="Analytic Account",
+    )
     move_line_ids = fields.Many2many(
         comodel_name="account.move.line", string="Move Lines"
     )
@@ -78,6 +86,12 @@ class AccountPaymentLineCreate(models.TransientModel):
             domain += [("move_id.state", "=", "posted")]
         if not self.allow_blocked:
             domain += [("blocked", "!=", True)]
+        if self.account_id:
+            domain.append(("account_id", "=", self.account_id.id))
+        if self.analytic_account_id:
+            domain.append(
+                ("analytic_line_ids.account_id", "=", self.analytic_account_id.id)
+            )
         if self.date_type == "due":
             domain += [
                 "|",
@@ -173,6 +187,8 @@ class AccountPaymentLineCreate(models.TransientModel):
         "allow_blocked",
         "payment_mode",
         "partner_ids",
+        "account_id",
+        "analytic_account_id",
     )
     def move_line_filters_change(self):
         domain = self._prepare_move_line_domain()

--- a/account_payment_order/wizard/account_payment_line_create_view.xml
+++ b/account_payment_order/wizard/account_payment_line_create_view.xml
@@ -31,6 +31,8 @@
                         widget="many2many_tags"
                         placeholder="Keep empty to use all partners"
                     />
+                    <field name="account_id" />
+                    <field name="analytic_account_id" />
                     <field name="payment_mode" />
                     <field name="target_move" widget="radio" />
                     <field name="invoice" />


### PR DESCRIPTION
@Escodoo HT01631

## PR Description
Added two new filters to the `“Create Payment Lines from Journal Items”` wizard (`account.payment.line.create`):
Account (`account_id`)
Analytic Account / Cost Center (`analytic_account_id`)
These fields are now applied in the domain used to search journal items, including the “`Add All Move Lines`” button, reducing the number of `account.move.line` records loaded.

#### Result: users can better isolate what they want to pay (by account and/or cost center), with fewer unwanted records and less manual line deletion.

cc @marcelsavegnago @kaynnan @WesleyOliveira98 