### PR TITLE
[19.0][FIX] account_banking_pain_base: Add company_id to the account.journal search domain in TestPainBase

### DIFF
--- a/account_banking_pain_base/tests/test_account_banking.py
+++ b/account_banking_pain_base/tests/test_account_banking.py
@@ -23,7 +23,9 @@ class TestPainBase(BaseCommon):
                 "bank_account_link": "variable",
             }
         )
-        Journal = cls.env["account.journal"].search([], limit=1)
+        Journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
         cls.partner = cls.env["res.partner"].create({"name": "Partner"})
         Bank = cls.env["res.bank"].create({"name": "Bank", "bic": "NEDSZAJJXXX"})
         cls.partner_bank = cls.env["res.partner.bank"].create(
@@ -191,7 +193,9 @@ class TestPainBase(BaseCommon):
         self.assertFalse(self.order.batch_booking)
         self.assertFalse(self.Mode.default_batch_booking)
         self.Mode.default_batch_booking = True
-        journal = self.env["account.journal"].search([], limit=1)
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.env.company.id)], limit=1
+        )
         order = self.env["account.payment.order"].create(
             {
                 "name": "TESTDBB",


### PR DESCRIPTION
If it is not filtered by company, this error is raised:

```
 File "/opt/odoo/auto/addons/account_banking_pain_base/tests/test_account_banking.py", line 37, in setUpClass
odoo.exceptions.UserError: Uh-oh! You’ve got some company inconsistencies here:
- “TST001” belongs to company “My Company (San Francisco)” while “Bank Journal” (journal_id: 'Sales') belongs to another company.
To avoid a mess, no company crossover is allowed!
```