### PR TITLE
[17.0][FIX] account_payment_sale: We need to set the value if we want to us…

### DIFF
--- a/account_payment_sale/models/sale_order.py
+++ b/account_payment_sale/models/sale_order.py
@@ -25,8 +25,9 @@ class SaleOrder(models.Model):
             ).customer_payment_mode_id
 
     def _get_payment_mode_vals(self, vals):
+        # We need to set it if we want to use it as invoice key
+        vals["payment_mode_id"] = self.payment_mode_id.id
         if self.payment_mode_id:
-            vals["payment_mode_id"] = self.payment_mode_id.id
             if (
                 self.payment_mode_id.bank_account_link == "fixed"
                 and self.payment_mode_id.payment_method_id.code == "manual"

--- a/account_payment_sale/tests/test_sale_order.py
+++ b/account_payment_sale/tests/test_sale_order.py
@@ -141,3 +141,12 @@ class TestSaleOrder(CommonTestCase):
         other_company = self.env["res.company"].create({"name": "other company"})
         order.company_id = other_company
         self.assertFalse(order.payment_mode_id)
+
+    def test_grouped_invoicing_payment_mode_compare(self):
+        order_1 = self.create_sale_order()
+        order_1.payment_mode_id = False
+        order_2 = self.create_sale_order()
+        orders = order_1 | order_2
+        orders.action_confirm()
+        invoices = orders._create_invoices(grouped=False)
+        self.assertEqual(len(invoices), 2)


### PR DESCRIPTION
…e it as key in grouping


backport https://github.com/OCA/bank-payment/pull/1534

The error only appears if we have 2 records with the same company, customer, same fiscal position and one with payment_mode and one without it. This happens because we are comparing tuples and comparison is done in order:

(1,2,3,1) < (2,2,3,None) # Different company
(1,2,3,1) < (1,3,3,None) # Different partner
(1,2,3,1) < (1,2,4,None) # Different fiscal position (1,2,3,1) < (1,2,3,None)  --> Type error because int(None) cannot be defined.

This is a rare scenario, but might happen
