### PR TITLE
[19.0][IMP] account_banking_sepa_direct_debit: SEPA validation message

### DIFF
--- a/account_banking_sepa_direct_debit/i18n/account_banking_sepa_direct_debit.pot
+++ b/account_banking_sepa_direct_debit/i18n/account_banking_sepa_direct_debit.pot
@@ -285,8 +285,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 msgid ""
-"Missing SEPA Direct Debit mandate on the line with partner {partner_name} "
-"(reference {reference})."
+"Missing SEPA Direct Debit mandate on the line with partner %(partner_name)s "
+"(reference %(reference)s)."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
@@ -419,17 +419,17 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has expired."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has expired."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has type set to 'One-Off' but has a last debit date set to "
-"{last_debit_date}. Therefore, it cannot be used."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has type set to 'One-Off' but has a last debit date set to "
+"%(last_debit_date)s. Therefore, it cannot be used."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/i18n/de.po
+++ b/account_banking_sepa_direct_debit/i18n/de.po
@@ -287,8 +287,8 @@ msgstr ""
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"Missing SEPA Direct Debit mandate on the line with partner {partner_name} "
-"(reference {reference})."
+"Missing SEPA Direct Debit mandate on the line with partner %(partner_name)s "
+"(reference %(reference)s)."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
@@ -430,8 +430,8 @@ msgstr ""
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has expired."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has expired."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit
@@ -439,9 +439,9 @@ msgstr ""
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has type set to 'One-Off' but has a last debit date set to "
-"{last_debit_date}. Therefore, it cannot be used."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has type set to 'One-Off' but has a last debit date set to "
+"%(last_debit_date)s. Therefore, it cannot be used."
 msgstr ""
 
 #. module: account_banking_sepa_direct_debit

--- a/account_banking_sepa_direct_debit/i18n/es.po
+++ b/account_banking_sepa_direct_debit/i18n/es.po
@@ -346,11 +346,11 @@ msgstr "Actualizacion de mandato"
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"Missing SEPA Direct Debit mandate on the line with partner {partner_name} "
-"(reference {reference})."
+"Missing SEPA Direct Debit mandate on the line with partner %(partner_name)s "
+"(reference %(reference)s)."
 msgstr ""
-"Falta el mandato de adeudo directo SEPA en la linea de pago bancario de la "
-"empresa {partner_name} (referencia {reference})."
+"Falta el mandato de adeudo directo SEPA en la línea con cliente "
+"%(partner_name)s (referencia de la línea %(reference)s)."
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.model.fields.selection,name:account_banking_sepa_direct_debit.selection__account_banking_mandate__type__oneoff
@@ -495,24 +495,24 @@ msgstr "Identificador de acreedor SEPA '%s' no válido."
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has expired."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has expired."
 msgstr ""
-"El mandato de adeudo directo SEPA con referencia {mandate_ref} para la "
-"empresa {partner_name} ha expirado."
+"El mandato de adeudo directo SEPA con referencia %(mandate_ref)s del cliente "
+"%(partner_name)s ha expirado."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has type set to 'One-Off' but has a last debit date set to "
-"{last_debit_date}. Therefore, it cannot be used."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has type set to 'One-Off' but has a last debit date set to "
+"%(last_debit_date)s. Therefore, it cannot be used."
 msgstr ""
-"El mandato con referencia {mandate_ref} para la empresa {partner_name} tipo "
-"como 'Único', ya tiene como fecha de último cobro {last_debit_date}, por lo "
-"que no se puede usar."
+"El mandato de adeudo directo SEPA con referencia %(mandate_ref)s del cliente "
+"%(partner_name)s es de tipo «Único», pero ya se utilizó el "
+"%(last_debit_date)s. Por tanto, no puede volver a utilizarse."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python

--- a/account_banking_sepa_direct_debit/i18n/fr.po
+++ b/account_banking_sepa_direct_debit/i18n/fr.po
@@ -325,11 +325,11 @@ msgstr "Mise-à-jour du mandat"
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"Missing SEPA Direct Debit mandate on the line with partner {partner_name} "
-"(reference {reference})."
+"Missing SEPA Direct Debit mandate on the line with partner %(partner_name)s "
+"(reference %(reference)s)."
 msgstr ""
 "Absence du mandat de prélèvement SEPA sur la ligne de paiement bancaire avec "
-"le partenaire {partner_name} (référence {reference})."
+"le partenaire %(partner_name)s (référence %(reference)s)."
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.model.fields.selection,name:account_banking_sepa_direct_debit.selection__account_banking_mandate__type__oneoff
@@ -472,24 +472,24 @@ msgstr "L'identification de créancier SEPA '%s' est invalide."
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has expired."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has expired."
 msgstr ""
-"Le mandat de prélèvement SEPA portant la référence {mandate_ref} pour le "
-"partenaire {partner_name} a expiré."
+"Le mandat de prélèvement SEPA portant la référence %(mandate_ref)s pour le "
+"partenaire %(partner_name)s a expiré."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has type set to 'One-Off' but has a last debit date set to "
-"{last_debit_date}. Therefore, it cannot be used."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has type set to 'One-Off' but has a last debit date set to "
+"%(last_debit_date)s. Therefore, it cannot be used."
 msgstr ""
-"Le mandat SEPA portant la référence {mandate_ref} pour le partenaire "
-"{partner_name} est de type 'One-Off' et il a une date de dernier débit au "
-"{last_debit_date}. Il n'est donc pas utilisable."
+"Le mandat SEPA portant la référence %(mandate_ref)s pour le partenaire "
+"%(partner_name)s est de type 'One-Off' et il a une date de dernier débit au "
+"%(last_debit_date)s. Il n'est donc pas utilisable."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python

--- a/account_banking_sepa_direct_debit/i18n/it.po
+++ b/account_banking_sepa_direct_debit/i18n/it.po
@@ -340,11 +340,11 @@ msgstr "Aggiornamento mandato"
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"Missing SEPA Direct Debit mandate on the line with partner {partner_name} "
-"(reference {reference})."
+"Missing SEPA Direct Debit mandate on the line with partner %(partner_name)s "
+"(reference %(reference)s)."
 msgstr ""
 "Mandato di addebito diretto SEPA non trovato sulla riga con partner "
-"{partner_name} (reference {reference})."
+"%(partner_name)s (reference %(reference)s)."
 
 #. module: account_banking_sepa_direct_debit
 #: model:ir.model.fields.selection,name:account_banking_sepa_direct_debit.selection__account_banking_mandate__type__oneoff
@@ -489,24 +489,24 @@ msgstr "L'identificativo creditore SEPA '%s' non è valido."
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has expired."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has expired."
 msgstr ""
-"Il mandato di addebito diretto SEPA con riferimento {mandate_ref} for "
-"partner {partner_name} è scaduto."
+"Il mandato di addebito diretto SEPA con riferimento %(mandate_ref)s for "
+"partner %(partner_name)s è scaduto."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python
 #: code:addons/account_banking_sepa_direct_debit/models/account_payment_line.py:0
 #, python-format
 msgid ""
-"The SEPA Direct Debit mandate with reference {mandate_ref} for partner "
-"{partner_name} has type set to 'One-Off' but has a last debit date set to "
-"{last_debit_date}. Therefore, it cannot be used."
+"The SEPA Direct Debit mandate with reference %(mandate_ref)s for partner "
+"%(partner_name)s has type set to 'One-Off' but has a last debit date set to "
+"%(last_debit_date)s. Therefore, it cannot be used."
 msgstr ""
-"Il mandato di addebito diretto SEPA con riferimento {mandate_ref} per il "
-"partner {partner_name} ha timpo impostato a 'Singolo' ma ha una data ultimo "
-"addebito impostata a {last_debit_date}. Pertanto non può essere usato."
+"Il mandato di addebito diretto SEPA con riferimento %(mandate_ref)s per il "
+"partner %(partner_name)s ha timpo impostato a 'Singolo' ma ha una data ultimo "
+"addebito impostata a %(last_debit_date)s. Pertanto non può essere usato."
 
 #. module: account_banking_sepa_direct_debit
 #. odoo-python

--- a/account_banking_sepa_direct_debit/models/account_payment_line.py
+++ b/account_banking_sepa_direct_debit/models/account_payment_line.py
@@ -27,8 +27,8 @@ class AccountPaymentLine(models.Model):
                 raise UserError(
                     self.env._(
                         "Missing SEPA Direct Debit mandate on the line with "
-                        "partner {partner_name} (reference {reference}).",
-                        artner_name=rec.partner_id.name,
+                        "partner %(partner_name)s (reference %(reference)s).",
+                        partner_name=rec.partner_id.name,
                         reference=rec.name,
                     )
                 )
@@ -36,7 +36,7 @@ class AccountPaymentLine(models.Model):
                 raise UserError(
                     self.env._(
                         "The SEPA Direct Debit mandate with reference "
-                        "{mandate_ref} for partner {partner_name} has "
+                        "%(mandate_ref)s for partner %(partner_name)s has "
                         "expired.",
                         mandate_ref=rec.mandate_id.unique_mandate_reference,
                         partner_name=rec.partner_id.name,
@@ -46,9 +46,9 @@ class AccountPaymentLine(models.Model):
                 raise UserError(
                     self.env._(
                         "The SEPA Direct Debit mandate with reference "
-                        "{mandate_ref} for partner {partner_name} has type set "
+                        "%(mandate_ref)s for partner %(partner_name)s has type set "
                         "to 'One-Off' but has a last debit date set to "
-                        "{last_debit_date}. Therefore, it cannot be used.",
+                        "%(last_debit_date)s. Therefore, it cannot be used.",
                         mandate_ref=rec.mandate_id.unique_mandate_reference,
                         partner_name=rec.partner_id.name,
                         last_debit_date=rec.mandate_id.last_debit_date,


### PR DESCRIPTION
SEPA Direct Debit validation errors used unsupported {field} placeholders, causing literal placeholders to appear instead of the actual mandate, customer, line reference, or date values

<img width="872" height="206" alt="image" src="https://github.com/user-attachments/assets/d4a9c991-35a2-46d2-9ce3-c6f00c61bd60" />
