### PR TITLE
[16.0][FIX] account_payment_sale: ensure payment_mode_id in invoice vals

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -25,15 +25,21 @@ class SaleOrder(models.Model):
             ).customer_payment_mode_id
 
     def _get_payment_mode_vals(self, vals):
-        if self.payment_mode_id:
-            vals["payment_mode_id"] = self.payment_mode_id.id
-            if (
-                self.payment_mode_id.bank_account_link == "fixed"
-                and self.payment_mode_id.payment_method_id.code == "manual"
-            ):
-                vals[
-                    "partner_bank_id"
-                ] = self.payment_mode_id.fixed_journal_id.bank_account_id.id
+        # NB: since "payment_mode_id" is in the grouping keys,
+        # there needs to be a key in the dict for every record.
+        # Otherwise the "sorted by grouping key" might fail in
+        # "sales > models > sale_orderpy > _create_invoices" when
+        # receiving a None alongside int's.
+        vals["payment_mode_id"] = self.payment_mode_id.id
+
+        if (
+            self.payment_mode_id
+            and self.payment_mode_id.bank_account_link == "fixed"
+            and self.payment_mode_id.payment_method_id.code == "manual"
+        ):
+            vals[
+                "partner_bank_id"
+            ] = self.payment_mode_id.fixed_journal_id.bank_account_id.id
 
     def _prepare_invoice(self):
         """Copy bank partner from sale order to invoice"""


### PR DESCRIPTION
When creating invoices from multiple sales orders, Odoo groups them based on specific keys. If `payment_mode_id` is used as a grouping key, it must be present in the values dictionary for every record, even if it is False. (NB: during a sort, python will not fail if there is a mix of False and int)

Previously, the key was only added if a payment mode existed. This could lead to `TypeError '<' between 'int' and 'NoneType'` during sorting in `_create_invoices` when the system attempts to compare an integer with a missing key (resolved as `None`).

See this comment for a unit test reproducing the error: https://github.com/OCA/account-invoicing/pull/2220#issuecomment-4324904141