### PR TITLE
[16.0][FIX] account_payment_partner: If acc_number is incorrect raise an error

### DIFF
--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -522,7 +522,7 @@ class TestAccountPaymentPartner(TransactionCase):
         )
         trusted_bank = self.env["res.partner.bank"].create(
             {
-                "acc_number": "BE32121212121212",
+                "acc_number": "es1299999999509999999999",
                 "partner_id": partner_no_mode.id,
                 "allow_out_payment": True,
             }


### PR DESCRIPTION
raise exceptions.InvalidChecksumDigits("Invalid checksum digits") 

Traceback:
```
File "/opt/odoo/auto/addons/account_payment_partner/tests/test_account_payment_partner.py", line 523, in test_refund_no_payment_mode_preserves_partner_bank
    trusted_bank = self.env["res.partner.bank"].create(
  File "<decorator-gen-782>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 430, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in create
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 21, in <listcomp>
    vals_list = [self._add_bank_vals(vals) for vals in vals_list]
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 30, in _add_bank_vals
    vals["bank_id"] = self._get_bank_from_iban(vals["acc_number"]).id
  File "/opt/odoo/auto/addons/base_bank_from_iban/models/res_partner_bank.py", line 36, in _get_bank_from_iban
    iban = schwifty.IBAN(acc_number)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 77, in __init__
    self.validate(validate_bban)
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 178, in validate
    self._validate_iban_checksum()
  File "/usr/local/lib/python3.10/site-packages/schwifty/iban.py", line 202, in _validate_iban_checksum
    raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
schwifty.exceptions.InvalidChecksumDigits: Invalid checksum digits
```

@Tecnativa
TT61063