### PR TITLE
[18.0][FIX] account_payment_order: fix company currency total aggregation.

### DIFF
--- a/account_payment_order/views/account_payment_order.xml
+++ b/account_payment_order/views/account_payment_order.xml
@@ -172,6 +172,7 @@
                     string="Payment Transactions"
                 />
                 <field name="total_company_currency" sum="Total Company Currency" />
+                <field name="company_currency_id" column_invisible="True" />
                 <field
                     name="state"
                     decoration-info="state == 'draft'"


### PR DESCRIPTION
total_company_currency uses company_currency_id as its currency field, but the currency field was not included in the list view.
This caused the total aggregation to display "No currency provided".
This change adds company_currency_id as an invisible column so the monetary total can be properly rendered.
<img width="1588" height="245" alt="Captura desde 2026-08-31 13-04-35" src="https://github.com/user-attachments/assets/a163caed-c743-4c86-9efd-f8f3d137ae71" />

