### PR TITLE
[FIX] account_payment_partner/sale: Trigger Recipient Bank computation

### DIFF
--- a/account_payment_partner/models/account_move.py
+++ b/account_payment_partner/models/account_move.py
@@ -158,14 +158,3 @@ class AccountMove(models.Model):
             )
         # Return this as empty recordset
         return self.partner_bank_id
-
-    @api.model
-    def create(self, vals):
-        """Force compute partner_bank_id when invoice is created from SO
-        to avoid that odoo _prepare_invoice method value will be set.
-        """
-        if self.env.context.get("active_model") == "sale.order":  # pragma: no cover
-            virtual_move = self.new(vals)
-            virtual_move._compute_partner_bank()
-            vals["partner_bank_id"] = virtual_move.partner_bank_id.id
-        return super().create(vals)

--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -38,5 +38,8 @@ class SaleOrder(models.Model):
     def _prepare_invoice(self):
         """Copy bank partner from sale order to invoice"""
         vals = super()._prepare_invoice()
+        # `partner_bank_id` is a computed field:
+        # remove the assignation so that the value will be computed
+        vals.pop("partner_bank_id", None)
         self._get_payment_mode_vals(vals)
         return vals

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -76,6 +76,7 @@ class TestSaleOrder(CommonTestCase):
             Create the invoice from sale.advance.payment.inv
         Expected result:
             The invoice must be created with the specific payment_mode
+            The invoice computes the Recipient Bank
         """
         order = self.create_sale_order(payment_mode=self.payment_mode_2)
         context = {
@@ -95,4 +96,4 @@ class TestSaleOrder(CommonTestCase):
         invoice = order.invoice_ids
         self.assertEqual(len(invoice), 1)
         self.assertEqual(invoice.payment_mode_id, self.payment_mode_2)
-        self.assertFalse(invoice.partner_bank_id)
+        self.assertEqual(invoice.partner_bank_id, self.bank)


### PR DESCRIPTION
**Steps**:
1. Install `account_payment_partner` and `sale_order_invoicing_queued` (from https://github.com/OCA/account-invoicing/tree/7015684f6d9ffd8607efb85e771b63edf737fb65/sale_order_invoicing_queued).
    Note that `account_payment_partner` is installed automatically.
2. Create a sale order.
3. Create the invoice for the order (without queue).
    Check that there is no Recipient Bank (`partner_bank_id`)
5. Delete the invoice.
6. From the sale order, enqueue the invoice creation.
7. Wait for the job to be completed.

**Expected behavior**:
There is no Recipient Bank, like when the invoice was created without queue.

**Actual behavior**:
There is a Recipient Bank.

The override of `create` was added in https://github.com/OCA/bank-payment/commit/2e5995027cdb7360784134a519633cba28ec1a52, maybe the author @carlosdauden wants to have a look?