### PR TITLE
[18.0][FIX] account_payment_order: use payment_reference if available for out payments

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
         communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
             if self.is_purchase_document():
-                communication = self.ref or self.payment_reference
+                communication = self.payment_reference or self.ref or ""
             else:
                 communication = self.payment_reference or self.name
         return communication or ""

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -307,7 +307,14 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
     def test_invoice_communication_02(self):
         self.invoice.payment_reference = "R1234"
         self.assertEqual(
-            "F1242", self.invoice._get_payment_order_communication_direct()
+            "R1234", self.invoice._get_payment_order_communication_direct()
+        )
+
+    def test_supplier_invoice_payment_reference(self):
+        self.invoice.payment_reference = "+++F1234+++"
+        self.invoice.action_post()
+        self.assertEqual(
+            "+++F1234+++", self.invoice._get_payment_order_communication_full()
         )
 
     @mute_logger("odoo.models.unlink")
@@ -437,7 +444,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.invoice.payment_reference = "F/1234"
         self.invoice.action_post()
         self.assertEqual(
-            "F1242", self.invoice._get_payment_order_communication_direct()
+            "F/1234", self.invoice._get_payment_order_communication_direct()
         )
         self.refund = self._create_supplier_refund(self.invoice)
         with Form(self.refund) as refund_form:
@@ -447,7 +454,9 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
                 line_form.price_unit = 75.0
 
         self.refund.action_post()
-        self.assertEqual("R1234", self.refund._get_payment_order_communication_direct())
+        self.assertEqual(
+            "FR/1234", self.refund._get_payment_order_communication_direct()
+        )
 
         self.env["account.invoice.payment.line.multi"].with_context(
             active_model="account.move", active_ids=self.invoice.ids
@@ -460,8 +469,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
 
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
-        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
-        self.assertNotIn("FR/1234", payment_order.payment_line_ids.communication)
+        self.assertEqual("F/1234 FR/1234", payment_order.payment_line_ids.communication)
 
     def test_supplier_manual_refund(self):
         """


### PR DESCRIPTION
Use `payment_reference` before ref when building payment order
communication.