### PR TITLE
[18.0] [FIX] account_banking_sepa_credit_transfer

### DIFF
--- a/account_banking_sepa_credit_transfer/views/account_payment_method.xml
+++ b/account_banking_sepa_credit_transfer/views/account_payment_method.xml
@@ -7,7 +7,7 @@
         <field name="model">account.payment.method</field>
         <field
             name="inherit_id"
-            ref="account_payment_mode.account_payment_method_form"
+            ref="account_banking_pain_base.account_payment_method_form"
         />
         <field name="arch" type="xml">
             <field name="pain_version" position="after">


### PR DESCRIPTION
**Bug introduced on [this](https://github.com/OCA/bank-payment/pull/1553/changes#diff-a03d136f1828fe00fb96adcafbbe84a01faf1f8424392cc45d46499dcf801cf5R1) PR**

**File: account_payment_method.xml**

**This change updates the inherited view to account_banking_pain_base.account_payment_method_form, so the [pain_version](vscode-file://vscode-app/snap/code/240/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field is guaranteed to exist when the extension is applied, preventing view validation errors during clean installations and module upgrades.**

**Solved bug:**

<img width="1688" height="883" alt="image" src="https://github.com/user-attachments/assets/b2e85fdc-4800-48d6-885c-4511a227de46" />
