### PR TITLE
[16.0] [FIX] account_banking_sepa_credit_transfer

### DIFF
--- a/account_banking_sepa_credit_transfer/views/account_payment_method.xml
+++ b/account_banking_sepa_credit_transfer/views/account_payment_method.xml
@@ -2,7 +2,10 @@
   <record id="view_account_payment_method_form_inherit_sepa_hybrid" model="ir.ui.view">
     <field name="name">account.payment.method.form.sepa.hybrid</field>
     <field name="model">account.payment.method</field>
-    <field name="inherit_id" ref="account_payment_mode.account_payment_method_form" />
+    <field
+            name="inherit_id"
+            ref="account_banking_pain_base.account_payment_method_form"
+        />
     <field name="arch" type="xml">
         <field name="pain_version" position="after">
             <field


### PR DESCRIPTION
**Bug introduced on [this](https://github.com/OCA/bank-payment/pull/1578/changes#diff-a03d136f1828fe00fb96adcafbbe84a01faf1f8424392cc45d46499dcf801cf5) PR**

**File: account_payment_method.xml**

**This change updates the inherited view to account_banking_pain_base.account_payment_method_form, so the [pain_version](vscode-file://vscode-app/snap/code/240/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field is guaranteed to exist when the extension is applied, preventing view validation errors during clean installations and module upgrades.**

**Solved bug:**

<img width="1688" height="883" alt="image" src="https://github.com/user-attachments/assets/9178e8c8-0905-417e-80d9-7834d8587fa6" />
