### PR TITLE
[18.0][FIX] account_payment_order: Display the communication data in the report if no move_line_id is defined

### DIFF
--- a/account_payment_order/report/account_payment_order.xml
+++ b/account_payment_order/report/account_payment_order.xml
@@ -91,8 +91,11 @@
                                         t-esc="line.move_line_id.move_id.ref or line.move_line_id.move_id.payment_reference"
                                     />
                                 </t>
-                                <t t-else="">
+                                <t t-elif="line.move_line_id">
                                     <span t-esc="line.move_line_id.move_id.name" />
+                                </t>
+                                <t t-else="">
+                                    <span t-esc="line.communication" />
                                 </t>
                             </td>
                             <td class="text-center">


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/bank-payment/pull/1599

Display the communication data in the report if no move_line_id is defined

Please @pedrobaeza can you review it?

@Tecnativa TT62979