### PR TITLE
[16.0][FIX] account_payment_purchase: purchase order payment mode not copied to the invoice

### DIFF
--- a/account_payment_purchase/models/account_move.py
+++ b/account_payment_purchase/models/account_move.py
@@ -11,10 +11,11 @@ class AccountMove(models.Model):
 
     @api.onchange("purchase_vendor_bill_id", "purchase_id")
     def _onchange_purchase_auto_complete(self):
+        old_mode = self.payment_mode_id.id or False
         new_mode = self.purchase_id.payment_mode_id.id or False
         new_bank = self.purchase_id.supplier_partner_bank_id.id or False
         res = super()._onchange_purchase_auto_complete() or {}
-        if self.payment_mode_id and new_mode and self.payment_mode_id.id != new_mode:
+        if old_mode and new_mode and old_mode != new_mode:
             res["warning"] = {
                 "title": _("Warning"),
                 "message": _("Selected purchase order have different payment mode."),

--- a/account_payment_purchase/models/purchase_order.py
+++ b/account_payment_purchase/models/purchase_order.py
@@ -59,4 +59,6 @@ class PurchaseOrder(models.Model):
         correct value with compute."""
         invoice_vals = super()._prepare_invoice()
         invoice_vals.pop("partner_bank_id")
+        if self.payment_mode_id:
+            invoice_vals["payment_mode_id"] = self.payment_mode_id.id
         return invoice_vals


### PR DESCRIPTION
@Escodoo HT02141

When generating a vendor bill from a purchase order, the "Payment Mode"
field (`payment_mode_id`) was left empty on the invoice, even when the
purchase order had a payment mode set (e.g. Bank Slip / Boleto).

cc @kaynnan @marcelsavegnago @WesleyOliveira98 