### PR TITLE
[16.0][FIX] account_payment_order: allow selecting child partners on payment lines

### DIFF
--- a/account_payment_order/models/account_payment_line.py
+++ b/account_payment_order/models/account_payment_line.py
@@ -56,7 +56,6 @@ class AccountPaymentLine(models.Model):
         comodel_name="res.partner",
         string="Partner",
         required=True,
-        domain=[("parent_id", "=", False)],
         check_company=True,
     )
     partner_bank_id = fields.Many2one(

--- a/account_payment_order/wizard/account_payment_line_create.py
+++ b/account_payment_order/wizard/account_payment_line_create.py
@@ -20,7 +20,6 @@ class AccountPaymentLineCreate(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name="res.partner",
         string="Partners",
-        domain=[("parent_id", "=", False)],
     )
     target_move = fields.Selection(
         selection=[("posted", "All Posted Entries"), ("all", "All Entries")],


### PR DESCRIPTION
Remove the parent_id domain on partner_id (account.payment.line) and on partner_ids (account.payment.line.create wizard) so contacts/child partners can be freely picked when creating payment lines.


Some companies are just not billed on PO with the commercial entity, does not make sense to hold this restriction here which could be applied by view domain instead (easier to modify in Odoo use-cases).
