### PR TITLE
[16.0][FIX] account_payment_order_grouped_output: reconcile grouped payments when transfer account differs from outstanding account

### DIFF
--- a/account_payment_order_grouped_output/models/account_payment_order.py
+++ b/account_payment_order_grouped_output/models/account_payment_order.py
@@ -78,8 +78,14 @@ class AccountPaymentOrder(models.Model):
     def reconcile_grouped_payments(self, move, payments):
         lines_to_rec = move.line_ids[:-1]
         for payment in payments:
+            journal = payment.journal_id
+            outstanding_accounts = (
+                journal._get_journal_inbound_outstanding_payment_accounts()
+                | journal._get_journal_outbound_outstanding_payment_accounts()
+                | payment.outstanding_account_id
+            )
             lines_to_rec += payment.move_id.line_ids.filtered(
-                lambda x: x.account_id == payment.outstanding_account_id
+                lambda x, accounts=outstanding_accounts: x.account_id in accounts
             )
         lines_to_rec.reconcile()
 


### PR DESCRIPTION
On 16.0 `reconcile_grouped_payments` looks up the payment lines to reconcile by `payment.outstanding_account_id` only. When the outstanding/efectos account is taken from the journal's outstanding-payment accounts and isn't that exact field, nothing matches, `reconcile()` does nothing, and the invoices stay in `in_payment` with the account left open.

Now it also matches against the journal's inbound/outbound outstanding accounts, like 17.0 and 18.0 do. `payment.outstanding_account_id` came in with #1486 for general-type transfer journals and I kept it, so both setups reconcile.

17.0/18.0 don't carry #1486, so they probably want the same union.