### PR TITLE
[17.0][FIX] account_*: Adapt tests to odoo new banks flow

### DIFF
--- a/account_banking_mandate_contact/tests/test_account_payment_order.py
+++ b/account_banking_mandate_contact/tests/test_account_payment_order.py
@@ -30,8 +30,12 @@ class TestAccountPaymentOrder(TransactionCase):
                 "name": "BANK",
                 "type": "bank",
                 "code": "bank",
+                "bank_acc_number": "123456",
             }
         )
+        cls.journal_bank.bank_account_id.with_user(
+            cls.env.ref("base.user_admin")
+        ).allow_out_payment = True
         payment_form = Form(cls.env["account.payment.mode"])
         payment_form.name = "SEPA (CORE)"
         payment_form.payment_method_id = cls.method_sepa

--- a/account_banking_sepa_credit_transfer/tests/test_sct.py
+++ b/account_banking_sepa_credit_transfer/tests/test_sct.py
@@ -121,13 +121,17 @@ class TestSCT(BaseCommon):
                 "name": "Test Partner 1",
             }
         )
-        cls.partner_bank_1 = cls.env["res.partner.bank"].create(
-            {
-                "acc_number": "FR66 1212 1212 1212 1212 1212 121",
-                "bank_id": cls.bank.id,
-                "partner_id": cls.partner_1.id,
-                "allow_out_payment": True,
-            }
+        cls.partner_bank_1 = (
+            cls.env["res.partner.bank"]
+            .with_user(cls.env.ref("base.user_admin"))
+            .create(
+                {
+                    "acc_number": "FR66 1212 1212 1212 1212 1212 121",
+                    "bank_id": cls.bank.id,
+                    "partner_id": cls.partner_1.id,
+                    "allow_out_payment": True,
+                }
+            )
         )
         cls.partner_2 = cls.env["res.partner"].create(
             {

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -69,6 +69,12 @@ class TestAccountPaymentPartner(TransactionCase):
                 "bank_acc_number": "123456",
             }
         )
+        # Use admin user as the SUPERUSER is not allowed to
+        # modify allow_out_payment on bank accounts and this
+        # is needed to avoid error when posting the invoice
+        cls.journal_c1.bank_account_id.with_user(
+            cls.env.ref("base.user_admin")
+        ).allow_out_payment = True
 
         cls.journal_c2 = cls.journal_model.create(
             {
@@ -247,7 +253,10 @@ class TestAccountPaymentPartner(TransactionCase):
         move_form = Form(
             self.env["account.move"].with_context(default_move_type="out_invoice")
         )
-        self.assertFalse(move_form.partner_bank_id)
+        # The partner bank should be set as Odoo made possible
+        # to assign not allow_out_payment bank account
+        # more info https://github.com/odoo/odoo/commit/1794fce234735ed174599891435d4e2accc16324
+        self.assertTrue(move_form.partner_bank_id)
         move_form.partner_id = self.customer
         self.assertEqual(move_form.payment_mode_id, self.customer_payment_mode)
         self.assertFalse(move_form.partner_bank_id)
@@ -262,12 +271,13 @@ class TestAccountPaymentPartner(TransactionCase):
             }
         )
         self.assertEqual(invoice.payment_mode_id, self.customer_payment_mode)
-
         invoice.company_id = self.company_2
         self.assertEqual(invoice.payment_mode_id, self.payment_mode_model)
-
+        prev_partner_bank_id = invoice.partner_bank_id.id
         invoice.payment_mode_id = False
-        self.assertFalse(invoice.partner_bank_id)
+        # Without the check keep_partner_bank_without_payment_mode on company
+        # the partner bank should remain the same
+        self.assertEqual(invoice.partner_bank_id.id, prev_partner_bank_id)
 
     def test_invoice_create_in_invoice(self):
         invoice = self._create_invoice(
@@ -411,7 +421,8 @@ class TestAccountPaymentPartner(TransactionCase):
             refund_invoice.payment_mode_id,
             invoice.payment_mode_id.refund_payment_mode_id,
         )
-        self.assertEqual(refund_invoice.partner_bank_id, invoice.partner_bank_id)
+        # Now the partner_bank_id can be a not allow_out_payment bank account
+        self.assertTrue(refund_invoice.partner_bank_id)
 
     def test_invoice_out_refund(self):
         invoice = self._create_invoice(
@@ -477,7 +488,9 @@ class TestAccountPaymentPartner(TransactionCase):
         self.assertFalse(invoice.partner_bank_id)
         vals = {"partner_id": False, "move_type": "in_refund"}
         invoice = self.move_model.new(vals)
-        self.assertFalse(invoice.partner_bank_id)
+        # The partner bank should be set as odoo made posible
+        # to assign not allow_out_payment bank accounts
+        self.assertTrue(invoice.partner_bank_id)
 
     def test_onchange_payment_mode_id(self):
         mode = self.supplier_payment_mode

--- a/account_vendor_bank_account_default/tests/test_account_vendor_bank_account_default.py
+++ b/account_vendor_bank_account_default/tests/test_account_vendor_bank_account_default.py
@@ -97,11 +97,11 @@ class TestAccountVendorBankAccountDefault(AccountTestInvoicingCommon):
         self.assertFalse(in_invoice.partner_bank_id)
 
     def test_no_payment_mode(self):
-        # Test no bank account if bank_account is not required in payment mode
+        # Test bank account remains the same if no payment mode
         self.partner_a.default_bank_id = self.bank_account2
         self.partner_a.supplier_payment_mode_id = False
         in_invoice = self.create_in_invoice()
-        self.assertFalse(in_invoice.partner_bank_id)
+        self.assertEqual(in_invoice.partner_bank_id, self.bank_account1)
 
     def test_commercial_fields(self):
         # Test the default partner account in vendor bills with individual partner


### PR DESCRIPTION
The commit https://github.com/odoo/odoo/commit/1794fce234735ed174599891435d4e2accc16324 contains the next changes summarized:
- SUPERUSER is not capable of make a bank account allowed (Unless is at module install), now the user needs any of the groups:
  - `account.group_validate_bank_account`
  - `base.group_system`
- Now the `partner_bank_id` can contain non allow_out_payment banks, but the error will raise on post

This PR adapt the tests to the new bank flow
@Tecnativa TT61155
@carlos-lopez-tecnativa @pilarvargas-tecnativa @pedrobaeza @victoralmau 