### PR TITLE
[16.0][FIX] account_banking_sepa_credit_transfer + account_payment_partner + account_payment_purchase: Fix tests

### DIFF
--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -128,6 +128,7 @@ class TestSCT(TransactionCase):
                 "acc_number": "FR66 1212 1212 1212 1212 1212 121",
                 "bank_id": cls.bank.id,
                 "partner_id": cls.partner_1.id,
+                "allow_out_payment": True,
             }
         )
         cls.partner_2 = cls.env["res.partner"].create(

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -149,6 +149,7 @@ class TestAccountPaymentPartner(TransactionCase):
             {
                 "acc_number": "5345345",
                 "partner_id": cls.supplier.id,
+                "allow_out_payment": True,
             }
         )
         cls.supplier.with_company(

--- a/account_payment_purchase/tests/test_account_payment_purchase.py
+++ b/account_payment_purchase/tests/test_account_payment_purchase.py
@@ -46,6 +46,7 @@ class TestAccountPaymentPurchaseBase(TransactionCase):
                 "bank_name": "Test bank",
                 "acc_number": "1234567890",
                 "partner_id": cls.partner.id,
+                "allow_out_payment": True,
             }
         )
         cls.bank2 = cls.env["res.partner.bank"].create(


### PR DESCRIPTION
Fix tests: `account_banking_sepa_credit_transfer` + `account_payment_partner` + `account_payment_purchase`

Related to https://github.com/odoo/odoo/commit/7763099c91383745464f55b3a8ef13eb0d7f31f2

Although https://github.com/OCA/bank-payment/pull/1340 already exists, this PR only aims to correct the tests, leaving the other PR for all internal behavioral changes that need to be made.

@Tecnativa TT60914