### PR TITLE
[16.0][IMP] Update Copier template to v1.37 and add pyproject.toml

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.29
+_commit: v1.37
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 convert_readme_fragments_to_markdown: false
@@ -17,10 +17,10 @@ odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups: []
-repo_description: 'TODO: add repo description.'
+repo_description: Banking payment addons for Odoo.
 repo_name: bank-payment
 repo_slug: bank-payment
 repo_website: https://github.com/OCA/bank-payment
-use_pyproject_toml: false
+use_pyproject_toml: true
 use_ruff: false
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-requirements.txt merge=union

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             makepot: "true"
     services:
       postgres:
-        image: postgres:12.0
+        image: postgres:12
         env:
           POSTGRES_USER: odoo
           POSTGRES_PASSWORD: odoo
@@ -63,6 +63,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,12 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+  - repo: https://github.com/sbidoul/whool
+    rev: v1.3
+    hooks:
+      - id: whool-init
   - repo: https://github.com/oca/maintainer-tools
-    rev: d5fab7ee87fceee858a3d01048c78a548974d935
+    rev: f9b919b9868143135a9c9cb03021089cabba8223
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -53,6 +57,7 @@ repos:
           - --repo-name=bank-payment
           - --if-source-changed
           - --keep-source-digest
+      - id: oca-gen-external-dependencies
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.25
     hooks:
@@ -104,6 +109,7 @@ repos:
         additional_dependencies:
           - "eslint@8.24.0"
           - "eslint-plugin-jsdoc@"
+          - "globals@"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -139,16 +145,6 @@ repos:
         args:
           - --settings=.
         exclude: /__init__\.py$
-  - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
-    hooks:
-      - id: setuptools-odoo-make-default
-      - id: setuptools-odoo-get-requirements
-        args:
-          - --output
-          - requirements.txt
-          - --header
-          - "# generated from manifests external_dependencies"
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+[![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
 
+# bank-payment
 [![Runboat](https://img.shields.io/badge/runboat-Try%20me-875A7B.png)](https://runboat.odoo-community.org/builds?repo=OCA/bank-payment&target_branch=16.0)
 [![Pre-commit Status](https://github.com/OCA/bank-payment/actions/workflows/pre-commit.yml/badge.svg?branch=16.0)](https://github.com/OCA/bank-payment/actions/workflows/pre-commit.yml?query=branch%3A16.0)
 [![Build Status](https://github.com/OCA/bank-payment/actions/workflows/test.yml/badge.svg?branch=16.0)](https://github.com/OCA/bank-payment/actions/workflows/test.yml?query=branch%3A16.0)
@@ -7,9 +9,7 @@
 
 <!-- /!\ do not modify above this line -->
 
-# bank-payment
-
-TODO: add repo description.
+Banking payment addons for Odoo.
 
 <!-- /!\ do not modify below this line -->
 

--- a/account_banking_mandate/pyproject.toml
+++ b/account_banking_mandate/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_mandate_contact/pyproject.toml
+++ b/account_banking_mandate_contact/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_mandate_sale/pyproject.toml
+++ b/account_banking_mandate_sale/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_mandate_sale_contact/pyproject.toml
+++ b/account_banking_mandate_sale_contact/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_pain_base/pyproject.toml
+++ b/account_banking_pain_base/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_sepa_credit_transfer/pyproject.toml
+++ b/account_banking_sepa_credit_transfer/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_banking_sepa_direct_debit/pyproject.toml
+++ b/account_banking_sepa_direct_debit/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_method_fs_storage/pyproject.toml
+++ b/account_payment_method_fs_storage/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_mode/pyproject.toml
+++ b/account_payment_mode/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order/pyproject.toml
+++ b/account_payment_order/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order_grouped_output/pyproject.toml
+++ b/account_payment_order_grouped_output/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order_notification/pyproject.toml
+++ b/account_payment_order_notification/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order_return/pyproject.toml
+++ b/account_payment_order_return/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order_tier_validation/pyproject.toml
+++ b/account_payment_order_tier_validation/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_order_vendor_email/pyproject.toml
+++ b/account_payment_order_vendor_email/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_partner/pyproject.toml
+++ b/account_payment_partner/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_purchase/pyproject.toml
+++ b/account_payment_purchase/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_purchase_stock/pyproject.toml
+++ b/account_payment_purchase_stock/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/account_payment_sale/pyproject.toml
+++ b/account_payment_sale/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"


### PR DESCRIPTION
## Summary
- Update Copier template from v1.29 to v1.37
- Enable `use_pyproject_toml` and add `pyproject.toml` (whool) to all modules
- Update repo description, CI workflows, and pre-commit config

## Why this is needed
`setuptools-odoo` is no longer maintained and is breaking pre-commit hooks. Migrating to `whool` via `pyproject.toml` resolves this issue and ensures the repository stays functional with current tooling.

## Modules affected
All modules in this repository (one commit per module for pyproject.toml).