### PR TITLE
[16.0][FIX] account_payment_order: unset journal_id when it is not in allowed_journal_ids

### DIFF
--- a/account_banking_pain_base/i18n/gl.po
+++ b/account_banking_pain_base/i18n/gl.po
@@ -904,7 +904,7 @@ msgstr ""
 "SAIBA:\n"
 "{bic_list}\n"
 "\n"
-"Patrón SAIBA: {saiba_pattern}"
+"Patrón SAIBA: {sepa_pattern}"
 
 #. module: account_banking_pain_base
 #. odoo-python

--- a/account_payment_order/models/account_payment_order.py
+++ b/account_payment_order/models/account_payment_order.py
@@ -285,6 +285,8 @@ class AccountPaymentOrder(models.Model):
     def payment_mode_id_change(self):
         if len(self.allowed_journal_ids) == 1:
             self.journal_id = self.allowed_journal_ids
+        if self.journal_id not in self.allowed_journal_ids:
+            self.journal_id = False
         if self.payment_mode_id.default_date_prefered:
             self.date_prefered = self.payment_mode_id.default_date_prefered
 


### PR DESCRIPTION
FWD-Port of https://github.com/OCA/bank-payment/pull/1607
Create two payment modes with different allowed bank journals: PM1 with Journal 1 and Journal 2.
PM2 with Journal 3 and Journal 4.
Create a payment order and select PM1 and Journal 1. Change the payment mode to PM2.

Before this commit, Journal 1 remained selected even though it was not available for PM2. After this commit, the journal is cleared when it is not available for the selected payment mode, forcing the user to select a valid journal.

TT63778
@Tecnativa @pedrobaeza @carlosdauden @sergio-teruel @victoralmau could you please review this?