### PR TITLE
[18.0][PORT] account_payment_partner: add flag to control partner_bank_id without payment mode

### DIFF
--- a/account_payment_partner/__manifest__.py
+++ b/account_payment_partner/__manifest__.py
@@ -20,6 +20,7 @@
         "views/account_move_view.xml",
         "views/account_move_line.xml",
         "views/account_payment_mode.xml",
+        "views/res_config_settings.xml",
         "views/report_invoice.xml",
         "reports/account_invoice_report_view.xml",
     ],

--- a/account_payment_partner/models/__init__.py
+++ b/account_payment_partner/models/__init__.py
@@ -1,1 +1,8 @@
-from . import account_move, account_move_line, account_payment_mode, res_partner
+from . import (
+    account_move,
+    account_move_line,
+    account_payment_mode,
+    res_company,
+    res_config_settings,
+    res_partner,
+)

--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -120,7 +120,8 @@ class AccountMove(models.Model):
                     else:
                         move.partner_bank_id = False
             else:
-                move.partner_bank_id = False
+                if not move.company_id.keep_partner_bank_without_payment_mode:
+                    move.partner_bank_id = False
         return res
 
     @api.depends("line_ids.matched_credit_ids", "line_ids.matched_debit_ids")

--- a/account_payment_partner/models/res_company.py
+++ b/account_payment_partner/models/res_company.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Engenere - Felipe Motter Pereira
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    keep_partner_bank_without_payment_mode = fields.Boolean(
+        string="Keep Bank Account Without Payment Mode",
+        default=True,
+        help="When enabled, invoices without a payment mode will keep "
+        "the bank account auto-selected by Odoo. When disabled, "
+        "the bank account will be cleared if no payment mode is set.",
+    )

--- a/account_payment_partner/models/res_config_settings.py
+++ b/account_payment_partner/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Engenere - Felipe Motter Pereira
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    keep_partner_bank_without_payment_mode = fields.Boolean(
+        related="company_id.keep_partner_bank_without_payment_mode",
+        readonly=False,
+    )

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -229,6 +229,7 @@ class TestAccountPaymentPartner(BaseCommon):
 
     def test_partner_id_changes_compute_partner_bank(self):
         # Test _compute_partner_bank is executed when partner_id changes
+        self.env.company.keep_partner_bank_without_payment_mode = False
         move_form = Form(
             self.env["account.move"].with_context(default_move_type="out_invoice")
         )
@@ -251,6 +252,7 @@ class TestAccountPaymentPartner(BaseCommon):
         invoice.company_id = self.company_2
         self.assertEqual(invoice.payment_mode_id, self.payment_mode_model)
 
+        self.company_2.keep_partner_bank_without_payment_mode = False
         invoice.payment_mode_id = False
         self.assertFalse(invoice.partner_bank_id)
 
@@ -498,6 +500,7 @@ class TestAccountPaymentPartner(BaseCommon):
         vals = {"partner_id": False, "move_type": "in_invoice"}
         invoice = self.move_model.new(vals)
         self.assertFalse(invoice.partner_bank_id)
+        self.env.company.keep_partner_bank_without_payment_mode = False
         vals = {"partner_id": False, "move_type": "in_refund"}
         invoice = self.move_model.new(vals)
         self.assertFalse(invoice.partner_bank_id)
@@ -510,8 +513,60 @@ class TestAccountPaymentPartner(BaseCommon):
         self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
         mode.payment_method_id.bank_account_required = False
         self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
+        self.env.company.keep_partner_bank_without_payment_mode = True
+        self.supplier_invoice.payment_mode_id = False
+        self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
+
+    def test_no_payment_mode_clears_bank_when_flag_disabled(self):
+        """When keep_partner_bank_without_payment_mode is disabled,
+        clearing the payment mode should also clear partner_bank_id."""
+        self.company.keep_partner_bank_without_payment_mode = False
+        self.supplier_invoice.partner_bank_id = self.supplier_bank.id
         self.supplier_invoice.payment_mode_id = False
         self.assertFalse(self.supplier_invoice.partner_bank_id)
+
+    def test_refund_no_payment_mode_preserves_partner_bank(self):
+        """Test that partner_bank_id is preserved on refund without payment mode.
+
+        When a partner has a bank account with allow_out_payment=True but no
+        payment mode is configured, the reversal wizard should still auto-select
+        the trusted bank account via core _compute_partner_bank_id.
+        """
+        self.env.company.keep_partner_bank_without_payment_mode = True
+        partner_no_mode = (
+            self.env["res.partner"]
+            .with_company(self.company.id)
+            .create({"name": "Partner without payment mode"})
+        )
+        trusted_bank = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "BE32121212121212",
+                "partner_id": partner_no_mode.id,
+                "allow_out_payment": True,
+            }
+        )
+        invoice = self._create_invoice(
+            default_move_type="out_invoice", partner=partner_no_mode
+        )
+        invoice.payment_mode_id = False
+        invoice.action_post()
+
+        refund_wizard = (
+            self.env["account.move.reversal"]
+            .with_context(
+                active_ids=[invoice.id],
+                active_id=invoice.id,
+                active_model="account.move",
+            )
+            .create(
+                {
+                    "reason": "test refund without payment mode",
+                    "journal_id": invoice.journal_id.id,
+                }
+            )
+        )
+        refund_move = self.move_model.browse(refund_wizard.reverse_moves()["res_id"])
+        self.assertEqual(refund_move.partner_bank_id, trusted_bank)
 
     def test_print_report(self):
         self.supplier_invoice.partner_bank_id = self.supplier_bank.id

--- a/account_payment_partner/views/res_config_settings.xml
+++ b/account_payment_partner/views/res_config_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Engenere - Felipe Motter Pereira
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.account.payment.partner</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@id='pay_invoice_online_setting_container']"
+                position="inside"
+            >
+                <setting
+                    help="Keep the bank account auto-selected by Odoo on invoices without a payment mode. Disable to clear the bank account when no payment mode is set."
+                >
+                    <field name="keep_partner_bank_without_payment_mode" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_vendor_bank_account_default/tests/test_account_vendor_bank_account_default.py
+++ b/account_vendor_bank_account_default/tests/test_account_vendor_bank_account_default.py
@@ -113,7 +113,8 @@ class TestAccountVendorBankAccountDefault(AccountTestInvoicingCommon):
         self.assertFalse(in_invoice.partner_bank_id)
 
     def test_no_payment_mode(self):
-        # Test no bank account if bank_account is not required in payment mode
+        # Test no bank account when no payment mode and flag is disabled
+        self.env.company.keep_partner_bank_without_payment_mode = False
         self.partner_a.default_bank_id = self.bank_account2
         self.partner_a.supplier_payment_mode_id = False
         in_invoice = self.create_in_invoice()


### PR DESCRIPTION
Port of #1555 from 16.0 to 18.0.

## Summary

Adds a company-level flag `keep_partner_bank_without_payment_mode` to control whether `partner_bank_id` is preserved or cleared when no payment mode is set on an invoice.

- **`True` (default):** keeps the bank account auto-selected by Odoo core
- **`False`:** clears the bank account (legacy behavior)

Includes a Settings toggle under Accounting > Customer Payments and tests covering both flag states plus refund without payment mode.

### v18 adaptations

- Settings XML: uses `<block>` and `<setting>` tags (v18 pattern instead of v16 `<div>` / `o_setting_box`)
- Existing tests adapted with explicit `keep_partner_bank_without_payment_mode = False` where Odoo 18 core now computes `partner_bank_id` in scenarios that v16 did not
- `account_vendor_bank_account_default` test adapted (separate commit) since it depends on `account_payment_partner` and was affected by the behavior change