### PR TITLE
[19.0][IMP] account_payment_mode: add flag to control partner_bank_id without payment mode

### DIFF
--- a/account_payment_mode/__manifest__.py
+++ b/account_payment_mode/__manifest__.py
@@ -22,6 +22,7 @@
         "views/account_payment_method.xml",
         "views/account_payment_mode.xml",
         "views/account_journal.xml",
+        "views/res_config_settings.xml",
         "views/report_invoice.xml",
         "reports/account_invoice_report_view.xml",
     ],

--- a/account_payment_mode/models/__init__.py
+++ b/account_payment_mode/models/__init__.py
@@ -3,4 +3,6 @@ from . import account_payment_method
 from . import account_move
 from . import account_move_line
 from . import account_payment_mode
+from . import res_company
+from . import res_config_settings
 from . import res_partner

--- a/account_payment_mode/models/account_move.py
+++ b/account_payment_mode/models/account_move.py
@@ -116,7 +116,8 @@ class AccountMove(models.Model):
                     else:
                         move.partner_bank_id = False
             else:
-                move.partner_bank_id = False
+                if not move.company_id.keep_partner_bank_without_payment_mode:
+                    move.partner_bank_id = False
         return res
 
     @api.depends("line_ids.matched_credit_ids", "line_ids.matched_debit_ids")

--- a/account_payment_mode/models/res_company.py
+++ b/account_payment_mode/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Engenere - Felipe Motter Pereira
+# Copyright 2026 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    keep_partner_bank_without_payment_mode = fields.Boolean(
+        string="Keep Bank Account Without Payment Mode",
+        default=False,
+        help="When enabled, invoices without a payment mode will keep "
+        "the bank account auto-selected by Odoo. When disabled, "
+        "the bank account will be cleared if no payment mode is set.",
+    )

--- a/account_payment_mode/models/res_config_settings.py
+++ b/account_payment_mode/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Engenere - Felipe Motter Pereira
+# Copyright 2026 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    keep_partner_bank_without_payment_mode = fields.Boolean(
+        related="company_id.keep_partner_bank_without_payment_mode",
+        readonly=False,
+    )

--- a/account_payment_mode/tests/test_account_payment_partner.py
+++ b/account_payment_mode/tests/test_account_payment_partner.py
@@ -231,6 +231,7 @@ class TestAccountPaymentPartner(BaseCommon):
 
     def test_partner_id_changes_compute_partner_bank(self):
         # Test _compute_partner_bank is executed when partner_id changes
+        self.company.keep_partner_bank_without_payment_mode = False
         move_form = Form(
             self.env["account.move"].with_context(default_move_type="out_invoice")
         )
@@ -241,6 +242,8 @@ class TestAccountPaymentPartner(BaseCommon):
 
     def test_out_invoice_onchange(self):
         # Test the onchange methods in invoice
+        self.company.keep_partner_bank_without_payment_mode = False
+        self.company_2.keep_partner_bank_without_payment_mode = False
         invoice = self.move_model.new(
             {
                 "partner_id": self.customer.id,
@@ -438,6 +441,7 @@ class TestAccountPaymentPartner(BaseCommon):
         )
 
     def test_partner_onchange(self):
+        self.company.keep_partner_bank_without_payment_mode = False
         customer_invoice = self.move_model.create(
             {"partner_id": self.customer.id, "move_type": "out_invoice"}
         )
@@ -464,6 +468,7 @@ class TestAccountPaymentPartner(BaseCommon):
         self.assertFalse(invoice.partner_bank_id)
 
     def test_onchange_payment_mode_id(self):
+        self.company.keep_partner_bank_without_payment_mode = True
         mode = self.supplier_payment_mode
         mode.payment_method_id.bank_account_required = True
         self.supplier_invoice.partner_bank_id = self.supplier_bank.id
@@ -471,8 +476,61 @@ class TestAccountPaymentPartner(BaseCommon):
         self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
         mode.payment_method_id.bank_account_required = False
         self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
+        # With keep_partner_bank_without_payment_mode enabled, clearing the
+        # payment mode preserves the bank auto-selected by Odoo core
+        self.supplier_invoice.payment_mode_id = False
+        self.assertEqual(self.supplier_invoice.partner_bank_id, self.supplier_bank)
+
+    def test_no_payment_mode_clears_bank_when_flag_disabled(self):
+        """When keep_partner_bank_without_payment_mode is disabled,
+        clearing the payment mode should also clear partner_bank_id."""
+        self.company.keep_partner_bank_without_payment_mode = False
+        self.supplier_invoice.partner_bank_id = self.supplier_bank.id
         self.supplier_invoice.payment_mode_id = False
         self.assertFalse(self.supplier_invoice.partner_bank_id)
+
+    def test_refund_no_payment_mode_preserves_partner_bank(self):
+        """Test that partner_bank_id is preserved on refund without payment mode.
+
+        When a partner has a bank account with allow_out_payment=True but no
+        payment mode is configured, the reversal wizard should still auto-select
+        the trusted bank account via core _compute_partner_bank_id.
+        """
+        self.company.keep_partner_bank_without_payment_mode = True
+        partner_no_mode = (
+            self.env["res.partner"]
+            .with_company(self.company.id)
+            .create({"name": "Partner without payment mode"})
+        )
+        trusted_bank = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "BE32121212121212",
+                "partner_id": partner_no_mode.id,
+                "allow_out_payment": True,
+            }
+        )
+        invoice = self._create_invoice(
+            default_move_type="out_invoice", partner=partner_no_mode
+        )
+        invoice.payment_mode_id = False
+        invoice.action_post()
+
+        refund_wizard = (
+            self.env["account.move.reversal"]
+            .with_context(
+                active_ids=[invoice.id],
+                active_id=invoice.id,
+                active_model="account.move",
+            )
+            .create(
+                {
+                    "reason": "test refund without payment mode",
+                    "journal_id": invoice.journal_id.id,
+                }
+            )
+        )
+        refund_move = self.move_model.browse(refund_wizard.reverse_moves()["res_id"])
+        self.assertEqual(refund_move.partner_bank_id, trusted_bank)
 
     def test_print_report(self):
         self.supplier_invoice.partner_bank_id = self.supplier_bank.id

--- a/account_payment_mode/views/res_config_settings.xml
+++ b/account_payment_mode/views/res_config_settings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Engenere - Felipe Motter Pereira
+     Copyright 2026 ForgeFlow S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.account.payment.mode</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@id='pay_invoice_online_setting_container']"
+                position="inside"
+            >
+                <setting
+                    id="keep_partner_bank_without_payment_mode_setting"
+                    string="Keep Bank Account Without Payment Mode"
+                    help="Keep the bank account auto-selected by Odoo on invoices without a payment mode. Disable to clear the bank account when no payment mode is set."
+                >
+                    <field name="keep_partner_bank_without_payment_mode" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Forward port https://github.com/OCA/bank-payment/pull/1555

Add changes to account_payment_mode, as account_payment_partner was merged into it

@ForgeFlow