### PR TITLE
[IMP] account_payment_partner: Explicit Bank Account details

### DIFF
--- a/account_payment_partner/models/account_payment_mode.py
+++ b/account_payment_partner/models/account_payment_mode.py
@@ -21,6 +21,11 @@ class AccountPaymentMode(models.Model):
         default="full",
         help="Show in invoices partial or full bank account number",
     )
+    show_company_name = fields.Boolean(
+        help="Show Company name alongwith the Bank Account label.\n"
+        'This will print "<Company Name> Bank Account" instead of '
+        '"Bank Account" in the invoice.',
+    )
     show_bank_account_from_journal = fields.Boolean(string="Bank account from journals")
     show_bank_account_chars = fields.Integer(
         string="# of digits for customer bank account"

--- a/account_payment_partner/tests/test_account_payment_partner.py
+++ b/account_payment_partner/tests/test_account_payment_partner.py
@@ -497,7 +497,7 @@ class TestAccountPaymentPartner(SavepointCase):
         self.supplier_invoice.partner_bank_id = self.supplier_bank.id
         report = self.env.ref("account.account_invoices")
         res = str(report._render_qweb_html(self.supplier_invoice.ids)[0])
-        self.assertIn(self.supplier_bank.acc_number, res)
+        self.assertIn(self.supplier_bank.sanitized_acc_number, res)
         payment_mode = self.supplier_payment_mode
         payment_mode.show_bank_account_from_journal = True
         self.supplier_invoice.payment_mode_id = payment_mode.id
@@ -507,7 +507,7 @@ class TestAccountPaymentPartner(SavepointCase):
         payment_mode.bank_account_link = "variable"
         payment_mode.variable_journal_ids = [(6, 0, self.journal.ids)]
         res = str(report._render_qweb_html(self.supplier_invoice.ids)[0])
-        self.assertIn(self.journal_bank.acc_number, res)
+        self.assertIn(self.journal_bank.sanitized_acc_number, res)
 
     def test_filter_type_domain(self):
         in_invoice = self.move_model.create(

--- a/account_payment_partner/views/account_payment_mode.xml
+++ b/account_payment_partner/views/account_payment_mode.xml
@@ -13,6 +13,7 @@
                 <group string="Show bank account in invoice report">
                     <group>
                         <field name="show_bank_account" />
+                        <field name="show_company_name" />
                         <field
                             name="show_bank_account_from_journal"
                             attrs="{'invisible': [('show_bank_account', '=', 'no')]}"

--- a/account_payment_partner/views/report_invoice.xml
+++ b/account_payment_partner/views/report_invoice.xml
@@ -11,23 +11,37 @@
             </p>
             <t t-if="o.payment_mode_id and o.payment_mode_id.show_bank_account != 'no'">
                 <p t-foreach="o.sudo().partner_banks_to_show()" t-as="partner_bank">
+                    <strong
+                        t-if="o.payment_mode_id.show_company_name"
+                        t-esc="o.company_id.name"
+                    />
                     <strong>Bank Account:</strong>
                     <t t-if="partner_bank.bank_id">
-                        <t
-                            t-esc="partner_bank.bank_id.name + ('' if not partner_bank.bank_id.bic else ' (' + partner_bank.bank_id.bic + ')')"
-                        />
+                        <t t-esc="partner_bank.bank_id.name" />
+                        <t t-if="partner_bank.bank_id.bic">
+                            (<strong>BIC/SWIFT:</strong> <t
+                                t-esc="partner_bank.bank_id.bic"
+                            />)
+                        </t>
                     </t>
+
+                    <strong t-if="partner_bank.acc_type == 'iban'">IBAN:</strong>
+                    <t t-set="acc_number" t-value="partner_bank.sanitized_acc_number" />
+                    <t
+                        t-set="show_chars"
+                        t-value="o.payment_mode_id.show_bank_account_chars"
+                    />
                     <t t-if="o.payment_mode_id.show_bank_account == 'full'">
-                        <span t-field="partner_bank.acc_number" />
+                        <span t-esc="acc_number" />
                     </t>
                     <t t-elif="o.payment_mode_id.show_bank_account == 'first'">
                         <span
-                            t-esc="partner_bank.acc_number[:o.payment_mode_id.show_bank_account_chars] + '*' * (len(partner_bank.acc_number) - o.payment_mode_id.show_bank_account_chars)"
+                            t-esc="acc_number[:show_chars] + '*' * (len(acc_number) - show_chars)"
                         />
                     </t>
                     <t t-elif="o.payment_mode_id.show_bank_account == 'last'">
                         <span
-                            t-esc="'*' * (len(partner_bank.acc_number) - o.payment_mode_id.show_bank_account_chars) + partner_bank.acc_number[-o.payment_mode_id.show_bank_account_chars:]"
+                            t-esc="'*' * (len(acc_number) - show_chars) + acc_number[-show_chars:]"
                         />
                     </t>
                 </p>


### PR DESCRIPTION
Allow to show the Company Name near the Bank Account details: to clarify it's the company's Bank Account.

Add BIC/SWIFT label near BIC/SWIFT value as well as IBAN label near IBAN value.

Use the sanitized Account Number (no spaces) for easier copy/paste for the customer.

Small refactoring to clarify account number shortening and variables for better maintainability.

Before: <img width="1155" height="97" alt="image" src="https://github.com/user-attachments/assets/0b995879-2e4f-46ba-a226-8f6479cec970" />

After (with **Show Company Name** enabled): <img width="1155" height="97" alt="image" src="https://github.com/user-attachments/assets/e8d9826f-a526-48dd-bf36-c845ce93521c" />
