### PR TITLE
[17.0][FIX] account_payment_order: use payment_reference if present for out payments

### DIFF
--- a/account_payment_order/models/account_move.py
+++ b/account_payment_order/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
         communication = self.payment_reference or self.ref or self.name
         if self.is_invoice():
             if self.is_purchase_document():
-                communication = self.ref or self.payment_reference
+                communication = self.payment_reference or self.ref
             else:
                 communication = self.payment_reference or self.name
         return communication or ""

--- a/account_payment_order/tests/test_payment_order_outbound.py
+++ b/account_payment_order/tests/test_payment_order_outbound.py
@@ -277,9 +277,12 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         )
 
     def test_invoice_communication_02(self):
-        self.invoice.payment_reference = "R1234"
         self.assertEqual(
             "F1242", self.invoice._get_payment_order_communication_direct()
+        )
+        self.invoice.payment_reference = "R1234"
+        self.assertEqual(
+            "R1234", self.invoice._get_payment_order_communication_direct()
         )
 
     def test_invoice_communication_03(self):
@@ -302,6 +305,13 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(
             "ref %s" % reverse_move.ref,
             self.invoice._get_payment_order_communication_full(),
+        )
+
+    def test_supplier_invoice_payment_reference(self):
+        self.invoice.payment_reference = "+++F1234+++"
+        self.invoice.action_post()
+        self.assertEqual(
+            "+++F1234+++", self.invoice._get_payment_order_communication_full()
         )
 
     def test_manual_line_and_manual_date(self):
@@ -406,7 +416,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.invoice.payment_reference = "F/1234"
         self.invoice.action_post()
         self.assertEqual(
-            "F1242", self.invoice._get_payment_order_communication_direct()
+            "F/1234", self.invoice._get_payment_order_communication_direct()
         )
         self.refund = self._create_supplier_refund(self.invoice)
         with Form(self.refund) as refund_form:
@@ -416,7 +426,9 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
                 line_form.price_unit = 75.0
 
         self.refund.action_post()
-        self.assertEqual("R1234", self.refund._get_payment_order_communication_direct())
+        self.assertEqual(
+            "FR/1234", self.refund._get_payment_order_communication_direct()
+        )
 
         self.env["account.invoice.payment.line.multi"].with_context(
             active_model="account.move", active_ids=self.invoice.ids
@@ -429,8 +441,7 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
 
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
-        self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
-        self.assertNotIn("FR/1234", payment_order.payment_line_ids.communication)
+        self.assertEqual("F/1234 FR/1234", payment_order.payment_line_ids.communication)
 
     def test_supplier_manual_refund(self):
         """


### PR DESCRIPTION
forward port of https://github.com/OCA/bank-payment/pull/1331 , fixes https://github.com/OCA/bank-payment/issues/1539